### PR TITLE
Complete full set of Spectre checks possible with current PDB records

### DIFF
--- a/src/BinSkim.Rules.FunctionalTests/ILDiagnosticsAnalyzerTests.cs
+++ b/src/BinSkim.Rules.FunctionalTests/ILDiagnosticsAnalyzerTests.cs
@@ -87,6 +87,8 @@ namespace Microsoft.CodeAnalysis.IL
                 "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable.PE'",
                 "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable.SafePointer'",
                 "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.CompilandRecord'",
+                "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.SwitchState'",
+                "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.OrderOfPrecedence'",
                 "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.CompilerCommandLine.WarningState'",
                 "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.CompilerCommandLine'",
                 "Symbol encountered in MSIL 'global::Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.<CreateSourceFileIteratorImpl>d__21'",

--- a/src/BinSkim.Rules/EnableSpectreMitigations.cs
+++ b/src/BinSkim.Rules/EnableSpectreMitigations.cs
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 SwitchState effectiveState;
 
                 // Go process the command line to check for switches
-                effectiveState = omDetails.GetSwitchStateWithAliases(mitigationSwitches, onbyDefault == true ? SwitchState.SwitchEnabled : SwitchState.SwitchDisabled, OrderOfPrecedence.LastWins);
+                effectiveState = omDetails.GetSwitchState(mitigationSwitches, null, onbyDefault == true ? SwitchState.SwitchEnabled : SwitchState.SwitchDisabled, OrderOfPrecedence.LastWins);
 
                 if (effectiveState == SwitchState.SwitchDisabled)
                 {
@@ -295,11 +295,13 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
                 if (supportsOd == false)
                 {
-                    string[] OptimizerSwitches = { "/Od", "/O1", "/O2", "/Ox", "/Og" };
+                    string[] OdSwitches = { "/Od" };
+                    // These switches override /Od - there is no one place to find this information on msdn at this time.
+                    string[] OptimizeSwitches = { "/O1", "/O2", "/Ox", "/Og" };
 
                     bool debugEnabled = false;
 
-                    if (omDetails.GetSwitchStateFactoringOverrides(OptimizerSwitches, SwitchState.SwitchEnabled, OrderOfPrecedence.LastWins) == SwitchState.SwitchEnabled)
+                    if (omDetails.GetSwitchState(OdSwitches, OptimizeSwitches, SwitchState.SwitchEnabled, OrderOfPrecedence.LastWins) == SwitchState.SwitchEnabled)
                     {
                         debugEnabled = true;
                     }

--- a/src/BinSkim.Rules/EnableSpectreMitigations.cs
+++ b/src/BinSkim.Rules/EnableSpectreMitigations.cs
@@ -220,6 +220,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     // Now check the patched versions that we match on the major, minor versions and then are greater than or equal to on the rest...
                     foreach (var compilerVersionEntry in minimumCompilers)
                     {
+                        // TODO - This code currently assumes a sorted order of the array and that there are not multiple versions (major/minor) 
+                        // that support different sets of switches (something that will probably break very soon).
+                        // This logic needs to be updated to be more robust.
                         Version ver = compilerVersionEntry.Value.compilerVersion;
 
                         if (ver.Major == omVer.Major
@@ -277,7 +280,6 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                             om.CreateCompilandRecordWithSuffix(
                                 string.Format(CultureInfo.InvariantCulture,
                                 RuleResources.BA2024_Error_BuildWithSpectreMitigation_SpectreMitigationMissing)));
-                        continue;
                     }
                     else
                     {

--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -828,6 +828,15 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to built with /Od which disables Spectre mitigations in the compiler version {0}..
+        /// </summary>
+        internal static string BA2024_Error_BuiltWithSpectreMitigation_OdUsedAndUnsupported {
+            get {
+                return ResourceManager.GetString("BA2024_Error_BuiltWithSpectreMitigation_OdUsedAndUnsupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All modules linked into {0} have been verified to be compiled with Spectre mitigations enabled..
         /// </summary>
         internal static string BA2024_Pass {

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -376,6 +376,9 @@ Modules triggering this check were:
   <data name="BA2024_Error_BuildWithSpectreMitigation_SpectreMitigationMissing" xml:space="preserve">
     <value>built with tools that support the Spectre mitigations but these have not been enabled.</value>
   </data>
+  <data name="BA2024_Error_BuiltWithSpectreMitigation_OdUsedAndUnsupported" xml:space="preserve">
+    <value>built with /Od which disables Spectre mitigations in the compiler version {0}.</value>
+  </data>
   <data name="BA2024_Pass" xml:space="preserve">
     <value>All modules linked into {0} have been verified to be compiled with Spectre mitigations enabled.</value>
   </data>

--- a/src/BinaryParsers/ProgramDatabase/ObjectModuleDetails.cs
+++ b/src/BinaryParsers/ProgramDatabase/ObjectModuleDetails.cs
@@ -147,19 +147,28 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
                 return _hasDebugInfo;
             }
         }
+
+        /// <summary>
+        /// Determine the state of a single switch
+        /// </summary>
+        /// <param name="switchName">Switch name to check.</param>
+        /// <param name="precedence">The precedence rules for this switch.</param>
         public SwitchState GetSwitchState(string switchName, OrderOfPrecedence precedence)
         {
-            return _commandLine.GetSwitchState(switchName, precedence);
+            string[] switchNames = new string[1] { switchName };
+            return _commandLine.GetSwitchState(switchNames, null, SwitchState.SwitchNotFound, precedence);
         }
 
-        public SwitchState GetSwitchStateFactoringOverrides(string[] switchNames, SwitchState defaultStateOfFirst, OrderOfPrecedence precedence)
+        /// <summary>
+        /// Determine if a switch is set,unset or not present on the command-line.
+        /// </summary>
+        /// <param name="switchNames">Array of switches that alias each other and all set the same compiler state.</param>
+        /// <param name="overrideNames">Array of switches that invalidate the state of the switches in switchNames.</param>
+        /// <param name="defaultState">The default state of the switch should no instance of the switch or its overrides be found.</param>
+        /// <param name="precedence">The precedence rules for this set of switches.</param>
+        public SwitchState GetSwitchState(string[] switchNames, string[] overrideNames, SwitchState defaultStateOfFirst, OrderOfPrecedence precedence)
         {
-            return _commandLine.GetSwitchStateFactoringOverrides(switchNames, defaultStateOfFirst, precedence);
-        }
-
-        public SwitchState GetSwitchStateWithAliases(string[] switchNames, SwitchState defaultState, OrderOfPrecedence precedence)
-        {
-            return _commandLine.GetSwitchStateWithAliases(switchNames, defaultState, precedence);
+            return _commandLine.GetSwitchState(switchNames, overrideNames, defaultStateOfFirst, precedence);
         }
 
     }

--- a/src/BinaryParsers/ProgramDatabase/ObjectModuleDetails.cs
+++ b/src/BinaryParsers/ProgramDatabase/ObjectModuleDetails.cs
@@ -152,6 +152,16 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
             return _commandLine.GetSwitchState(switchName, precedence);
         }
 
+        public SwitchState GetSwitchStateFactoringOverrides(string[] switchNames, SwitchState defaultStateOfFirst, OrderOfPrecedence precedence)
+        {
+            return _commandLine.GetSwitchStateFactoringOverrides(switchNames, defaultStateOfFirst, precedence);
+        }
+
+        public SwitchState GetSwitchStateWithAliases(string[] switchNames, SwitchState defaultState, OrderOfPrecedence precedence)
+        {
+            return _commandLine.GetSwitchStateWithAliases(switchNames, defaultState, precedence);
+        }
+
     }
 
     public enum Language : uint


### PR DESCRIPTION
Add support for /Od checking and updated CompilerCommandLine to be able to cope with aliasing and overriding switched to return an actual state based on precedence.

I'm pretty sure that this is the full set of checks that are possible with the existing PDB records.  I will have to work with the compiler team on if we can surface additional information.

This is independent of the refactoring changes @michaelcfanning proposed in his PR.