### PR TITLE
Send exceptions data to AppInsight

### DIFF
--- a/src/BinSkim.Driver/AnalysisSummaryExtractor.cs
+++ b/src/BinSkim.Driver/AnalysisSummaryExtractor.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis.IL.Sdk;
+using Microsoft.CodeAnalysis.Sarif;
+
+namespace Microsoft.CodeAnalysis.IL
+{
+    public static class AnalysisSummaryExtractor
+    {
+        public static AnalysisSummary ExtractAnalysisSummary(SarifLog sarifLog, AnalyzeOptions options)
+        {
+            if (sarifLog == null || sarifLog.Runs == null || !sarifLog.Runs.Any())
+            {
+                return null;
+            }
+
+            Tool tool = sarifLog.Runs[0].Tool;
+            Invocation invocation = sarifLog.Runs[0].Invocations[0];
+            IList<Artifact> artifacts = sarifLog.Runs[0].Artifacts;
+
+            return new AnalysisSummary
+            {
+                ToolName = tool.Driver.Name,
+                ToolVersion = tool.Driver.Version,
+                NormalizedPath = string.Join(";", options.TargetFileSpecifiers.Select(p => System.IO.Path.GetDirectoryName(p)).Distinct()),
+                SymbolPath = options.SymbolsPath,
+                FileAnalyzed = artifacts.Count,
+                // FileNotAnalyzed = 
+                StartTimeUtc = invocation.StartTimeUtc,
+                EndTimeUtc = invocation.EndTimeUtc,
+                TimeConsumed = invocation.EndTimeUtc - invocation.StartTimeUtc,
+            };
+        }
+
+        public static IEnumerable<ExecutionException> ExtractExceptionData(SarifLog sarifLog)
+        {
+            if (sarifLog == null || sarifLog.Runs == null || !sarifLog.Runs.Any())
+            {
+                yield break;
+            }
+
+            IList<Sarif.Notification> notifications = sarifLog.Runs[0]?.Invocations[0]?.ToolExecutionNotifications;
+
+            foreach (Sarif.Notification notification in notifications)
+            {
+                if (notification.Exception != null)
+                {
+                    yield return new ExecutionException(
+                                        notification.Exception.Kind,
+                                        notification.Exception.Message,
+                                        notification.Exception.Stack.ToString(),
+                                        GetInnerException(notification.Exception.InnerExceptions));
+                }
+            }
+        }
+
+        private static ExecutionException ConvertSarifException(ExceptionData sarifException)
+        {
+            return new ExecutionException(
+                sarifException.Kind,
+                sarifException.Message,
+                sarifException.Stack.ToString(),
+                GetInnerException(sarifException.InnerExceptions));
+        }
+
+        private static Exception GetInnerException(IList<ExceptionData> exceptions)
+        {
+            if (exceptions == null || !exceptions.Any())
+            {
+                return null;
+            }
+
+            if (exceptions.Count > 1)
+            {
+                // its converted from AggregateException
+                var aggregateException = new AggregateException();
+                foreach (ExceptionData exception in exceptions)
+                {
+                    aggregateException.InnerExceptions.Append(ConvertSarifException(exception));
+                }
+                return aggregateException;
+            }
+            else
+            {
+                return ConvertSarifException(exceptions.First());
+            }
+        }
+    }
+}

--- a/src/BinSkim.Driver/AnalyzeCommand.cs
+++ b/src/BinSkim.Driver/AnalyzeCommand.cs
@@ -101,9 +101,17 @@ namespace Microsoft.CodeAnalysis.IL
                     !string.IsNullOrEmpty(analyzeOptions.OutputFilePath) &&
                     this.FileSystem.FileExists(analyzeOptions.OutputFilePath))
                 {
-                    CompilerDataLogger.Summarize(
-                        this.ExtractAnalysisSummary(SarifLog.Load(analyzeOptions.OutputFilePath),
-                                                    analyzeOptions));
+                    SarifLog sarifLog = SarifLog.Load(analyzeOptions.OutputFilePath);
+
+                    AnalysisSummary summary = AnalysisSummaryExtractor.ExtractAnalysisSummary(
+                        sarifLog, analyzeOptions);
+                    CompilerDataLogger.Summarize(summary);
+
+                    IEnumerable<ExecutionException> exceptions = AnalysisSummaryExtractor.ExtractExceptionData(sarifLog);
+                    foreach (ExecutionException ex in exceptions)
+                    {
+                        CompilerDataLogger.WriteException(ex, summary);
+                    }
                 }
             }
             catch (Exception e)

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -240,6 +240,23 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             }
         }
 
+        public static void WriteException(ExecutionException exception, AnalysisSummary summary)
+        {
+            if (TelemetryEnabled)
+            {
+                s_telemetryClient.TrackException(exception, new Dictionary<string, string>
+                {
+                    { "toolName", summary.ToolName },
+                    { "toolVersion", summary.ToolVersion },
+                    { "sessionId", s_sessionId },
+                });
+            }
+            else
+            {
+                Console.WriteLine(exception.ToString());
+            }
+        }
+
         public static void Summarize(AnalysisSummary summary)
         {
             if (TelemetryEnabled)

--- a/src/BinSkim.Sdk/ExecutionException.cs
+++ b/src/BinSkim.Sdk/ExecutionException.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.IL.Sdk
+{
+    public class ExecutionException : Exception
+    {
+        private readonly string stackTrace;
+
+        private readonly string originalType;
+
+        public ExecutionException(string type, string message, string stackTrace, Exception innerException)
+            : base(message, innerException)
+        {
+            this.originalType = type;
+            this.stackTrace = stackTrace;
+        }
+
+        public override string ToString()
+        {
+            return $"{this.originalType},{this.Message},{this.StackTrace}";
+        }
+
+        public string OriginalType => this.originalType;
+
+        public override string StackTrace => this.stackTrace;
+    }
+}


### PR DESCRIPTION
Get ExceptionData from SarifLog Invocations and build exceptions to be sent to AppInsight.