### PR TITLE
Fixing exception when pdb is embedded

### DIFF
--- a/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
@@ -106,6 +106,12 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
 
                 byte[] b = new byte[max];
 
+                // PdbLocation is a directory, which means that PdbType is embedded.
+                if (Directory.Exists(PdbLocation))
+                {
+                    return this.pdbFileType;
+                }
+
                 using (FileStream fs = File.OpenRead(PdbLocation))
                 {
                     if (fs.Read(b, 0, b.Length) != b.Length)

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
@@ -106,7 +106,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
 
                 byte[] b = new byte[max];
 
-                // PdbLocation is a directory, which means that PdbType is embedded.
+                // When we are at this step, we were able to read the pdb.
+                // If PdbLocation is a directory, it means that PdbType is embedded.
                 if (Directory.Exists(PdbLocation))
                 {
                     return this.pdbFileType;


### PR DESCRIPTION
```
C:\Path\Humanizer.dll : error ERR998.ExceptionInAnalyze : BA2004 : An exception of type 'UnauthorizedAccessException' was raised analyzing 'Humanizer.dll' for check 'EnableSecureSourceCodeHashing' (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target, and not specific to the rule, however.
UnauthorizedAccessException: Access to the path 'C:\Path' is denied.
   at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
   at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.File.OpenRead(String path)
   at Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.get_FileType() in C:\Microsoft\binskim\src\BinaryParsers\PEBinary\ProgramDatabase\Pdb.cs:line 159
   at Microsoft.CodeAnalysis.IL.Rules.EnableSecureSourceCodeHashing.AnalyzeManagedAssemblyAndPdb(BinaryAnalyzerContext context) in C:\Microsoft\binskim\src\BinSkim.Rules\PERules\BA2004.EnableSecureSourceCodeHashing.cs:line 57
   at Microsoft.CodeAnalysis.IL.Rules.EnableSecureSourceCodeHashing.AnalyzePortableExecutableAndPdb(BinaryAnalyzerContext context) in C:\Microsoft\binskim\src\BinSkim.Rules\PERules\BA2004.EnableSecureSourceCodeHashing.cs:line 48
   at Microsoft.CodeAnalysis.IL.Rules.WindowsBinaryAndPdbSkimmerBase.Analyze(BinaryAnalyzerContext context) in C:\Microsoft\binskim\src\BinSkim.Rules\PERules\WindowsBinaryAndPdbSkimmerBase.cs:line 52
   at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.AnalyzeTarget(IEnumerable`1 skimmers, TContext context, ISet`1 disabledSkimmers)
```