### PR TITLE
Update README (formatting and new version on nuget.org).

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This repository contains source code for BinSkim, a portable executable scanner 
 Getting Started as a Developer
 ==============================
 
-1. Clone the repository
-2. Load and compile src\BinSkim.sln
+1. Clone the repository.
+2. Load and compile `src\BinSkim.sln`.
 
-Execute output in bld\bin\BinSkim.Driver for testing.
+Execute output in `bld\bin\BinSkim.Driver` for testing.
 
 Submitting Pull Requests
 ========================
-Run test.cmd at the root of the enlistment to ensure that all tests pass, and x64 and x86 release builds succeed.
+Run `test.cmd` at the root of the enlistment to ensure that all tests pass, and x64 and x86 release builds succeed.
 
 Getting Started as a User
 =========================
@@ -24,6 +24,7 @@ Download BinSkim from Nuget
 
 Command-Line Documentation
 ==========================
+```
   -o, --output        File path to which analysis output will be written.
 
   -v, --verbose       Emit verbose output. The resulting comprehensive report
@@ -53,9 +54,10 @@ Command-Line Documentation
 
   value pos. 0        One or more specifiers to a file, directory, or filter
                       pattern that resolves to one or more binaries to analyze.
+```
 
 Example Command-Line
 ====================
-binskim.exe c:\bld\*.dll --recurse --policy default --output MyRun.sarif
+`binskim.exe c:\bld\*.dll --recurse --policy default --output MyRun.sarif`
 
 See the [SARIF](https://github.com/sarif-standard/sarif-spec/) site for more information on the 'Static Analysis Results Interchange Format'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Getting Started as a User
 
 Download BinSkim from Nuget
 
-*Latest stable Nuget version:* [1.3.8](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/)
+*Latest stable Nuget version:* [1.3.9](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/)
 
 Command-Line Documentation
 ==========================


### PR DESCRIPTION
No content changes, but I fixed the formatting within the README file and bumped the version link to reflect v1.3.9, which is now available on nuget.org.