### PR TITLE
Fixing build to copy correct dependencies

### DIFF
--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -64,8 +64,8 @@
 
   <ItemGroup>
     <!-- May need to be changed to x86 on a 32 bit machine. -->
-    <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(Configuration)' == 'Debug' And '$(TargetFramework)'=='$(NetRuntimeVersion)' And '$(RuntimeIdentifier)'=='win7-x86'" />
-    <MsDiaLibs Include="..\..\refs\x86\*" Condition="'$(Configuration)' == 'Debug' And '$(TargetFramework)'=='$(NetCoreVersion)' And '$(RuntimeIdentifier)'==''" />
+    <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(TargetFramework)'=='$(NetRuntimeVersion)' And '$(RuntimeIdentifier)'=='win7-x86'" />
+    <MsDiaLibs Include="..\..\refs\x86\*" Condition="'$(TargetFramework)'=='$(NetCoreVersion)' And '$(RuntimeIdentifier)'==''" />
     <!-- Note: Official Release builds on Windows should specify a RID. Build using the BuildAndTest.cmd script. -->
     <MsDiaLibs Include="..\..\refs\x86\*" Condition="'$(RuntimeIdentifier)'=='win-x86'" />
     <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(RuntimeIdentifier)'=='win-x64'" />

--- a/src/BinSkim.Driver/BinSkim.cs
+++ b/src/BinSkim.Driver/BinSkim.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 
 namespace Microsoft.CodeAnalysis.IL
 {


### PR DESCRIPTION
This fixes the build so that the native dependencies are properly copied.