### PR TITLE
Change compiler report rule to report all modules in file

### DIFF
--- a/src/BinSkim.Rules/DwarfRules/BA4002.ReportDwarfCompilerData.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA4002.ReportDwarfCompilerData.cs
@@ -85,7 +85,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     var record = new CompilerData
                     {
                         BinaryType = "ELF",
+                        ModuleName = info.FileName,
                         Dialect = info.GetDialect(),
+                        ModuleLibrary = string.Empty,
                         CommandLine = info.CommandLine,
                         CompilerName = compiler.Compiler.ToString(),
                         CompilerBackEndVersion = compiler.Version.ToString(),
@@ -100,7 +102,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
                     processedRecords.Add(record);
 
-                    context.CompilerDataLogger.Write(record, info.FileName);
+                    context.CompilerDataLogger.Write(record);
                 }
             }
         }

--- a/src/BinSkim.Rules/PERules/BA4001.ReportPECompilerData.cs
+++ b/src/BinSkim.Rules/PERules/BA4001.ReportPECompilerData.cs
@@ -84,6 +84,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     var record = new CompilerData
                     {
                         BinaryType = "PE",
+                        ModuleName = omDetails?.Name,
+                        ModuleLibrary = omDetails?.Library,
                         Dialect = omDetails.GetDialect(out _),
                         CompilerName = omDetails.CompilerName,
                         CommandLine = omDetails.RawCommandLine,
@@ -104,7 +106,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
             foreach (KeyValuePair<CompilerData, ObjectModuleDetails> kv in records)
             {
-                context.CompilerDataLogger.Write(kv.Key, kv.Value);
+                context.CompilerDataLogger.Write(kv.Key);
             }
         }
     }

--- a/src/BinSkim.Sdk/CompilerData.cs
+++ b/src/BinSkim.Sdk/CompilerData.cs
@@ -8,9 +8,11 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         public string Dialect { get; set; }
         public string Language { get; set; }
         public string BinaryType { get; set; }
+        public string ModuleName { get; set; }
         public string CommandLine { get; set; }
         public string FileVersion { get; set; }
         public string CompilerName { get; set; }
+        public string ModuleLibrary { get; set; }
         public string DebuggingFileName { get; set; }
         public string DebuggingFileGuid { get; set; }
         public string CompilerBackEndVersion { get; set; }
@@ -18,7 +20,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
         public override string ToString()
         {
-            return $"{CompilerName},{CompilerBackEndVersion},{CompilerFrontEndVersion},{FileVersion},{BinaryType},{Language},{DebuggingFileName},{DebuggingFileGuid},{CommandLine},{Dialect}";
+            return $"{CompilerName},{CompilerBackEndVersion},{CompilerFrontEndVersion},{FileVersion},{BinaryType},{Language},{DebuggingFileName},{DebuggingFileGuid},{CommandLine},{Dialect},{ModuleName},{(ModuleLibrary == ModuleName ? string.Empty : ModuleLibrary)}";
         }
     }
 }

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* BUGFIX: Change compiler report rule to report all modules in file. [#476](https://github.com/microsoft/binskim/pull/476)
 * FEATURE: Add dialects to the reporting rules. [#475](https://github.com/microsoft/binskim/pull/475)
 * BUGFIX: Fix exception `System.AccessViolationException` caused by trying to read data out of boundary. [#470](https://github.com/microsoft/binskim/pull/470)
 * BUGFIX: Fix exception handling when PDB cannot be loaded by `IDiaDataSource`. [#461](https://github.com/microsoft/binskim/pull/461)


### PR DESCRIPTION
1. Change compiler report rule to report all modules in file
2. fix bug in the report field position
3. merge 2 similar method to one