### PR TITLE
Fix failing BinSkim.Driver.FunctionalTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 *.user 
 *.userosscache 
 *.sln.docstates 
-  
+.vs/
+
 # Build results 
 bin/
 obj/
 src/packages/
-src/TestResults
+src/TestResults/
+src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Actual/

--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -38,3 +38,4 @@ md bld\bin\nuget
 .nuget\NuGet.exe pack .\src\Nuget\BinSkim.nuspec -Symbols -Properties id=Microsoft.CodeAnalysis.BinSkim;major=%MAJOR%;minor=%MINOR%;patch=%PATCH%;prerelease=%PRERELEASE% -Verbosity Quiet -BasePath .\bld\bin\BinSkim.Driver -OutputDirectory .\bld\bin\Nuget
 
 src\packages\xunit.runner.console.2.1.0\tools\xunit.console.x86.exe bld\bin\BinSkim.Rules.FunctionalTests\x86_Release\BinSkim.Rules.FunctionalTests.dll
+src\packages\xunit.runner.console.2.1.0\tools\xunit.console.x86.exe bld\bin\BinSkim.Driver.FunctionalTests\x86_Release\BinSkim.Driver.FunctionalTests.dll

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Corrupted_Native_x86_VS2013_Default.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Corrupted_Native_x86_VS2013_Default.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Corrupted_Native_x86_VS2013_Default.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Corrupted_Native_x86_VS2013_Default.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Corrupted_Native_x86_VS2013_Default.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Corrupted_Native_x86_VS2013_Default.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe"
           }
         ]
       },
@@ -23,14 +23,14 @@
             "specifierId": "ExceptionLoadingAnalysisTarget",
             "arguments": [
               "Corrupted_Native_x86_VS2013_Default.exe",
-              "System.BadImageFormatException: Image is either too small or contains an invalid byte offset or count.\r\n   at System.Reflection.Throw.ImageTooSmallOrContainsInvalidOffsetOrCount()\r\n   at System.Reflection.PortableExecutable.PEHeaders.SkipDosHeader(PEBinaryReader& reader, Boolean& isCOFFOnly)\r\n   at System.Reflection.PortableExecutable.PEHeaders..ctor(Stream peStream, Nullable`1 sizeOpt)\r\n   at System.Reflection.PortableExecutable.PEReader.InitializePEHeaders()\r\n   at Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable.PE..ctor(String fileName) in D:\\src\\testbinskim\\src\\BinaryParsers\\PortableExecutable\\PE.cs:line 47"
+              "System.BadImageFormatException: Image is either too small or contains an invalid byte offset or count."
             ]
           },
           "locations": [
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/ManagedInteropAssemblyForAtlTestLibrary.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/ManagedInteropAssemblyForAtlTestLibrary.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim-ms\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim-ms\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\ManagedInteropAssemblyForAtlTestLibrary.dll --output D:\\src\\binskim-ms\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\ManagedInteropAssemblyForAtlTestLibrary.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\ManagedInteropAssemblyForAtlTestLibrary.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\ManagedInteropAssemblyForAtlTestLibrary.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -121,7 +121,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -144,7 +144,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -167,7 +167,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -190,7 +190,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -213,7 +213,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -236,7 +236,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -259,7 +259,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -282,7 +282,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -302,7 +302,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -322,7 +322,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -342,7 +342,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -365,7 +365,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -385,7 +385,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -405,7 +405,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -425,7 +425,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -459,8 +459,8 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' contains no data or code sections marked as both shared and executable, helping to prevent the exploitability of code vulnerabilities.",
-            "Fail": "'{0}' contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your toolchain to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes.",
-            "Fail_UnexpectedSectionAligment": "'{0}' has a section alignment ({1}) that is smaller than page size ({2})."
+            "Error": "'{0}' contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your toolchain to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes.",
+            "Error_UnexpectedSectionAligment": "'{0}' has a section alignment ({1}) that is smaller than page size ({2})."
           }
         },
         {
@@ -471,7 +471,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' contains no data or code sections marked as both shared and writable, helping to prevent the exploitability of code vulnerabilities.",
-            "Fail": "'{0}' contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to mutate memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you are required to share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
+            "Error": "'{0}' contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to mutate memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you are required to share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
           }
         },
         {
@@ -482,8 +482,8 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is not known to be an obsolete binary that is vulnerable to one or more security problems.",
-            "Fail": "'{0}' appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning.",
-            "Fail_CouldNotParseVersion": "Version information for '{0}' could not be parsed. The binary therefore could not be verified not to be an obsolete binary that is known to be vulnerable to one or more security problems."
+            "Error": "'{0}' appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning.",
+            "Error_CouldNotParseVersion": "Version information for '{0}' could not be parsed. The binary therefore could not be verified not to be an obsolete binary that is known to be vulnerable to one or more security problems."
           }
         },
         {
@@ -494,9 +494,9 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is properly compiled to enable address space layout randomization, reducing an attacker's ability to exploit code in well-known locations.",
-            "Fail_NotDynamicBase": "'{0}' is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. To resolve this issue, configure your tool chain to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later.",
-            "Fail_RelocsStripped": "'{0}' is marked as DYNAMICBASE but relocation data has been stripped from the image, preventing address space layout randomization. ",
-            "Fail_WinCENoRelocationSection": "'{0}' is a Windows CE image but does not contain any relocation data, preventing address space layout randomization."
+            "Error_NotDynamicBase": "'{0}' is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. To resolve this issue, configure your tool chain to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later.",
+            "Error_RelocsStripped": "'{0}' is marked as DYNAMICBASE but relocation data has been stripped from the image, preventing address space layout randomization. ",
+            "Error_WinCENoRelocationSection": "'{0}' is a Windows CE image but does not contain any relocation data, preventing address space layout randomization."
           }
         },
         {
@@ -508,7 +508,7 @@
           "formatSpecifiers": {
             "Pass": "'{0}' is an x86 binary that enables SafeSEH, a mitigation that verifies SEH exception jump targets are defined as exception handlers in the program (and not shellcode).",
             "Pass_NoSEH": "'{0}' is an x86 binary that does not use SEH, making it an invalid target for exploits that attempt to replace SEH jump targets with attacker-controlled shellcode.",
-            "Fail": "'{0}' is an x86 binary which {1}, indicating that it does not enable the SafeSEH mitigation. SafeSEH makes it more difficult to exploit memory corruption vulnerabilities that can overwrite SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
+            "Error": "'{0}' is an x86 binary which {1}, indicating that it does not enable the SafeSEH mitigation. SafeSEH makes it more difficult to exploit memory corruption vulnerabilities that can overwrite SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
           }
         },
         {
@@ -519,7 +519,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is marked as NX compatible, helping to prevent attackers from executing code that is injected into data segments.",
-            "Fail": "'{0}' is not marked NX compatible. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), is a processor feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit, because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment. To resolve this issue, ensure that your tool chain is configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
+            "Error": "'{0}' is not marked NX compatible. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), is a processor feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit, because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment. To resolve this issue, ensure that your tool chain is configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
           }
         }
       ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/ManagedResourcesOnly.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/ManagedResourcesOnly.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\ManagedResourcesOnly.dll --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\ManagedResourcesOnly.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\ManagedResourcesOnly.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\ManagedResourcesOnly.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -121,7 +121,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -144,7 +144,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -167,7 +167,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -190,7 +190,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -213,7 +213,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -236,7 +236,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -259,7 +259,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -282,7 +282,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -305,7 +305,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -328,7 +328,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -348,7 +348,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -368,7 +368,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -388,7 +388,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -409,7 +409,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -429,7 +429,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/ManagedResourcesOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -499,7 +499,7 @@
           "formatSpecifiers": {
             "Pass": "'{0}' appears to be signed securely by a trusted publisher with no verification or time stamp errors. Revocation checking was performed on the entire certificate chain, excluding the root certificate. The image was signed with '{1}', a cryptographically strong algorithm.",
             "Error_BadSigningAlgorithm": "'{0}' was signed using '{1}', an algorithm that WinTrustVerify has flagged as insecure.",
-            "Error_DidNotVerify": "'{0}' signing was flagged as insecure by WinTrustVerify with error code: '{1}'",
+            "Error_DidNotVerify": "'{0}' signing was flagged as insecure by WinTrustVerify with error code '{1}' ({2})",
             "Error_WinTrustVerifyApiError": "'{0}' signing could not be completely verified because '{1}' failed with error code: '{2}'."
           }
         },

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Managed_x86_VS2013_Wpf.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Managed_x86_VS2013_Wpf.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Managed_x86_VS2013_Wpf.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Managed_x86_VS2013_Wpf.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Managed_x86_VS2013_Wpf.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Managed_x86_VS2013_Wpf.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -121,7 +121,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -144,7 +144,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -167,7 +167,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -190,7 +190,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -213,7 +213,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -236,7 +236,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -259,7 +259,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -282,7 +282,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -302,7 +302,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -322,7 +322,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -342,7 +342,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -365,7 +365,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -385,7 +385,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -405,7 +405,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -425,7 +425,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Managed_x86_VS2013_Wpf.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x64_VS2013_Default.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x64_VS2013_Default.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x64_VS2013_Default.dll --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x64_VS2013_Default.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x64_VS2013_Default.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x64_VS2013_Default.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -140,7 +140,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -160,7 +160,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -180,7 +180,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -200,7 +200,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -220,7 +220,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -240,7 +240,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -260,7 +260,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -283,7 +283,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -303,7 +303,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -324,7 +324,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -344,7 +344,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -364,7 +364,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -384,7 +384,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -404,7 +404,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x64_VS2013_NoPdb.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x64_VS2013_NoPdb.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x64_VS2013_NoPdb.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x64_VS2013_NoPdb.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x64_VS2013_NoPdb.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x64_VS2013_NoPdb.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -142,7 +142,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -164,7 +164,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -184,7 +184,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -204,7 +204,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -224,7 +224,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -244,7 +244,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -264,7 +264,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -287,7 +287,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -307,7 +307,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -329,7 +329,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -351,7 +351,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -371,7 +371,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -393,7 +393,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -413,7 +413,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x86_VS2013_Default.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x86_VS2013_Default.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x86_VS2013_Default.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x86_VS2013_Default.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x86_VS2013_Default.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x86_VS2013_Default.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -140,7 +140,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -160,7 +160,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -180,7 +180,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -200,7 +200,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -220,7 +220,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -240,7 +240,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -260,7 +260,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -283,7 +283,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -303,7 +303,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -324,7 +324,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -344,7 +344,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -364,7 +364,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -384,7 +384,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -404,7 +404,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x86_VS2013_MissingPdb.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/MixedMode_x86_VS2013_MissingPdb.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x86_VS2013_MissingPdb.dll --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x86_VS2013_MissingPdb.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\MixedMode_x86_VS2013_MissingPdb.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\MixedMode_x86_VS2013_MissingPdb.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -142,7 +142,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -164,7 +164,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -184,7 +184,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -204,7 +204,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -224,7 +224,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -244,7 +244,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -264,7 +264,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -287,7 +287,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -307,7 +307,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -329,7 +329,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -351,7 +351,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -371,7 +371,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -393,7 +393,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -413,7 +413,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x64_VS2013_Default.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x64_VS2013_Default.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim-ms\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim-ms\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x64_VS2013_Default.dll --output D:\\src\\binskim-ms\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x64_VS2013_Default.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x64_VS2013_Default.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x64_VS2013_Default.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -140,7 +140,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -160,7 +160,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -180,7 +180,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -200,7 +200,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -220,7 +220,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -240,7 +240,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -260,7 +260,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -283,7 +283,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -303,7 +303,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -324,7 +324,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -344,7 +344,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -364,7 +364,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -384,7 +384,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -404,7 +404,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim-ms/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2013_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -437,9 +437,9 @@
           "fullDescription": "Application code should be compiled with the most up-to-date tool sets possible in order to take advantage of the most current compile-time security features.",
           "options": {},
           "formatSpecifiers": {
-            "Fail_BadModule": "built with {0} compiler version {1} (Front end version {2})",
+            "Error_BadModule": "built with {0} compiler version {1} (Front end version {2})",
             "Pass": "'{0}' was built with a tool chain that satisfies configured policy (compiler minimum version {1}, linker minimum version {2}).",
-            "Fail": "'{0}' was compiled with one or more modules which were not built using minimum required tool versions (compiler version {1}, linker version {2}). More recent tool chains contain mitigations that make it more difficult for an attacker to exploit vulnerabilities in programs they produce. To resolve this issue, compile and/or link your binary with more recent tools. If you are servicing a product where the tool chain cannot be modified (e.g. producing a hotfix for an already shipped version) ignore this warning.\r\nModules built outside of policy: \r\n{3}"
+            "Error": "'{0}' was compiled with one or more modules which were not built using minimum required tool versions (compiler version {1}, linker version {2}). More recent tool chains contain mitigations that make it more difficult for an attacker to exploit vulnerabilities in programs they produce. To resolve this issue, compile and/or link your binary with more recent tools. If you are servicing a product where the tool chain cannot be modified (e.g. producing a hotfix for an already shipped version) ignore this warning.\r\nModules built outside of policy: \r\n{3}"
           }
         },
         {
@@ -450,7 +450,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is a C or C++ binary built with the stack protector buffer security feature enabled which does not disable protection for any individual functions (via __declspec(safebuffers), making it more difficult for an attacker to exploit stack buffer overflow memory corruption vulnerabilities.",
-            "Fail": "'{0}' is a C or C++ binary built with function(s) ({1}) that disable the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, is disallowed by SDL policy. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
+            "Error": "'{0}' is a C or C++ binary built with function(s) ({1}) that disable the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, is disallowed by SDL policy. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
           }
         },
         {
@@ -461,7 +461,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' does not incorporate any known vulnerable dependencies, as configured by current policy.",
-            "Fail": "'{0}' was built with a dependency on version of {1}, which is subject to the following issues: {2}. To resolve this, {3}. The source files that triggered this were: {4}"
+            "Error": "'{0}' was built with a dependency on version of {1}, which is subject to the following issues: {2}. To resolve this, {3}. The source files that triggered this were: {4}"
           }
         },
         {
@@ -472,7 +472,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' does not have an imports section that is marked as executable, helping to prevent the exploitability of code vulnerabilities.",
-            "Fail": "'{0}' has the imports section marked executable. Because the loader will always mark the imports section as writable, it is important to mark this section as non-executable, so that an attacker cannot place shellcode here. To resolve this issue, ensure that your program does not mark the imports section as executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
+            "Error": "'{0}' has the imports section marked executable. Because the loader will always mark the imports section as writable, it is important to mark this section as non-executable, so that an attacker cannot place shellcode here. To resolve this issue, ensure that your program does not mark the imports section as executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
           }
         },
         {
@@ -483,8 +483,8 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' contains no data or code sections marked as both shared and executable, helping to prevent the exploitability of code vulnerabilities.",
-            "Fail": "'{0}' contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your toolchain to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes.",
-            "Fail_UnexpectedSectionAligment": "'{0}' has a section alignment ({1}) that is smaller than page size ({2})."
+            "Error": "'{0}' contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your toolchain to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes.",
+            "Error_UnexpectedSectionAligment": "'{0}' has a section alignment ({1}) that is smaller than page size ({2})."
           }
         },
         {
@@ -495,7 +495,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' contains no data or code sections marked as both shared and writable, helping to prevent the exploitability of code vulnerabilities.",
-            "Fail": "'{0}' contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to mutate memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you are required to share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
+            "Error": "'{0}' contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to mutate memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you are required to share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
           }
         },
         {
@@ -507,8 +507,9 @@
           "formatSpecifiers": {
             "Pass": "'{0}' is a C or C++ binary built with the buffer security feature that properly preserves the stack protecter cookie. This has the effect of enabling a significant increase in entropy provided by the operating system over that produced by the C runtime start-up code.",
             "Pass_NoLoadConfig": "'{0}' is  C or C++binary that does not contain a load config table, which indicates either that it was compiled and linked with a version of the compiler that precedes stack protection features or is a binary (such as an ngen'ed assembly) that is not subject to relevant security issues.",
-            "Fail": "'{0}' is a C or C++ binary that interferes with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the magic statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement. NOTE: the modified cookie value detected was: {1}",
-            "Fail_CouldNotLocateCookie": "'{0}' is a C or C++binary that enables the stack protection feature but the security cookie could not be located. The binary may be corrupted."
+            "Error": "'{0}' is a C or C++ binary that interferes with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the magic statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement. NOTE: the modified cookie value detected was: {1}",
+            "Error_CouldNotLocateCookie": "'{0}' is a C or C++binary that enables the stack protection feature but the security cookie could not be located. The binary may be corrupted.",
+            "Warning_InvalidSecurityCookieOffset": "'{0}' appears to be a packed C or C++ binary that reports a security cookie offset that exceeds the size of the packed file. Use of the stack protector (/GS) feature therefore could not be verified. The file was possibly packed by: {1}."
           }
         },
         {
@@ -519,8 +520,8 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is not known to be an obsolete binary that is vulnerable to one or more security problems.",
-            "Fail": "'{0}' appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning.",
-            "Fail_CouldNotParseVersion": "Version information for '{0}' could not be parsed. The binary therefore could not be verified not to be an obsolete binary that is known to be vulnerable to one or more security problems."
+            "Error": "'{0}' appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning.",
+            "Error_CouldNotParseVersion": "Version information for '{0}' could not be parsed. The binary therefore could not be verified not to be an obsolete binary that is known to be vulnerable to one or more security problems."
           }
         },
         {
@@ -531,9 +532,9 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is properly compiled to enable address space layout randomization, reducing an attacker's ability to exploit code in well-known locations.",
-            "Fail_NotDynamicBase": "'{0}' is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. To resolve this issue, configure your tool chain to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later.",
-            "Fail_RelocsStripped": "'{0}' is marked as DYNAMICBASE but relocation data has been stripped from the image, preventing address space layout randomization. ",
-            "Fail_WinCENoRelocationSection": "'{0}' is a Windows CE image but does not contain any relocation data, preventing address space layout randomization."
+            "Error_NotDynamicBase": "'{0}' is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. To resolve this issue, configure your tool chain to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later.",
+            "Error_RelocsStripped": "'{0}' is marked as DYNAMICBASE but relocation data has been stripped from the image, preventing address space layout randomization. ",
+            "Error_WinCENoRelocationSection": "'{0}' is a Windows CE image but does not contain any relocation data, preventing address space layout randomization."
           }
         },
         {
@@ -544,9 +545,9 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' was compiled at a secure warning level ({1}) and does not include any modules that disable specific warnings that are required by policy. As a result, there is a greater likelihood that memory corruption, information disclosure, double-free and other security-related vulnerabilities do not exist in code.",
-            "Fail_WarningsDisabled": "'{0}' disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation. An example compiler command line triggering this check was: {1}\r\nModules triggering this check were:\r\n{2}",
-            "Fail_InsufficientWarningLevel": "'{0}' was compiled at too low a warning level (effective warning level {1} for one or more modules). Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted. An example compiler command line triggering this check: {2}\r\nModules triggering this check: {3}",
-            "Fail_UnknownModuleLanguage": "'{0}' contains code from an unknown language, preventing a comprehensive analysis of the compiler warning settings. The language could not be identified for the following modules: {1}"
+            "Error_WarningsDisabled": "'{0}' disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation. An example compiler command line triggering this check was: {1}\r\nModules triggering this check were:\r\n{2}",
+            "Error_InsufficientWarningLevel": "'{0}' was compiled at too low a warning level (effective warning level {1} for one or more modules). Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted. An example compiler command line triggering this check: {2}\r\nModules triggering this check: {3}",
+            "Error_UnknownModuleLanguage": "'{0}' contains code from an unknown language, preventing a comprehensive analysis of the compiler warning settings. The language could not be identified for the following modules: {1}"
           }
         },
         {
@@ -557,8 +558,8 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is a C or C++ binary built with the stack protector buffer security feature enabled for all modules, making it more difficult for an attacker to exploit stack buffer overflow memory corruption vulnerabilities. ",
-            "Fail": "'{0}' is a C or C++ binary built with the stack protector buffer security feature disabled in one or more modules. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that your code is compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line. The affected modules were: {1}",
-            "Fail_UnknownModuleLanguage": "'{0}' contains code from an unknown language, preventing a comprehensive analysis of the stack protector buffer security features. The language could not be identified for the following modules: {1}."
+            "Error": "'{0}' is a C or C++ binary built with the stack protector buffer security feature disabled in one or more modules. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that your code is compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line. The affected modules were: {1}",
+            "Error_UnknownModuleLanguage": "'{0}' contains code from an unknown language, preventing a comprehensive analysis of the stack protector buffer security features. The language could not be identified for the following modules: {1}."
           }
         },
         {
@@ -569,9 +570,9 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is high entropy ASLR compatible, reducing an attacker's ability to exploit code in well-known locations.",
-            "Fail_NoHighEntropyVA": "'{0}' does not declare itself as high entropy ASLR compatible. High entropy allows Address Space Layout Randomization to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. (This image was determined to have been properly compiled as /LARGEADDRESSAWARE.)",
-            "Fail_NoLargeAddressAware": "'{0}' does not declare itself as high entropy ASLR compatible. High entropy allows Address Space Layout Randomization to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible by supplying /LARGEADDRESSAWARE to the C or C++ linker command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.)",
-            "Fail_NeitherHighEntropyVANorLargeAddressAware": "'{0}' does not declare itself as high entropy ASLR compatible. High entropy allows Address Space Layout Randomization to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA as well as /LARGEADDRESSAWARE to the C or C++ linker command line."
+            "Error_NoHighEntropyVA": "'{0}' does not declare itself as high entropy ASLR compatible. High entropy allows Address Space Layout Randomization to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. (This image was determined to have been properly compiled as /LARGEADDRESSAWARE.)",
+            "Error_NoLargeAddressAware": "'{0}' does not declare itself as high entropy ASLR compatible. High entropy allows Address Space Layout Randomization to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible by supplying /LARGEADDRESSAWARE to the C or C++ linker command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.)",
+            "Error_NeitherHighEntropyVANorLargeAddressAware": "'{0}' does not declare itself as high entropy ASLR compatible. High entropy allows Address Space Layout Randomization to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA as well as /LARGEADDRESSAWARE to the C or C++ linker command line."
           }
         },
         {
@@ -584,7 +585,7 @@
             "Pass": "'{0}' is a C or C++ binary built with the buffer security feature that properly initializes the stack protecter. This has the effect of increasing the effectiveness of the feature and reducing spurious detections.",
             "Pass_NoCode": "'{0}' is a C or C++ binary that is not required to initialize the stack protection, as it does not contain executable code.",
             "NotApplicable_FeatureNotEnabled": "'{0}' is a C or C++ binary that does enable the stack protection buffer security feature. It is therefore not required to initialize the stack protector.",
-            "Fail": "'{0}' is a C or C++ binary that does not initialize the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
+            "Error": "'{0}' is a C or C++ binary that does not initialize the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
           }
         },
         {
@@ -595,7 +596,7 @@
           "options": {},
           "formatSpecifiers": {
             "Pass": "'{0}' is a 64-bit image with a base address that is >= 4 gigabytes, increaseing the effectiveness of address space layout randomization (that helps prevent attackers from executing security-sensitive code in well-known locations).",
-            "Fail": "'{0}' is a 64-bit image with a preferred base address below the 4GB boundary. Having a preferred base address below this boundary triggers a compatibility mode in Address Space Layout Randomization (ASLR) on recent versions of Windows that reduces the number of locations to which ASLR may relocate the binary. This reduces the effectiveness of ASLR at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress / /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
+            "Error": "'{0}' is a 64-bit image with a preferred base address below the 4GB boundary. Having a preferred base address below this boundary triggers a compatibility mode in Address Space Layout Randomization (ASLR) on recent versions of Windows that reduces the number of locations to which ASLR may relocate the binary. This reduces the effectiveness of ASLR at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress / /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
           }
         }
       ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x64_VS2015_Default.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x64_VS2015_Default.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x64_VS2015_Default.dll --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x64_VS2015_Default.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x64_VS2015_Default.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x64_VS2015_Default.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -97,7 +97,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -117,7 +117,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -137,7 +137,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -157,7 +157,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -178,7 +178,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -198,7 +198,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -218,7 +218,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -238,7 +238,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -261,7 +261,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -281,7 +281,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -301,7 +301,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -322,7 +322,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -342,7 +342,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -362,7 +362,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -382,7 +382,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -402,7 +402,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x64_VS2015_Default.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2013_Default.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2013_Default.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2013_Default.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2013_Default.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2013_Default.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2013_Default.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -140,7 +140,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -160,7 +160,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -180,7 +180,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -201,7 +201,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -221,7 +221,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -241,7 +241,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -261,7 +261,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -284,7 +284,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -304,7 +304,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -325,7 +325,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -345,7 +345,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -366,7 +366,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -386,7 +386,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -406,7 +406,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2013_PdbMissing.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2013_PdbMissing.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2013_PdbMissing.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2013_PdbMissing.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2013_PdbMissing.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2013_PdbMissing.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -120,7 +120,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -142,7 +142,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -164,7 +164,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -184,7 +184,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -205,7 +205,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -225,7 +225,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -245,7 +245,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -265,7 +265,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -288,7 +288,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -308,7 +308,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -330,7 +330,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -352,7 +352,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -373,7 +373,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -395,7 +395,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -415,7 +415,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2013_ResourceOnly.dll.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2013_ResourceOnly.dll.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2013_ResourceOnly.dll --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2013_ResourceOnly.dll.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2013_ResourceOnly.dll --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2013_ResourceOnly.dll.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -98,7 +98,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -121,7 +121,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -144,7 +144,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -167,7 +167,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -190,7 +190,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -213,7 +213,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -236,7 +236,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -259,7 +259,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -282,7 +282,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -305,7 +305,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -325,7 +325,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -345,7 +345,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -365,7 +365,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -385,7 +385,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -408,7 +408,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -428,7 +428,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll",
                   "mimeType": "application/octet-stream"
                 }
               ]

--- a/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2015_Default.exe.sarif
+++ b/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Expected/Native_x86_VS2015_Default.exe.sarif
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "0.4",
   "runLogs": [
     {
@@ -8,10 +8,10 @@
         "version": "1.2.16"
       },
       "runInfo": {
-        "invocationInfo": "\"D:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2015_Default.exe --output D:\\src\\binskim\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2015_Default.exe.sarif.temp --verbose --config default",
+        "invocationInfo": "\"Z:\\bld\\bin\\BinSkim.Driver\\x86_Release\\BinSkim.exe\" analyze Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Native_x86_VS2015_Default.exe --output Z:\\src\\BinSkim.Driver.FunctionalTests\\BaselineTestsData\\Expected\\Native_x86_VS2015_Default.exe.sarif.temp --verbose --config default",
         "analysisTargets": [
           {
-            "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe"
+            "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe"
           }
         ]
       },
@@ -29,7 +29,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -52,7 +52,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -75,7 +75,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -97,7 +97,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -117,7 +117,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -137,7 +137,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -157,7 +157,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -178,7 +178,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -198,7 +198,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -218,7 +218,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -238,7 +238,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -261,7 +261,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -281,7 +281,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -301,7 +301,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -322,7 +322,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -342,7 +342,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -363,7 +363,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -383,7 +383,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]
@@ -403,7 +403,7 @@
             {
               "analysisTarget": [
                 {
-                  "uri": "file:///D:/src/binskim/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
+                  "uri": "file:///Z:/src/BinSkim.Driver.FunctionalTests/BaselineTestsData/Native_x86_VS2015_Default.exe",
                   "mimeType": "application/octet-stream"
                 }
               ]


### PR DESCRIPTION
They were not being run from BuildAndTest.cmd, but they were running and failing in VS. This fixes the test and enables it on the command line as well.

The baseline had machine, configuration, and runtime-specific strings in it. The fix is to strip them from the baseline on generation and from the actual output during the test run.

Also fix up .gitignore to ignore these files and the .vs/ directory and remove a baseline file that has no actual counterpart.

@michaelcfanning 