### PR TITLE
Spectre reporting

### DIFF
--- a/src/BinSkim.Driver/BinSkim.cs
+++ b/src/BinSkim.Driver/BinSkim.cs
@@ -5,10 +5,6 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 
 using CommandLine;
 using System.Collections.Generic;
-using System;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Sarif;
 
 namespace Microsoft.CodeAnalysis.IL

--- a/src/BinSkim.Driver/RoslynAnalyzer/ILDiagnosticsAnalyzer.cs
+++ b/src/BinSkim.Driver/RoslynAnalyzer/ILDiagnosticsAnalyzer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Threading;

--- a/src/BinSkim.Rules/ELFRules/BA3002.DoNotMarkStackAsExecutable.cs
+++ b/src/BinSkim.Rules/ELFRules/BA3002.DoNotMarkStackAsExecutable.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.BinaryParsers;
 using ELFSharp.ELF;
-using System.Linq;
 using ELFSharp.ELF.Segments;
 
 namespace Microsoft.CodeAnalysis.IL.Rules

--- a/src/BinSkim.Rules/ELFRules/BA3010.EnableReadOnlyRelocations.cs
+++ b/src/BinSkim.Rules/ELFRules/BA3010.EnableReadOnlyRelocations.cs
@@ -8,8 +8,6 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.BinaryParsers;
 using ELFSharp.ELF;
-using System.Linq;
-using ELFSharp.ELF.Segments;
 
 namespace Microsoft.CodeAnalysis.IL.Rules
 {

--- a/src/BinSkim.Rules/PERules/BA2002.DoNotIncorporateVulnerableDependencies.cs
+++ b/src/BinSkim.Rules/PERules/BA2002.DoNotIncorporateVulnerableDependencies.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
-using System.Reflection.PortableExecutable;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable;

--- a/src/BinSkim.Rules/PERules/BA2006.BuildWithSecureTools.cs
+++ b/src/BinSkim.Rules/PERules/BA2006.BuildWithSecureTools.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Globalization;
-using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable;
 using Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase;
@@ -122,7 +121,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     Version minAllowedVersion;
 
                     if (allowedLibraries.TryGetValue(libFileName, out minAllowedVersion) &&
-                        omDetails.CompilerVersion >= minAllowedVersion)
+                        omDetails.CompilerBackEndVersion >= minAllowedVersion)
                     {
                         continue;
                     }
@@ -135,7 +134,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 {
                     case Language.C:
                     case Language.Cxx:
-                        actualVersion = Minimum(omDetails.CompilerVersion, omDetails.CompilerFrontEndVersion);
+                        actualVersion = Minimum(omDetails.CompilerBackEndVersion, omDetails.CompilerFrontEndVersion);
                         minimumVersion = minCompilerVersion;
                         break;
 
@@ -184,7 +183,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                         om.CreateCompilandRecordWithSuffix(
                             String.Format(CultureInfo.InvariantCulture,
                             RuleResources.BA2006_Error_BadModule,
-                            omLanguage, omDetails.CompilerVersion, omDetails.CompilerFrontEndVersion)));
+                            omLanguage, omDetails.CompilerBackEndVersion, omDetails.CompilerFrontEndVersion)));
                 }
             }
 

--- a/src/BinSkim.Rules/PERules/BA2007.EnableCriticalCompilerWarnings.cs
+++ b/src/BinSkim.Rules/PERules/BA2007.EnableCriticalCompilerWarnings.cs
@@ -8,7 +8,6 @@ using System.Composition;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 
 using Dia2Lib;
 
@@ -150,7 +149,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 overallMinimumWarningLevel = Math.Min(overallMinimumWarningLevel, warningLevel);
                 if (warningLevel < 3)
                 {
-                    exampleTooLowWarningCommandLine = exampleTooLowWarningCommandLine ?? omDetails.CommandLine;
+                    exampleTooLowWarningCommandLine = exampleTooLowWarningCommandLine ?? omDetails.RawCommandLine;
 
                     string msg = "[warning level: " + warningLevel.ToString(CultureInfo.InvariantCulture) + "]";
                     warningTooLowModules.Add(om.CreateCompilandRecordWithSuffix(msg));
@@ -160,7 +159,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 if (requiredDisabledWarnings.Count != 0)
                 {
                     MergeInto(overallDisabledWarnings, requiredDisabledWarnings);
-                    exampleDisabledWarningCommandLine = exampleDisabledWarningCommandLine ?? omDetails.CommandLine;
+                    exampleDisabledWarningCommandLine = exampleDisabledWarningCommandLine ?? omDetails.RawCommandLine;
 
                     string msg = "[Explicitly disabled warnings: " + CreateTextWarningList(requiredDisabledWarnings) + "]";
                     disabledWarningModules.Add(om.CreateCompilandRecordWithSuffix(msg));

--- a/src/BinSkim.Rules/PERules/BA2011.EnableStackProtection.cs
+++ b/src/BinSkim.Rules/PERules/BA2011.EnableStackProtection.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 
 using Dia2Lib;
 

--- a/src/BinSkim.Rules/PERules/BA2013.InitializeStackProtection.cs
+++ b/src/BinSkim.Rules/PERules/BA2013.InitializeStackProtection.cs
@@ -3,7 +3,6 @@
 
 using System.Composition;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase;

--- a/src/BinSkim.Rules/PERules/BA2014.DoNotDisableStackProtectionForFunctions.cs
+++ b/src/BinSkim.Rules/PERules/BA2014.DoNotDisableStackProtectionForFunctions.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Reflection.PortableExecutable;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase;

--- a/src/BinSkim.Rules/PERules/BA2015.EnableHighEntropyVirtualAddresses.cs
+++ b/src/BinSkim.Rules/PERules/BA2015.EnableHighEntropyVirtualAddresses.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Reflection.PortableExecutable;

--- a/src/BinSkim.Rules/PERules/BA2022.SignSecurely.cs
+++ b/src/BinSkim.Rules/PERules/BA2022.SignSecurely.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/BinSkim.Rules/PERules/BA2024.EnableSpectreMitigations.cs
+++ b/src/BinSkim.Rules/PERules/BA2024.EnableSpectreMitigations.cs
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
             foreach (string key in librariesToObjectModulesMap.Keys)
             {
-                sb.Append(Environment.NewLine + key);
+                sb.Append(key);
 
                 List<string> objectModules = librariesToObjectModulesMap[key];
                 objectModules.Sort();

--- a/src/BinSkim.Rules/PERules/BA2024.EnableSpectreMitigations.cs
+++ b/src/BinSkim.Rules/PERules/BA2024.EnableSpectreMitigations.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics;
 using System.Reflection.PortableExecutable;
 using System.Text;
 
@@ -14,9 +13,9 @@ using Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase;
 using Microsoft.CodeAnalysis.IL.Sdk;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using System.Runtime;
 using System.Linq;
 using Microsoft.CodeAnalysis.BinaryParsers;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.IL.Rules
 {
@@ -131,8 +130,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
             Pdb pdb = target.Pdb;
 
-            TruncatedCompilandRecordList masmModules = new TruncatedCompilandRecordList();
-            TruncatedCompilandRecordList mitigationNotEnabledModules = new TruncatedCompilandRecordList();
+            var masmModules = new TruncatedCompilandRecordList();
+            var mitigationNotEnabledModules = new List<ObjectModuleDetails>();
             TruncatedCompilandRecordList mitigationDisabledInDebugBuild = new TruncatedCompilandRecordList();
             TruncatedCompilandRecordList mitigationExplicitlyDisabledModules = new TruncatedCompilandRecordList();
 
@@ -146,11 +145,11 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 // See if the item is in our skip list.
                 if (!string.IsNullOrEmpty(om.Lib))
                 {
-                    string libFileName = string.Concat(System.IO.Path.GetFileName(om.Lib), ",", omDetails.Language.ToString()).ToLowerInvariant();
+                    string libFileName = string.Concat(Path.GetFileName(om.Lib), ",", omDetails.Language.ToString()).ToLowerInvariant();
                     Version minAllowedVersion;
 
                     if (allowedLibraries.TryGetValue(libFileName, out minAllowedVersion) &&
-                        omDetails.CompilerVersion >= minAllowedVersion)
+                        omDetails.CompilerBackEndVersion >= minAllowedVersion)
                     {
                         continue;
                     }
@@ -173,7 +172,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                         }
                         else
                         {
-                            actualVersion = omDetails.CompilerVersion;
+                            actualVersion = omDetails.CompilerBackEndVersion;
                         }
                         break;
                     }
@@ -230,7 +229,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
                 // Get the appropriate compiler version against which to check this compiland.
                 // check that we are greater than or equal to the first fully supported release: 15.6 first
-                Version omVersion = omDetails.CompilerVersion;
+                Version omVersion = omDetails.CompilerBackEndVersion;
                 
                 CompilerMitigations availableMitigations = GetAvailableMitigations(context, machineType, omVersion);
                 
@@ -271,7 +270,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     if (QSpectreState == SwitchState.SwitchNotFound && d2guardspecloadState == SwitchState.SwitchNotFound)
                     {
                         // Built with tools that support the Spectre mitigations but these have not been enabled.
-                        mitigationNotEnabledModules.Add(om.CreateCompilandRecord());
+                        mitigationNotEnabledModules.Add(omDetails);
                     }
                     else
                     {
@@ -317,13 +316,13 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 sb.AppendLine(line);
             }
 
-            if (!mitigationNotEnabledModules.Empty)
+            if (mitigationNotEnabledModules.Count > 0)
             {
                 // The following modules were compiled with a toolset that supports 
                 // /Qspectre but the switch was not enabled on the command-line: {0}
                 line = string.Format(
                         RuleResources.BA2024_Error_SpectreMitigationNotEnabled,
-                        mitigationNotEnabledModules.CreateSortedObjectList());
+                        CreateOutputCoalescedByLibrary(mitigationNotEnabledModules));
                 sb.AppendLine(line);
             }
 
@@ -371,6 +370,41 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                         context.TargetUri.GetFileName()));
         }
 
+        private string CreateOutputCoalescedByLibrary(List<ObjectModuleDetails> objectModuleDetailsList)
+        {
+            var librariesToObjectModulesMap = new Dictionary<string, List<string>>();
+
+            foreach (ObjectModuleDetails objectModuleDetail in objectModuleDetailsList)
+            {
+                string key = CreateLibraryDescriptor(objectModuleDetail);
+                if (!librariesToObjectModulesMap.TryGetValue(key, out List<string> objectModules))
+                {
+                    objectModules = librariesToObjectModulesMap[key] = new List<string>();
+                }
+                objectModules.Add(Path.GetFileName(objectModuleDetail.Name));
+            }
+
+
+            var sb = new StringBuilder();
+
+            foreach (string key in librariesToObjectModulesMap.Keys)
+            {
+                sb.Append(Environment.NewLine + key);
+
+                List<string> objectModules = librariesToObjectModulesMap[key];
+                objectModules.Sort();
+                sb.AppendLine(" : " + string.Join(",", objectModules.ToArray()));
+            }
+             
+            return sb.ToString();
+        }
+
+        private string CreateLibraryDescriptor(ObjectModuleDetails objectModuleDetail) => 
+            Path.GetFileName(objectModuleDetail.Library) + "," + 
+            objectModuleDetail.Language.ToString().ToLowerInvariant() + "," + 
+            objectModuleDetail.CompilerBackEndVersion;
+
+
         internal static Version GetClosestCompilerVersionWithSpectreMitigations(BinaryAnalyzerContext context, ExtendedMachine machine, Version omVersion)
         {
             var compilerMitigationData = LoadCompilerDataFromConfig(context.Policy);
@@ -392,11 +426,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 Version previousMaximum = new Version(0, 0, 0, 0);
                 for (int i = 0; i < listOfMitigatedCompilers.Length; i++)
                 {
-                    if(omVersion > previousMaximum
-                        && omVersion <= listOfMitigatedCompilers[i].MinimalSupportedVersion 
-                        && (listOfMitigatedCompilers[i].SupportedMitigations 
-                            & (CompilerMitigations.QSpectreAvailable 
-                            | CompilerMitigations.D2GuardSpecLoadAvailable)) != 0)
+                    if (omVersion > previousMaximum && 
+                        omVersion <= listOfMitigatedCompilers[i].MinimalSupportedVersion && 
+                        (listOfMitigatedCompilers[i].SupportedMitigations & (CompilerMitigations.QSpectreAvailable | CompilerMitigations.D2GuardSpecLoadAvailable)) != 0)
                     {
                         return listOfMitigatedCompilers[i].MinimalSupportedVersion;
                     }

--- a/src/BinSkim.Rules/PERules/BA2024.EnableSpectreMitigations.cs
+++ b/src/BinSkim.Rules/PERules/BA2024.EnableSpectreMitigations.cs
@@ -49,10 +49,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             get
             {
                 return new string[] {
-                    nameof(RuleResources.BA2024_Error),
-                    nameof(RuleResources.BA2024_Error_OptimizationsDisabled),
-                    nameof(RuleResources.BA2024_Error_SpectreMitigationNotEnabled),
-                    nameof(RuleResources.BA2024_Error_SpectreMitigationExplicitlyDisabled),
+                    nameof(RuleResources.BA2024_Warning),
+                    nameof(RuleResources.BA2024_Warning_OptimizationsDisabled),
+                    nameof(RuleResources.BA2024_Warning_SpectreMitigationNotEnabled),
+                    nameof(RuleResources.BA2024_Warning_SpectreMitigationExplicitlyDisabled),
                     nameof(RuleResources.BA2024_Pass),
                     nameof(RuleResources.NotApplicable_InvalidMetadata)};
             }
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 // The following modules were compiled with Spectre
                 // mitigations explicitly disabled: {0}
                 line = string.Format(
-                        RuleResources.BA2024_Error_SpectreMitigationExplicitlyDisabled,
+                        RuleResources.BA2024_Warning_SpectreMitigationExplicitlyDisabled,
                         mitigationExplicitlyDisabledModules.CreateSortedObjectList());
                 sb.AppendLine(line);
             }
@@ -321,7 +321,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 // The following modules were compiled with a toolset that supports 
                 // /Qspectre but the switch was not enabled on the command-line: {0}
                 line = string.Format(
-                        RuleResources.BA2024_Error_SpectreMitigationNotEnabled,
+                        RuleResources.BA2024_Warning_SpectreMitigationNotEnabled,
                         CreateOutputCoalescedByLibrary(mitigationNotEnabledModules));
                 sb.AppendLine(line);
             }
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 // The following modules were compiled with optimizations disabled(/ Od),
                 // a condition that disables Spectre mitigations: {0}
                 line = string.Format(
-                        RuleResources.BA2024_Error_OptimizationsDisabled,
+                        RuleResources.BA2024_Warning_OptimizationsDisabled,
                         mitigationDisabledInDebugBuild.CreateSortedObjectList());
                 sb.AppendLine(line);
             }
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 !masmModules.Empty)
             {
                 line = string.Format(
-                        RuleResources.BA2024_Error_MasmModulesDetected,
+                        RuleResources.BA2024_Warning_MasmModulesDetected,
                         masmModules.CreateSortedObjectList());
                 sb.AppendLine(line);
             }
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 // The following modules are out of policy: {1}
                 context.Logger.Log(this,
                     RuleUtilities.BuildResult(ResultLevel.Error, context, null,
-                    nameof(RuleResources.BA2024_Error),
+                    nameof(RuleResources.BA2024_Warning),
                         context.TargetUri.GetFileName(),
                         sb.ToString()));
                 return;

--- a/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
+++ b/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.IL.Sdk;
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.IL.Rules
 {

--- a/src/BinSkim.Rules/ReproInformationConfiguration.cs
+++ b/src/BinSkim.Rules/ReproInformationConfiguration.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Sarif;
+
+namespace Microsoft.CodeAnalysis.IL.Rules
+{
+    public static class ReproInformationConfiguration
+    {
+        internal static PerLanguageOption<StringToVersionMap> BA2024_AllowedLibraries { get; } =
+            new PerLanguageOption<StringToVersionMap>(
+                null, nameof(BA2024_AllowedLibraries), defaultValue: () => { return null; });
+
+    }
+}

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -362,7 +362,8 @@ Modules triggering this check were:
     <value>Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it.</value>
   </data>
   <data name="BA2024_Error" xml:space="preserve">
-    <value>'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:
+    <value>'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre).
+
 {1}</value>
   </data>
   <data name="BA2024_Error_MasmModulesDetected" xml:space="preserve">

--- a/src/BinSkim.Sdk/BinaryAnalyzerContextExtensions.cs
+++ b/src/BinSkim.Sdk/BinaryAnalyzerContextExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.BinaryParsers;
-using Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.IL.Sdk
 {

--- a/src/BinSkim.Sdk/BinaryTargetManager.cs
+++ b/src/BinSkim.Sdk/BinaryTargetManager.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.BinaryParsers;
 using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.IL.Sdk
 {

--- a/src/BinSkim.Sdk/BuildKind.cs
+++ b/src/BinSkim.Sdk/BuildKind.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 
 namespace Microsoft.CodeAnalysis.IL.Sdk
 {

--- a/src/BinaryParsers/BinaryBase.cs
+++ b/src/BinaryParsers/BinaryBase.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers
 {

--- a/src/BinaryParsers/ELFBinary/ELFBinary.cs
+++ b/src/BinaryParsers/ELFBinary/ELFBinary.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using ELFSharp.ELF;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers

--- a/src/BinaryParsers/IBinary.cs
+++ b/src/BinaryParsers/IBinary.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers
 {

--- a/src/BinaryParsers/PEBinary/PEBinary.cs
+++ b/src/BinaryParsers/PEBinary/PEBinary.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection.PortableExecutable;
-using System.Text;
 
 using Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable;
 using Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase;

--- a/src/BinaryParsers/PEBinary/PortableExecutable/PE.cs
+++ b/src/BinaryParsers/PEBinary/PortableExecutable/PE.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
 {

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Dia2Lib;

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/Symbol.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/Symbol.cs
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
                 }
             }
 
-            return new ObjectModuleDetails(frontEndVersion, backEndVersion, commandLine, language, compilerName, hasSecurityChecks, debugInfo);
+            return new ObjectModuleDetails(this.Name, this.Lib, compilerName, frontEndVersion, backEndVersion, commandLine, language, hasSecurityChecks, debugInfo);
         }
 
         /// <summary>

--- a/src/BinaryParsers/VersionConstants.cs
+++ b/src/BinaryParsers/VersionConstants.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis.IL
 {                                                                               
     public static class VersionConstants                                        
     {                                                                           
-        public const string Prerelease = "-beta.1";                        
+        public const string Prerelease = "-beta.2";                        
         public const string AssemblyVersion = "1.6.0" + ".0"; 
         public const string FileVersion = "1.6.0" + ".0";     
         public const string Version = AssemblyVersion + Prerelease;             

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTest.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.BinSkim.Driver

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
@@ -100,6 +100,7 @@ namespace Microsoft.CodeAnalysis.IL
             options.ComputeFileHashes = true;
             options.OutputFilePath = actualFileName;
             options.ConfigurationFilePath = "default";
+            options.SarifVersion = SarifVersion.TwoZeroZero;
             options.TargetFileSpecifiers = new string[] { inputFileName };
 
             int result = command.Run(options);
@@ -125,6 +126,7 @@ namespace Microsoft.CodeAnalysis.IL
             actualText = Regex.Replace(actualText, @"\\r\\n   at [^""]+", "");
 
             actualText = actualText.Replace(@"""Sarif""", @"""BinSkim""");
+            actualText = actualText.Replace(@"        ""fileVersion"": ""15.0.0""," + Environment.NewLine, String.Empty);
 
             actualText = Regex.Replace(actualText, @"\s*""fullName""[^\n]+?\n", Environment.NewLine);
             actualText = Regex.Replace(actualText, @"\s*""semanticVersion""[^\n]+?\n", Environment.NewLine);

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Corrupted_Native_x86_VS2013_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Corrupted_Native_x86_VS2013_Default.exe.sarif
@@ -4,34 +4,30 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [],
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
+        "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe": {
+          "mimeType": "application/octet-stream",
+          "hashes": [
+            {
+              "value": "992F5D2554195F9F19B9480A0E11AC78",
+              "algorithm": "md5"
+            },
+            {
+              "value": "A88412258FFEAC619F3FD960AD9A48AC2F29CBAE",
+              "algorithm": "sha-1"
+            },
+            {
+              "value": "9F92EDE722DC8740BFDF02CD199090B249BFBBF268DE3CD541FE9400A5652166",
+              "algorithm": "sha-256"
+            }
+          ]
         }
       },
       "invocations": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedInteropAssemblyForAtlTestLibrary.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedInteropAssemblyForAtlTestLibrary.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -861,10 +855,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1024,21 +1018,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedResourcesOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedResourcesOnly.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -907,10 +901,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1027,21 +1021,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/ManagedResourcesOnly.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_AnyCPU_VS2017_NoPrefer32Bit.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_AnyCPU_VS2017_NoPrefer32Bit.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -836,10 +830,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1022,21 +1016,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_AnyCPU_VS2017_NoPrefer32Bit.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_AnyCPU_VS2017_Prefer32Bit.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_AnyCPU_VS2017_Prefer32Bit.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -861,10 +855,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1024,21 +1018,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_AnyCPU_VS2017_Prefer32Bit.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x64_VS2015_FSharp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x64_VS2015_FSharp.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -883,10 +877,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x64_VS2015_FSharp.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x86_VS2013_Wpf.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x86_VS2013_Wpf.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -861,10 +855,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1024,21 +1018,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x86_VS2013_Wpf.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x86_VS2015_FSharp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x86_VS2015_FSharp.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -861,10 +855,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1024,21 +1018,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x86_VS2015_FSharp.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2013_Default.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2013_Default.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -290,7 +284,7 @@
             "messageId": "Pass",
             "arguments": [
               "MixedMode_x64_VS2013_Default.dll",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -998,10 +992,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1010,21 +1004,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2013_Default.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2013_NoPdb.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2013_NoPdb.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -720,21 +714,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2015_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2015_Default.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -269,7 +263,7 @@
             "messageId": "Pass",
             "arguments": [
               "MixedMode_x64_VS2015_Default.exe",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -996,10 +990,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1008,21 +1002,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2015_Default.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2013_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2013_Default.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -229,7 +223,7 @@
             "messageId": "Pass",
             "arguments": [
               "MixedMode_x86_VS2013_Default.exe",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -994,10 +988,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1006,21 +1000,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x86_VS2013_Default.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2013_MissingPdb.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2013_MissingPdb.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -720,21 +714,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2015_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2015_Default.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -229,7 +223,7 @@
             "messageId": "Pass",
             "arguments": [
               "MixedMode_x86_VS2015_Default.exe",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -994,10 +988,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1006,21 +1000,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x86_VS2015_Default.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_ARM_VS2015_CvtresResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_ARM_VS2015_CvtresResourceOnly.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -885,10 +879,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_ARM_VS2015_CvtresResourceOnly.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2013_Default.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2013_Default.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -290,7 +284,7 @@
             "messageId": "Pass",
             "arguments": [
               "Native_x64_VS2013_Default.dll",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -998,10 +992,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1010,21 +1004,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2013_Default.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2015_CvtresResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2015_CvtresResourceOnly.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -885,10 +879,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2015_CvtresResourceOnly.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2015_Default.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2015_Default.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -269,7 +263,7 @@
             "messageId": "Pass",
             "arguments": [
               "Native_x64_VS2015_Default.dll",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -997,10 +991,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1009,21 +1003,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2015_Default.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_Default.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -250,7 +244,7 @@
             "messageId": "Pass",
             "arguments": [
               "Native_x86_VS2013_Default.exe",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -998,10 +992,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1010,21 +1004,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2013_Default.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_PdbMissing.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_PdbMissing.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -722,21 +716,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_ResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_ResourceOnly.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -885,10 +879,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2013_ResourceOnly.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_AtlProxyStubPS.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_AtlProxyStubPS.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -224,14 +218,12 @@
         },
         {
           "ruleId": "BA2007",
-          "level": "error",
+          "level": "pass",
           "message": {
-            "messageId": "Error_InsufficientWarningLevel",
+            "messageId": "Pass",
             "arguments": [
               "Native_x86_VS2015_AtlProxyStubPS.dll",
-              "1",
-              "-c -Zi -nologo -W1 -WX- -O2 -Oy- -DWIN32 -DREGISTER_PROXY_DLL -DNDEBUG -D_WINDLL -D_UNICODE -DUNICODE -Gm- -EHs -EHc -MD -GS -fp:precise -Zc:wchar_t -Zc:forScope -Zc:inline -Gd -TC -analyze- -errorreport:prompt -I\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\include\" -I\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\atlmfc\\include\" -I\"C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.10240.0\\ucrt\" -I\"C:\\Program Files (x86)\\Windows Kits\\8.1\\Include\\um\" -I\"C:\\Program Files (x86)\\Windows Kits\\8.1\\Include\\shared\" -I\"C:\\Program Files (x86)\\Windows Kits\\8.1\\Include\\winrt\" -X",
-              "dlldata.obj [warning level: 1]\r\nNative_x86_VS2015_AtlProxyStub_p.obj [warning level: 1]\r\n"
+              "0"
             ]
           },
           "locations": [
@@ -996,10 +988,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1008,21 +1000,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2015_AtlProxyStubPS.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_CvtresResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_CvtresResourceOnly.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -885,10 +879,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2015_CvtresResourceOnly.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_Default.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -229,7 +223,7 @@
             "messageId": "Pass",
             "arguments": [
               "Native_x86_VS2015_Default.exe",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -996,10 +990,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1008,21 +1002,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2015_Default.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_Default_Debug.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_Default_Debug.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -229,7 +223,7 @@
             "messageId": "Pass",
             "arguments": [
               "Native_x86_VS2015_Default_Debug.dll",
-              "2147483647"
+              "0"
             ]
           },
           "locations": [
@@ -996,10 +990,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1008,21 +1002,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2015_Default_Debug.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2017_15.5.4_PdbStripped.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2017_15.5.4_PdbStripped.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -718,21 +712,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2017_15.5.4_PdbStripped.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -1006,10 +1000,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1018,21 +1012,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_ARM_VS2015_DefaultBlankApp.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -998,10 +992,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1010,21 +1004,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_ARM_VS2015_DefaultBlankApp.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -1006,10 +1000,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1018,21 +1012,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x64_VS2015_DefaultBlankApp.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -996,10 +990,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1008,21 +1002,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x64_VS2015_DefaultBlankApp.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.dll.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -1004,10 +998,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1016,21 +1010,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x86_VS2015_DefaultBlankApp.dll": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.exe.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -996,10 +990,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1008,21 +1002,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x86_VS2015_DefaultBlankApp.exe": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.default_compilation.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.default_compilation.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.default_compilation": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.execstack": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.execstack.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.immediate_binding.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.immediate_binding": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_immediate_binding.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.no_immediate_binding": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_stack_protector.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.no_stack_protector": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.noexecstack": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.noexecstack.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.non_pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.non_pie_executable.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.non_pie_executable": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.object_file.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.object_file.o.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -1024,10 +1018,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1036,21 +1030,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.object_file.o": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.pie_executable.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.pie_executable": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsro.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsro.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.relocationsro": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsrw.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsrw.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.relocationsrw": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.shared_library.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.shared_library.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.shared_library.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.a.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.a.sarif
@@ -4,34 +4,30 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [],
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
+        "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.stack_protector.a": {
+          "mimeType": "application/octet-stream",
+          "hashes": [
+            {
+              "value": "2400EE99A6BB7B792A67A03A59385018",
+              "algorithm": "md5"
+            },
+            {
+              "value": "525CB4CBA8B8F80539BBC86C2D78A4275279D8F6",
+              "algorithm": "sha-1"
+            },
+            {
+              "value": "41BF336F8AB7D9A6246D37A6EC7210D4BE07893836890BAB0BFEDA98ACEDE87D",
+              "algorithm": "sha-256"
+            }
+          ]
         }
       },
       "invocations": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.stack_protector": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -942,10 +936,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1028,21 +1022,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.stack_protector.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.default_compilation.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.default_compilation.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.default_compilation": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.execstack": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.execstack.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.fortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.fortified.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.fortified": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.immediate_binding.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.immediate_binding": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_fortification_required.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_fortification_required.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.no_fortification_required": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_immediate_binding.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.no_immediate_binding": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_stack_protector.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.no_stack_protector": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.noexecstack": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.noexecstack.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.non_pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.non_pie_executable.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.non_pie_executable": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.object_file.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.object_file.o.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -1024,10 +1018,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1036,21 +1030,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.object_file.o": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.pie_executable.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.pie_executable": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsro.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsro.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.relocationsro": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsrw.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsrw.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.relocationsrw": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.shared_library.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.shared_library.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.shared_library.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.a.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.a.sarif
@@ -4,34 +4,30 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [],
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
+        "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.stack_protector.a": {
+          "mimeType": "application/octet-stream",
+          "hashes": [
+            {
+              "value": "764B913022B393EAF22F96014401576F",
+              "algorithm": "md5"
+            },
+            {
+              "value": "4B49DA507C9212490EE09280A5A7AD1F1A389188",
+              "algorithm": "sha-1"
+            },
+            {
+              "value": "8548292CA34C14D090A1DE7327874010E3A7ACE5846B2E28D743CC0F35C069CB",
+              "algorithm": "sha-256"
+            }
+          ]
         }
       },
       "invocations": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.stack_protector": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.so.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.stack_protector.so": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.unfortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.unfortified.sarif
@@ -4,16 +4,10 @@
   "runs": [
     {
       "tool": {
-        "name": "BinSkim",
-        "fullName": "BinSkim 1.6.0.0",
-        "version": "1.6.0.0",
-        "semanticVersion": "1.6.0",
-        "sarifLoggerVersion": "2.0.0.0",
+        "name": "testhost",
+        "version": "15.0.0.0",
         "language": "en-US",
         "properties": {
-          "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
-          "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -920,10 +914,10 @@
               "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
             },
             "messageStrings": {
-              "Error": "'{0}' was compiled with one or more modules that do not properly enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). The following modules are out of policy:\r\n{1}",
-              "Error_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
-              "Error_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
-              "Error_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
+              "Warning": "'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre). This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. The following modules are out of policy:\r\n{1}",
+              "Warning_OptimizationsDisabled": "The following modules were compiled with optimizations disabled (/Od), a condition that disables Spectre mitigations:\r\n{0}",
+              "Warning_SpectreMitigationNotEnabled": "The following modules were compiled with a toolset that supports /Qspectre but the switch was not enabled on the command-line:\r\n{0}",
+              "Warning_SpectreMitigationExplicitlyDisabled": "The following modules were compiled with Spectre mitigations explicitly disabled:\r\n{0}",
               "Pass": "All linked modules '{0}' were compiled with mitigations enabled that help prevent Spectre (speculative execution side-channel attack) vulnerabilities.",
               "NotApplicable_InvalidMetadata": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
             },
@@ -1026,21 +1020,6 @@
         }
       },
       "files": {
-        "EVMAUS-MAIN": {
-          "mimeType": "application/octet-stream"
-        },
-        "evmaus": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND": {
-          "mimeType": "application/octet-stream"
-        },
-        "REDMOND.CORP.MICROSOFT.COM": {
-          "mimeType": "application/octet-stream"
-        },
-        "file://co1-red-dc-29/": {
-          "mimeType": "application/octet-stream"
-        },
         "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.unfortified": {
           "mimeType": "application/octet-stream",
           "hashes": [

--- a/src/Test.FunctionalTests.BinSkim.Driver/UpdateBaselines.ps1
+++ b/src/Test.FunctionalTests.BinSkim.Driver/UpdateBaselines.ps1
@@ -25,7 +25,7 @@ function Build-Baselines($sourceExtension)
     Write-Host "$sourceExtension"
 
     Get-ChildItem $testsDirectory -Filter $sourceExtension | ForEach-Object {
-        Write-Host "    $_ -> $_.sarif"
+        Write-Host [Environment]::Newline
         $input = $_.FullName
         $outputFile = $_.Name
         $output = Join-Path $expectedDirectory "$outputFile.sarif"
@@ -33,8 +33,8 @@ function Build-Baselines($sourceExtension)
 
         # Actually run the tool
         Remove-Item $outputTemp -ErrorAction SilentlyContinue
-        Write-Host "$utility analyze "$input" --output "$outputTemp" --pretty-print --verbose --hashes --config default"
-        &$utility analyze "$input" --output "$outputTemp" --pretty-print --verbose --hashes --config default
+        Write-Host "$utility analyze "$input" --output "$outputTemp" --pretty-print --verbose --hashes --config default --quiet"
+        &           $utility analyze "$input" --output "$outputTemp" --pretty-print --verbose --hashes --config default --quiet
 
         # Replace repository root absolute path with Z:\ for machine and enlistment independence
         $text = [IO.File]::ReadAllText($outputTemp)
@@ -50,6 +50,14 @@ function Build-Baselines($sourceExtension)
         $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"endTime`"[^\n]+?\n", [Environment]::Newline)
         $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"processId`"[^\n]+?\n", [Environment]::Newline)
         $text = [Text.RegularExpressions.Regex]::Replace($text, "      `"id`"[^,]+,\s+`"tool`"", "      `"tool`"", [Text.RegularExpressions.RegexOptions]::Singleline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "`"name`": `"BinSkim`"", "`"name`": `"testhost`"")
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"semanticVersion`"[^\n]+?\n", [Environment]::Newline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"sarifLoggerVersion`"[^\n]+?\n", [Environment]::Newline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"fullName`"[^\n]+?\n", [Environment]::Newline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"Comments`"[^\n]+?\n", [Environment]::Newline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"CompanyName`"[^\n]+?\n", [Environment]::Newline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "\s*`"ProductName`"[^\n]+?\n", [Environment]::Newline)
+        $text = [Text.RegularExpressions.Regex]::Replace($text, "    `"version`"[^,]+?,", "    `"version`": `"15.0.0.0`",")
     
         [IO.File]::WriteAllText($outputTemp, $text, [Text.Encoding]::UTF8)
         Move-Item $outputTemp $output -Force

--- a/src/Test.FunctionalTests.BinSkim.Rules/RuleTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Rules/RuleTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-
-using Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable;
 using Microsoft.CodeAnalysis.IL.Sdk;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 


### PR DESCRIPTION
We now group all spectre output by the linking library. We no longer introduce a newline for each library compiland in which we detected a problem. We now emit relevant language and version information in the output that can be used (begrudgingly) to configure an XML file to suppress the results, if necessary.

MyNativeLibrary.lib,cxx,11.12.2600.42 : oneTranslationUnit.obj,aSecondTranslationUnit.obj,etc.obj,etcetera.obj