### PR TITLE
Resolves: Add a CI pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,99 @@
+name: CI Pipeline
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    env:
+      pathToSolution: src/BinSkim.sln
+      testResultsFolderName: Test results
+      publishOutputFolderName: Publish output
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Tooling setup
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.411
+
+      # Build and test validation
+
+      - name: Restore solution
+        shell: pwsh
+        run: |
+          $pathToSolution = "${{ env.pathToSolution }}"
+
+          dotnet restore $pathToSolution
+
+      - name: Build solution
+        shell: pwsh
+        run: |
+          $pathToSolution = "${{ env.pathToSolution }}"
+          $configurationSetting = "Debug"
+
+          dotnet build $pathToSolution `
+          -property:Platform=x64 `
+          --configuration $configurationSetting `
+          --no-restore
+
+      - name: Run unit tests
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $testProjects = "src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj", "src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj", "src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj", "src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj", "src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj"
+          $configurationSetting = "Debug"
+          $date = Get-Date -Format "MM-dd-yyyy"
+          $testOutputFolder = "${{ env.testResultsFolderName }}"
+
+          foreach ( $project in $testProjects ) {
+            $projectName = (gci $project).BaseName
+
+            dotnet test $project `
+            -property:Platform=x64 `
+            --configuration $configurationSetting `
+            --logger "trx;LogFileName=$projectName-$date.trx;verbosity=normal" `
+            --results-directory $testOutputFolder/$projectName `
+            --no-build
+          }
+
+      # Artifact generation
+
+      - name: Publish project for each target framework
+        shell: pwsh
+        run: |
+          $pathToProject = "src/BinSkim.Driver/BinSkim.Driver.csproj"
+          $configurationSetting = "Debug"
+          $publishOutputFolder = "${{ env.publishOutputFolderName }}"
+          $frameworkVersion = "netcoreapp3.1"
+          $runtimeIdentifiers = "win-x86","win-x64","linux-x64"
+
+          foreach ( $runtimeIdentifier in $runtimeIdentifiers ) {
+            dotnet publish $pathToProject `
+            --configuration $configurationSetting `
+            --output "$publishOutputFolder/$frameworkVersion/$runtimeIdentifier" `
+            --framework $frameworkVersion `
+            --runtime $runtimeIdentifier
+          }
+
+      # Artifact publish to pipeline
+
+      - name: Upload test results as pipeline artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test results
+          path: "${{ env.testResultsFolderName }}"
+
+      - name: Upload publish output as pipeline artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Publish outputs
+          path: "${{ env.publishOutputFolderName }}"
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
### The pipeline runs:

1. CI
- build and unit tests validation
- assemblies and unit tests results generation
- uploading artifacts to pipeline run (checkout the PR run of the pipeline for artifact download)

### Additions:

We would like to add Continuous Deployment as well, however we know there are internal procedures often incorporated with Microsoft projects for the packaging, so we wanted to confirm first if what we have as an idea is desirable. The CD would include:
- commit-based automated versioning
- NuGet package generation and signing
- deployment to NuGet.org
- creation of GitHub Release

Please let us know if you'd like us to include that, if anything could be done better and/or if any other automation is required by the project! We would be happy to improve it to satisfactory completion 🙂  

Resolves #427 