### PR TITLE
Provide for x86 and x64 builds

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -31,11 +31,18 @@ msbuild /verbosity:minimal /target:rebuild src\BinSkim.sln /p:Configuration=Rele
 
 md bld\bin\nuget
 md bld\bin\LayoutForSigning
+md bld\bin\LayoutForSigning\x86
+md bld\bin\LayoutForSigning\x64
 
-xcopy /Y bld\bin\x86_Release\BinSkim.exe       bld\bin\LayoutForSigning
-xcopy /Y bld\bin\x86_Release\BinaryParsers.dll bld\bin\LayoutForSigning
-xcopy /Y bld\bin\x86_Release\BinSkim.Rules.dll bld\bin\LayoutForSigning
-xcopy /Y bld\bin\x86_Release\BinSkim.Sdk.dll   bld\bin\LayoutForSigning
+xcopy /Y bld\bin\x86_Release\BinSkim.exe       bld\bin\LayoutForSigning\x86
+xcopy /Y bld\bin\x86_Release\BinaryParsers.dll bld\bin\LayoutForSigning\x86
+xcopy /Y bld\bin\x86_Release\BinSkim.Rules.dll bld\bin\LayoutForSigning\x86
+xcopy /Y bld\bin\x86_Release\BinSkim.Sdk.dll   bld\bin\LayoutForSigning\x86
+
+xcopy /Y bld\bin\x64_Release\BinSkim.exe       bld\bin\LayoutForSigning\x64
+xcopy /Y bld\bin\x64_Release\BinaryParsers.dll bld\bin\LayoutForSigning\x64
+xcopy /Y bld\bin\x64_Release\BinSkim.Rules.dll bld\bin\LayoutForSigning\x64
+xcopy /Y bld\bin\x64_Release\BinSkim.Sdk.dll   bld\bin\LayoutForSigning\x64
 
 call BuildPackages.cmd || goto :ExitFailure
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -4,10 +4,16 @@ SETLOCAL
 
 call SetCurrentVersion.cmd
 
-xcopy /Y bld\bin\LayoutForSigning\BinSkim.exe       bld\bin\x86_Release\ || goto :ExitFailure
-xcopy /Y bld\bin\LayoutForSigning\BinaryParsers.dll bld\bin\x86_Release\ || goto :ExitFailure
-xcopy /Y bld\bin\LayoutForSigning\BinSkim.Rules.dll  bld\bin\x86_Release\ || goto :ExitFailure
-xcopy /Y bld\bin\LayoutForSigning\BinSkim.Sdk.dll   bld\bin\x86_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x86\BinSkim.exe       bld\bin\x86_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x86\BinaryParsers.dll bld\bin\x86_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x86\BinSkim.Rules.dll bld\bin\x86_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x86\BinSkim.Sdk.dll   bld\bin\x86_Release\ || goto :ExitFailure
+
+xcopy /Y bld\bin\LayoutForSigning\x64\BinSkim.exe       bld\bin\x64_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x64\BinaryParsers.dll bld\bin\x64_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x64\BinSkim.Rules.dll bld\bin\x64_Release\ || goto :ExitFailure
+xcopy /Y bld\bin\LayoutForSigning\x64\BinSkim.Sdk.dll   bld\bin\x64_Release\ || goto :ExitFailure
+
 
 .nuget\NuGet.exe pack .\src\Nuget\BinSkim.nuspec -Symbols -Properties id=Microsoft.CodeAnalysis.BinSkim;major=%MAJOR%;minor=%MINOR%;patch=%PATCH%;prerelease=%PRERELEASE% -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget || goto :ExitFailed
 


### PR DESCRIPTION
Correct build scripts to provide for both x86 and x64 packages. @EasyRhinoMSFT 

