### PR TITLE
Dev/evmaus ms/fix signing layout

### DIFF
--- a/CreateLayoutDirectory.cmd
+++ b/CreateLayoutDirectory.cmd
@@ -27,19 +27,30 @@ call :CreateDirIfNotExist %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\
 call :CreateDirIfNotExist %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\
 call :CreateDirIfNotExist %LayoutForSigningDirectory%\netcoreapp2.0\linux-x64\
 
-call :CopyFilesForMultitargeting BinSkim.exe       || goto :ExitFailed
+call :CopyExeForSigning BinSkim.exe                || goto :ExitFailed
+call :CopyFilesForMultitargeting BinSkim.dll      || goto :ExitFailed
 call :CopyFilesForMultitargeting BinaryParsers.dll || goto :ExitFailed
 call :CopyFilesForMultitargeting BinSkim.Rules.dll || goto :ExitFailed
 call :CopyFilesForMultitargeting BinSkim.Sdk.dll   || goto :ExitFailed
 
 goto :Exit
 
+:CopyExeForSigning
+xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\win-x86\%~n1.exe  %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :ExeFilesExit)
+xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\win-x64\%~n1.exe  %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :ExeFilesExit)
+:ExeFilesExit
+Exit /B %ERRORLEVEL%
+
 :CopyFilesForMultitargeting
 xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\win-x86\%~n1.dll  %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\win-x64\%~n1.dll  %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\linux-x64\%~n1.dll  %LayoutForSigningDirectory%\netcoreapp2.0\linux-x64\
-
-if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed.)
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
+:CopyFilesExit
 Exit /B %ERRORLEVEL%
 
 :CreateDirIfNotExist

--- a/CreatePackagesFromLayoutDirectory.cmd
+++ b/CreatePackagesFromLayoutDirectory.cmd
@@ -36,10 +36,12 @@ goto :Exit
 
 :CopyFilesForMultitargeting
 xcopy /Y  %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.0\win-x86\
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.0\win-x64\
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.0\linux-x64\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.0\linux-x64\
-
-if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed.)
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
+:CopyFilesExit
 Exit /B %ERRORLEVEL%
 
 :ExitFailed

--- a/CreatePackagesFromLayoutDirectory.cmd
+++ b/CreatePackagesFromLayoutDirectory.cmd
@@ -22,7 +22,8 @@ set BinaryOutputDirectory=%BinaryOutputDirectory%\%Platform%_%Configuration%\Pub
 set LayoutForSigningDirectory=%BinaryOutputDirectory%\..\LayoutForSigning
 
 :: Copy all multitargeted assemblies to their locations
-call :CopyFilesForMultitargeting BinSkim.exe       || goto :ExitFailed
+call :CopyExeForSigning BinSkim.exe
+call :CopyFilesForMultitargeting BinSkim.dll       || goto :ExitFailed
 call :CopyFilesForMultitargeting BinaryParsers.dll || goto :ExitFailed
 call :CopyFilesForMultitargeting BinSkim.Rules.dll || goto :ExitFailed
 call :CopyFilesForMultitargeting BinSkim.Sdk.dll   || goto :ExitFailed
@@ -34,12 +35,20 @@ call BuildPackages.cmd %Configuration% %Platform% %NuGetOutputDirectory% %Versio
 
 goto :Exit
 
+:CopyExeForSigning
+xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\%~n1.exe %BinaryOutputDirectory%\netcoreapp2.0\win-x86\ 
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :ExeFilesExit)
+xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\%~n1.exe %BinaryOutputDirectory%\netcoreapp2.0\win-x64\ 
+if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :ExeFilesExit)
+:ExeFilesExit
+Exit /B %ERRORLEVEL%
+
 :CopyFilesForMultitargeting
-xcopy /Y  %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.0\win-x86\
+xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\win-x86\%~n1.dll %LayoutForSigningDirectory%\netcoreapp2.0\win-x86\ 
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
-xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.0\win-x64\
+xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\win-x64\%~n1.dll %LayoutForSigningDirectory%\netcoreapp2.0\win-x64\ 
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
-xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.0\linux-x64\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.0\linux-x64\
+xcopy /Y %BinaryOutputDirectory%\netcoreapp2.0\linux-x64\%~n1.dll  %LayoutForSigningDirectory%\netcoreapp2.0\linux-x64\
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 :CopyFilesExit
 Exit /B %ERRORLEVEL%


### PR DESCRIPTION
We weren't signing the .exe on Windows.  Although my understanding is that the .exe is basically a modified .net core runtime, we should sign it along with BinSkim.dll.