### PR TITLE
Make context setters private. Pass per-compilation symbol actions dir…

### DIFF
--- a/src/BinSkim.Driver/RoslynAnalyzer/RoslynCompilationStartAnalysisContext.cs
+++ b/src/BinSkim.Driver/RoslynAnalyzer/RoslynCompilationStartAnalysisContext.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.IL
     /// </summary>
     internal sealed class RoslynCompilationStartAnalysisContext : CompilationStartAnalysisContext
     {
-        public ActionMap<SymbolAnalysisContext, SymbolKind> SymbolActions { get; set; }
+        public ActionMap<SymbolAnalysisContext, SymbolKind> SymbolActions { get; private set; }
 
-        public Action<CompilationAnalysisContext> CompilationEndActions { get; set; }
+        public Action<CompilationAnalysisContext> CompilationEndActions { get; private set; }
 
         public RoslynCompilationStartAnalysisContext(Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken)
             : base(compilation, options, cancellationToken)


### PR DESCRIPTION
…ectly to Analyze method (reflecting the lifetime/relevance of this data). @nguerrera @lgolding 

Nick's CR feedback.