### PR TITLE
Resolves: Add native GitHub continuous code security and quality analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,59 @@
+name: CodeQL Analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.411
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          queries: security-and-quality
+          languages: csharp
+
+      - name: Build solution
+        shell: pwsh
+        run: |
+          $pathToSolution = "src/BinSkim.sln"
+          $buildConfiguration = "Release"
+          $useSharedCompilation = "false"
+          $testProjects = "Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj", "Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj", "Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj", "Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj", "Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj"
+
+          dotnet nuget locals all --clear
+
+          # remove one or more test projects, 
+          # so that CodeQL only analyzes the source code
+          dotnet sln $pathToSolution remove $testProjects
+
+          dotnet clean $pathToSolution `
+          --configuration $buildConfiguration
+
+          dotnet restore $pathToSolution
+
+          dotnet build $pathToSolution `
+          -property:UseSharedCompilation=$useSharedCompilation `
+          --configuration $buildConfiguration `
+          --no-incremental `
+          --no-restore
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           $pathToSolution = "src/BinSkim.sln"
           $buildConfiguration = "Release"
           $useSharedCompilation = "false"
-          $testProjects = "Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj", "Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj", "Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj", "Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj", "Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj"
+          $testProjects = "src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj", "src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj", "src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj", "src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj", "src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj"
 
           dotnet nuget locals all --clear
 


### PR DESCRIPTION
- add `codeql-analysis.yml` which automatically enables CodeQL code security and quality scanner. It executes on every push commit, PR, manually and every day at 8:00AM UTC. A scan check can be viewed on commits and PRs. All alerts and fix suggestion can be viewed at **Security** tab -> **Code scanning alerts** -> **CodeQL**

Resolves #425 