### PR TITLE
Remove redundant code, now handled in sarif-sdk

### DIFF
--- a/src/BinSkim.Driver/AnalyzeCommand.cs
+++ b/src/BinSkim.Driver/AnalyzeCommand.cs
@@ -48,24 +48,6 @@ namespace Microsoft.CodeAnalysis.IL
                 analyzeOptions.SarifOutputVersion = s_UnitTestOutputVersion;
             }
 
-            // TODO: the SARIF SDK should be providing this backwards compatibility.
-            // I've filed a bug. We should convert BinSkim to consume SARIF-SDK as
-            // a sub-module. This would make implementing SDK spot fixes easier.
-            // https://github.com/microsoft/sarif-sdk/issues/2211
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (analyzeOptions.ComputeFileHashes)
-#pragma warning restore CS0618
-            {
-                OptionallyEmittedData dataToInsert = analyzeOptions.DataToInsert.ToFlags();
-                dataToInsert |= OptionallyEmittedData.Hashes;
-
-                analyzeOptions.DataToInsert =
-                    dataToInsert.ToString().Split('|')
-                        .Select(d => { return Enum.Parse<OptionallyEmittedData>(d); })
-                        .ToList();
-            }
-
             int result = base.Run(analyzeOptions);
 
             // In BinSkim, no rule is ever applicable to every target type. For example,


### PR DESCRIPTION
Also fixes #2211

The initial creation of this draft PR includes a change to point to a specific commit in sarif-sdk, where the changes from BinSkim were moved.
