### PR TITLE
Handle null reference expcetion when reading PE header from pdb files

### DIFF
--- a/src/BinSkim.Rules/PERules/BA2001.LoadImagesAboveFourGigabyteAddress.cs
+++ b/src/BinSkim.Rules/PERules/BA2001.LoadImagesAboveFourGigabyteAddress.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
 
             reasonForNotAnalyzing = MetadataConditions.ImageIsNot64BitBinary;
-            if (portableExecutable.PEHeaders.PEHeader.Magic != PEMagic.PE32Plus) { return result; }
+            if (portableExecutable.PEHeaders?.PEHeader?.Magic != PEMagic.PE32Plus) { return result; }
 
             reasonForNotAnalyzing = MetadataConditions.ImageIsILOnlyAssembly;
             if (portableExecutable.IsILOnly) { return result; }

--- a/src/BinSkim.Rules/PERules/BA2009.EnableAddressSpaceLayoutRandomization.cs
+++ b/src/BinSkim.Rules/PERules/BA2009.EnableAddressSpaceLayoutRandomization.cs
@@ -47,6 +47,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             PE portableExecutable = target.PE;
             AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
 
+            reasonForNotAnalyzing = MetadataConditions.ImageIsNotPE;
+            if (portableExecutable.PEHeaders == null) { return result; }
+
             reasonForNotAnalyzing = MetadataConditions.ImageIsKernelModeBinary;
             if (portableExecutable.IsKernelMode) { return result; }
 

--- a/src/BinSkim.Rules/PERules/BA2010.DoNotMarkImportsSectionAsExecutable.cs
+++ b/src/BinSkim.Rules/PERules/BA2010.DoNotMarkImportsSectionAsExecutable.cs
@@ -45,6 +45,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             PE portableExecutable = target.PE;
             AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
 
+            reasonForNotAnalyzing = MetadataConditions.ImageIsNotPE;
+            if (portableExecutable.PEHeaders == null) { return result; }
+
             reasonForNotAnalyzing = MetadataConditions.ImageIsKernelModeBinary;
             if (portableExecutable.IsKernelMode) { return result; }
 

--- a/src/BinSkim.Rules/PERules/BA2012.DoNotModifyStackProtectionCookie.cs
+++ b/src/BinSkim.Rules/PERules/BA2012.DoNotModifyStackProtectionCookie.cs
@@ -53,6 +53,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
         public override AnalysisApplicability CanAnalyzePE(PEBinary target, Sarif.PropertiesDictionary policy, out string reasonForNotAnalyzing)
         {
+            AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
+            reasonForNotAnalyzing = MetadataConditions.ImageIsNotPE;
+            if (target.PE.PEHeaders == null) { return result; }
+
             return StackProtectionUtilities.CommonCanAnalyze(target, out reasonForNotAnalyzing);
         }
 

--- a/src/BinSkim.Rules/PERules/BA2015.EnableHighEntropyVirtualAddresses.cs
+++ b/src/BinSkim.Rules/PERules/BA2015.EnableHighEntropyVirtualAddresses.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             if (portableExecutable.IsKernelMode) { return result; }
 
             reasonForNotAnalyzing = MetadataConditions.ImageLikelyLoadsAs32BitProcess;
-            if (portableExecutable.PEHeaders.PEHeader.Magic != PEMagic.PE32Plus)
+            if (portableExecutable.PEHeaders?.PEHeader?.Magic != PEMagic.PE32Plus)
             {
                 // If the image's magic bytes are 'PE32', it is either a 32 bit binary (rule does not apply), or it is a managed binary compiled as AnyCpu.
                 // If it's an AnyCPU managed binary, we need to do a bit more checking--if it has 'Prefers32Bit'/'Requires32Bit' flagged, it will probably

--- a/src/BinSkim.Rules/PERules/BA2016.MarkImageAsNXCompatible.cs
+++ b/src/BinSkim.Rules/PERules/BA2016.MarkImageAsNXCompatible.cs
@@ -47,8 +47,11 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             PE portableExecutable = target.PE;
             AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
 
+            reasonForNotAnalyzing = MetadataConditions.ImageIsNotPE;
+            if (portableExecutable.PEHeaders == null) { return result; }
+
             reasonForNotAnalyzing = MetadataConditions.ImageIs64BitBinary;
-            if (target.PE.PEHeaders.PEHeader.Magic == PEMagic.PE32Plus) { return result; }
+            if (target.PE.PEHeaders?.PEHeader?.Magic == PEMagic.PE32Plus) { return result; }
 
             reasonForNotAnalyzing = MetadataConditions.ImageIsKernelModeBinary;
             if (portableExecutable.IsKernelMode) { return result; }

--- a/src/BinSkim.Rules/PERules/BA2019.DoNotMarkWritableSectionsAsShared.cs
+++ b/src/BinSkim.Rules/PERules/BA2019.DoNotMarkWritableSectionsAsShared.cs
@@ -45,6 +45,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             PE portableExecutable = target.PE;
             AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
 
+            reasonForNotAnalyzing = MetadataConditions.ImageIsNotPE;
+            if (portableExecutable.PEHeaders == null) { return result; }
+
             reasonForNotAnalyzing = MetadataConditions.ImageIsXBoxBinary;
             if (portableExecutable.IsXBox) { return result; }
 

--- a/src/BinSkim.Rules/PERules/BA2021.DoNotMarkWritableSectionsAsExecutable.cs
+++ b/src/BinSkim.Rules/PERules/BA2021.DoNotMarkWritableSectionsAsExecutable.cs
@@ -47,6 +47,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             PE portableExecutable = target.PE;
             AnalysisApplicability result = AnalysisApplicability.NotApplicableToSpecifiedTarget;
 
+            reasonForNotAnalyzing = MetadataConditions.ImageIsNotPE;
+            if (portableExecutable.PEHeaders == null) { return result; }
+
             reasonForNotAnalyzing = MetadataConditions.ImageIsKernelModeBinary;
             if (portableExecutable.IsKernelMode) { return result; }
 

--- a/src/BinaryParsers/PEBinary/PortableExecutable/PE.cs
+++ b/src/BinaryParsers/PEBinary/PortableExecutable/PE.cs
@@ -109,8 +109,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
         {
             get
             {
-                PEHeader peHeader = this.PEHeaders.PEHeader;
-                if ((peHeader.DllCharacteristics & DllCharacteristics.AppContainer) == 0)
+                PEHeader peHeader = this.PEHeaders?.PEHeader;
+                if (peHeader == null || (peHeader.DllCharacteristics & DllCharacteristics.AppContainer) == 0)
                 {
                     return false;
                 }
@@ -163,6 +163,11 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
         {
             get
             {
+                if (this.peReader == null)
+                {
+                    yield break;
+                }
+
                 foreach (DebugDirectoryEntry debugDirectoryEntry in this.peReader.ReadDebugDirectory())
                 {
                     yield return debugDirectoryEntry;
@@ -203,14 +208,19 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
             {
                 if (this.asImports == null)
                 {
-                    DirectoryEntry importTableDirectory = this.PEHeaders.PEHeader.ImportTableDirectory;
-                    if (this.PEHeaders.PEHeader.ImportTableDirectory.Size == 0)
+                    DirectoryEntry? importTableDirectory = this.PEHeaders?.PEHeader?.ImportTableDirectory;
+                    if (importTableDirectory == null)
+                    {
+                        return null;
+                    }
+
+                    if (importTableDirectory.Value.Size == 0)
                     {
                         this.asImports = Array.Empty<string>();
                     }
                     else
                     {
-                        var sp = new SafePointer(this.pImage.array, importTableDirectory.RelativeVirtualAddress);
+                        var sp = new SafePointer(this.pImage.array, importTableDirectory.Value.RelativeVirtualAddress);
 
                         var al = new ArrayList();
 
@@ -454,7 +464,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
                     return this.isResourceOnly.Value;
                 }
 
-                PEHeader peHeader = this.PEHeaders.PEHeader;
+                PEHeader peHeader = this.PEHeaders?.PEHeader;
                 if (peHeader == null)
                 {
                     this.isResourceOnly = false;
@@ -667,7 +677,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
         /// <summary>
         /// Returns true if the binary is built for XBox
         /// </summary>
-        public bool IsXBox => this.PEHeaders.PEHeader != null
+        public bool IsXBox => this.PEHeaders?.PEHeader != null
                     ? this.PEHeaders.PEHeader.Subsystem == System.Reflection.PortableExecutable.Subsystem.Xbox
                     : false;
 
@@ -682,7 +692,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
 
                 this.isBoot = false;
 
-                if (this.PEHeaders.PEHeader != null)
+                if (this.PEHeaders?.PEHeader != null)
                 {
                     //
                     // Currently SubsystemVersion is an optional field but I would hope we can use this in the future
@@ -703,14 +713,14 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
         /// <summary>
         /// Machine type
         /// </summary>
-        public Machine Machine => this.PEHeaders.PEHeader != null
+        public Machine Machine => this.PEHeaders?.PEHeader != null
                     ? this.PEHeaders.CoffHeader.Machine
                     : Machine.Unknown;
 
         /// <summary>
         /// Subsystem type
         /// </summary>
-        public Subsystem Subsystem => this.PEHeaders.PEHeader != null
+        public Subsystem Subsystem => this.PEHeaders?.PEHeader != null
                     ? this.PEHeaders.PEHeader.Subsystem
                     : Subsystem.Unknown;
 
@@ -763,7 +773,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
         {
             get
             {
-                PEHeader optionalHeader = this.PEHeaders.PEHeader;
+                PEHeader optionalHeader = this.PEHeaders?.PEHeader;
 
                 if (optionalHeader != null)
                 {


### PR DESCRIPTION
PDB files don't have PEHeaders, adding checks for null cases.