### PR TITLE
When path is empty do not replace string

### DIFF
--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -56,7 +56,10 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 // We must get directory name because there are cases where the targetFilePath is
                 // c:\path\*.dll
                 string directoryName = Path.GetDirectoryName(path);
-                this.relativeFilePath = this.relativeFilePath.Replace(directoryName, string.Empty);
+                if (!string.IsNullOrEmpty(directoryName))
+                {
+                    this.relativeFilePath = this.relativeFilePath.Replace(directoryName, string.Empty);
+                }
             }
         }
 


### PR DESCRIPTION
This change will fix the following exception:

```
ArgumentException: String cannot be of zero length. (Parameter 'oldValue')
at System.String.Replace(String oldValue, String newValue)
at Microsoft.CodeAnalysis.IL.Sdk.CompilerDataLogger..ctor(IAnalysisContext analysisContext, IEnumerable`1 targetFileSpecifiers) in D:\a\r1\a\src\BinSkim.Sdk\CompilerDataLogger.cs:line 59
at Microsoft.CodeAnalysis.IL.AnalyzeCommand.CreateContext(AnalyzeOptions options, IAnalysisLogger logger, RuntimeConditions runtimeErrors, PropertiesDictionary policy, String filePath) in D:\a\r1\a\src\BinSkim.Driver\AnalyzeCommand.cs:line 59
at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.DetermineApplicabilityAndAnalyze(TOptions options, IEnumerable`1 skimmers, TContext rootContext, String target, ISet`1 disabledSkimmers)
at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.AnalyzeTargets(TOptions options, IEnumerable`1 skimmers, TContext rootContext, IEnumerable`1 targets)
at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.Analyze(TOptions options, AggregatingLogger logger)
at Microsoft.CodeAnalysis.Sarif.Driver.AnalyzeCommandBase`2.Run(TOptions options
```
