### PR TITLE
Enable reporting of MASM modules

### DIFF
--- a/src/BinSkim.Rules/RuleConstants.cs
+++ b/src/BinSkim.Rules/RuleConstants.cs
@@ -36,6 +36,6 @@ namespace Microsoft.CodeAnalysis.IL.Rules
         public const string SignCorrectly = "BA2022";
         public const string DoNotMarkImportsSectionAsWritableId = "BA2023";
 
-        public const string EnableSpectreMitigiations = "BA2024";
+        public const string EnableSpectreMitigations = "BA2024";
     }
 }

--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class RuleResources {
@@ -788,6 +788,16 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         internal static string BA2024_Error {
             get {
                 return ResourceManager.GetString("BA2024_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following MASM modules were detected. The MASM compiler does not currently mitigate against speculative execution attacks:
+        ///{0}.
+        /// </summary>
+        internal static string BA2024_Error_MasmModulesDetected {
+            get {
+                return ResourceManager.GetString("BA2024_Error_MasmModulesDetected", resourceCulture);
             }
         }
         

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -365,6 +365,10 @@ Modules triggering this check were:
     <value>'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:
 {1}</value>
   </data>
+  <data name="BA2024_Error_MasmModulesDetected" xml:space="preserve">
+    <value>The following MASM modules were detected. The MASM compiler does not currently mitigate against speculative execution attacks:
+{0}</value>
+  </data>
   <data name="BA2024_Error_SpectreMitigationExplicitlyDisabled" xml:space="preserve">
     <value>The following modules were compiled with the Spectre mitigations explicitly disabled:
 {0}</value>


### PR DESCRIPTION
@Evmaus-MS @paddymcd-MSFT 

There is a deserialization issue with the new option, will get this fixed in the next commit. Wanted to show the basics of this change. We need a test binary that links a MASM modules