### PR TITLE
Add command to restore submodule in BuildAndTest.cmd

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -36,6 +36,9 @@ echo         public const string Version = AssemblyVersion + Prerelease;        
 echo     }                                                                           >> %VERSION_CONSTANTS%
 echo  }                                                                              >> %VERSION_CONSTANTS%
 
+::Download Submodules
+if not exist %~dp0src\sarif-sdk\src\Sarif.Sdk.sln (git submodule update --init --recursive)
+
 ::Restore packages
 echo Restoring packages...
 dotnet restore %~dp0src\BinSkim.sln /p:Configuration=%Configuration% --packages "%NuGetPackageDir%


### PR DESCRIPTION
Tried adding prebuild target in csproj file to enlist submodule during visualstudio build (msbuild) but doesn't work.
Looks like vs/msbuild always tries to build referenced projects first and if referenced project files doesn't exist physically the build fails.