### PR TITLE
Ignore .pdb files in PEBinarySkimmer

### DIFF
--- a/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
+++ b/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             if (context.IsPE())
             {
                 PEBinary target = context.PEBinary();
-                return target.PE != null && target.PE.PEHeaders != null
+                return target.PE != null && target.PE.IsPEFile
                     ? this.CanAnalyzePE(target, context.Policy, out reasonForNotAnalyzing)
                     : AnalysisApplicability.NotApplicableToSpecifiedTarget;
             }

--- a/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
+++ b/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             if (context.IsPE())
             {
                 PEBinary target = context.PEBinary();
-                return target.PE != null
+                return target.PE != null && target.PE.PEHeaders != null
                     ? this.CanAnalyzePE(target, context.Policy, out reasonForNotAnalyzing)
                     : AnalysisApplicability.NotApplicableToSpecifiedTarget;
             }


### PR DESCRIPTION
To avoid null reference exception when accessing PEHeader for a pdb file.


Fixes #419 