### PR TITLE
Correct retrieval of MajorSubsystemVersion

### DIFF
--- a/src/BinaryParsers/PortableExecutable/PE.cs
+++ b/src/BinaryParsers/PortableExecutable/PE.cs
@@ -584,7 +584,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
 
                 if (optionalHeader != null)
                 {
-                    UInt16 major = optionalHeader.MajorImageVersion;
+                    UInt16 major = optionalHeader.MajorSubsystemVersion;
                     UInt16 minor = optionalHeader.MinorSubsystemVersion;
 
                     return new Version(major, minor);


### PR DESCRIPTION
@BillyONeal 

Identified by Paul Brookes. This problem doesn't seem to effect most PEs as the MajorImageVersion tends to match the MajorSubsystemVersion. This isn't true for some EFI binaries under analysis, though.