### PR TITLE
Create one session/telemetry configuration per run

### DIFF
--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             }
             else
             {
-                Console.WriteLine(summary.ToString());
+                Console.WriteLine(summary);
             }
         }
 

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -20,14 +20,18 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         private const string CommandLineEventName = "CommandLineInformation";
         private const string AssemblyReferencesEventName = "AssemblyReferencesInformation";
 
-        private readonly int ChunkSize;
-        private readonly string sha256;
-        private readonly string relativeFilePath;
+        private string Sha256 => context?.Hashes?.Sha256;
 
-        private static string s_sessionId;
+        private readonly int chunkSize;
+        private readonly string relativeFilePath;
+        private readonly IAnalysisContext context;
+
+        internal static string s_sessionId;
         private static bool s_printHeader = true;
         private static TelemetryClient s_telemetryClient;
         private static TelemetryConfiguration s_telemetryConfiguration;
+
+        private static readonly object s_syncRoot = new object();
 
         public static bool TelemetryEnabled => s_telemetryClient != null;
 
@@ -37,10 +41,10 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                                   TelemetryClient telemetryClient = null,
                                   int chunkSize = 8192)
         {
-            s_telemetryConfiguration = telemetryConfiguration;
-            s_telemetryClient = telemetryClient;
-            s_sessionId = TelemetryEnabled ? Guid.NewGuid().ToString() : null;
-            ChunkSize = chunkSize;
+            s_telemetryConfiguration ??= telemetryConfiguration;
+            s_telemetryClient ??= telemetryClient;
+            s_sessionId ??= Guid.NewGuid().ToString();
+            this.chunkSize = chunkSize;
 
             if (!TelemetryEnabled)
             {
@@ -58,7 +62,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 }
             }
 
-            this.sha256 = analysisContext?.Hashes?.Sha256 ?? string.Empty;
+            this.context = analysisContext;
             this.relativeFilePath = analysisContext?.TargetUri?.LocalPath ?? string.Empty;
 
             foreach (string path in targetFileSpecifiers)
@@ -77,9 +81,15 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         {
             if (s_telemetryConfiguration == null && s_telemetryClient == null)
             {
-                s_sessionId = Guid.NewGuid().ToString();
-                s_telemetryConfiguration = new TelemetryConfiguration(instrumentationKey);
-                s_telemetryClient = new TelemetryClient(s_telemetryConfiguration);
+                lock (s_syncRoot)
+                {
+                    if (s_telemetryConfiguration == null && s_telemetryClient == null)
+                    {
+                        s_sessionId = Guid.NewGuid().ToString();
+                        s_telemetryConfiguration = new TelemetryConfiguration(instrumentationKey);
+                        s_telemetryClient = new TelemetryClient(s_telemetryConfiguration);
+                    }
+                }
             }
         }
 
@@ -152,7 +162,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                     { "moduleName", compilerData.ModuleName ?? string.Empty },
                     { "moduleLibrary", (compilerData.ModuleName == compilerData.ModuleLibrary ? string.Empty : compilerData.ModuleLibrary ?? string.Empty) },
                     { "sessionId", s_sessionId },
-                    { "hash", this.sha256 },
+                    { "hash", this.Sha256 },
                     { "error", string.Empty }
                 };
 
@@ -183,7 +193,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             }
             else
             {
-                string log = $"{this.relativeFilePath},{compilerData},{this.sha256},";
+                string log = $"{this.relativeFilePath},{compilerData},{this.Sha256},";
                 Console.WriteLine(log);
             }
         }
@@ -208,13 +218,13 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                     { "moduleName", string.Empty },
                     { "moduleLibrary", string.Empty },
                     { "sessionId", s_sessionId },
-                    { "hash", this.sha256 },
+                    { "hash", this.Sha256 },
                     { "error", errorMessage },
                 });
             }
             else
             {
-                string log = $"{this.relativeFilePath},,,,,,,,,,,,,{this.sha256},{errorMessage}";
+                string log = $"{this.relativeFilePath},,,,,,,,,,,,,{this.Sha256},{errorMessage}";
                 Console.WriteLine(log);
             }
         }
@@ -268,13 +278,20 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             }
         }
 
+        internal static void Reset()
+        {
+            s_sessionId = null;
+            s_telemetryClient = null;
+            s_telemetryConfiguration = null;
+        }
+
         private void SendChunkedContent(string eventName, string contentId, string contentName, string content)
         {
             int j = 1;
-            int size = (int)Math.Ceiling(1.0 * content.Length / ChunkSize);
-            for (int i = 0; i < content.Length; i += ChunkSize)
+            int size = (int)Math.Ceiling(1.0 * content.Length / this.chunkSize);
+            for (int i = 0; i < content.Length; i += this.chunkSize)
             {
-                string chunckedContent = content.Substring(i, Math.Min(ChunkSize, content.Length - i));
+                string chunckedContent = content.Substring(i, Math.Min(this.chunkSize, content.Length - i));
 
                 s_telemetryClient.TrackEvent(eventName, properties: new Dictionary<string, string>
                 {
@@ -284,6 +301,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                     { "totalNumber", size.ToString() },
                     { $"chunked{contentName}", chunckedContent },
                 });
+
                 j++;
             }
         }

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -27,10 +27,10 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         private readonly IAnalysisContext context;
 
         internal static string s_sessionId;
+
         private static bool s_printHeader = true;
         private static TelemetryClient s_telemetryClient;
         private static TelemetryConfiguration s_telemetryConfiguration;
-
         private static readonly object s_syncRoot = new object();
 
         public static bool TelemetryEnabled => s_telemetryClient != null;
@@ -278,9 +278,16 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             }
         }
 
+        /// <summary>
+        /// This method will clean all static variables.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be used for testing purpose.
+        /// </remarks>
         internal static void Reset()
         {
             s_sessionId = null;
+            s_printHeader = true;
             s_telemetryClient = null;
             s_telemetryConfiguration = null;
         }

--- a/src/BinSkim.Sdk/Properties/AssemblyInfo.cs
+++ b/src/BinSkim.Sdk/Properties/AssemblyInfo.cs
@@ -6,5 +6,3 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("BinSkim SDK")]
 [assembly: AssemblyDescription("BinSkim SDK and utilities for authoring analysis checks")]
-
-[assembly: InternalsVisibleTo("Test.UnitTests.BinSkim.Driver")]

--- a/src/BinSkim.Sdk/Properties/AssemblyInfo.cs
+++ b/src/BinSkim.Sdk/Properties/AssemblyInfo.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("BinSkim SDK")]
 [assembly: AssemblyDescription("BinSkim SDK and utilities for authoring analysis checks")]
+
+[assembly: InternalsVisibleTo("Test.UnitTests.BinSkim.Driver")]

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/src/Shared/SharedAssemblyInfo.cs
+++ b/src/Shared/SharedAssemblyInfo.cs
@@ -23,6 +23,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("BinSkim")]
 [assembly: InternalsVisibleTo("UnitTests.BinSkim.Rules")]
 [assembly: InternalsVisibleTo("Test.UnitTests.BinaryParsers")]
+[assembly: InternalsVisibleTo("Test.UnitTests.BinSkim.Driver")]
 [assembly: InternalsVisibleTo("Test.FunctionalTests.BinSkim.Driver")]
 [assembly: InternalsVisibleTo("BinSkim.Driver.FunctionalTests")]
 [assembly: InternalsVisibleTo("BinSkim.Rules.FunctionalTests")]

--- a/src/Test.UnitTests.BinSkim.Driver/CompilerDataLoggerUnitTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/CompilerDataLoggerUnitTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
         {
             (TelemetryConfiguration, TelemetryClient, List<ITelemetry>) setup = TestSetup();
 
-            var context = new BinaryAnalyzerContext { };
+            var context = new BinaryAnalyzerContext();
             string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
             int chunksize = 10;
             string assemblies = "Microsoft.DiaSymReader (1.3.0);Newtonsoft.Json (13.0.1)";
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
         {
             (TelemetryConfiguration, TelemetryClient, List<ITelemetry>) setup = TestSetup();
 
-            var context = new BinaryAnalyzerContext { };
+            var context = new BinaryAnalyzerContext();
             string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
             int chunksize = 10;
             string assemblies = null;
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
         {
             string sessionId = string.Empty;
             int numberOfCompilerDataLoggers = 1000;
-            var context = new BinaryAnalyzerContext { };
+            var context = new BinaryAnalyzerContext();
             string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
 
             Environment.SetEnvironmentVariable("BinskimAppInsightsKey", Guid.NewGuid().ToString());
@@ -73,6 +73,31 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
 
                 sessionId.Should().Be(CompilerDataLogger.s_sessionId);
             });
+
+            CompilerDataLogger.Reset();
+        }
+
+        [Fact]
+        public void CompilerDataLogger_SessionIdShouldNotBeReplacedWhenValid()
+        {
+            var context = new BinaryAnalyzerContext();
+            string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
+
+            _ = new CompilerDataLogger(context, targetFileSpecifier);
+            CompilerDataLogger.s_sessionId.Should().NotBeNullOrWhiteSpace();
+
+            string currentGuid = Guid.NewGuid().ToString();
+            Environment.SetEnvironmentVariable("BinskimAppInsightsKey", currentGuid);
+
+            // SessionId will be created when BinskimAppInsightsKey is retrieved.
+            _ = new CompilerDataLogger(context, targetFileSpecifier);
+            CompilerDataLogger.s_sessionId.Should().Be(currentGuid);
+
+            // Since sessionId is not null, no new session should be created.
+            _ = new CompilerDataLogger(context, targetFileSpecifier);
+            CompilerDataLogger.s_sessionId.Should().Be(currentGuid);
+
+            CompilerDataLogger.Reset();
         }
 
         private (TelemetryConfiguration, TelemetryClient, List<ITelemetry>) TestSetup()

--- a/src/Test.UnitTests.BinSkim.Driver/CompilerDataLoggerUnitTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/CompilerDataLoggerUnitTests.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
 
 using FluentAssertions;
 
@@ -18,27 +18,10 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
 {
     public class CompilerDataLoggerUnitTests
     {
-        private TelemetryConfiguration telemetryConfiguration;
-        private TelemetryClient telemetryClient;
-        private List<ITelemetry> sendItems;
-
-        private void TestSetup()
-        {
-            if (this.telemetryConfiguration == null && this.telemetryClient == null)
-            {
-                this.telemetryConfiguration = new TelemetryConfiguration();
-                this.sendItems = new List<ITelemetry>();
-                this.telemetryConfiguration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
-                this.telemetryConfiguration.InstrumentationKey = Guid.NewGuid().ToString();
-                this.telemetryConfiguration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
-                this.telemetryClient = new TelemetryClient(this.telemetryConfiguration);
-            }
-        }
-
         [Fact]
-        public void CompilerDataLogger_Write_ShouldSendAssemblyReferencesInChunks()
+        public void CompilerDataLogger_Write_ShouldSendAssemblyReferencesInChunks_WhenTelemetryIsEnabled()
         {
-            this.TestSetup();
+            (TelemetryConfiguration, TelemetryClient, List<ITelemetry>) setup = TestSetup();
 
             var context = new BinaryAnalyzerContext { };
             string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
@@ -46,26 +29,69 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
             string assemblies = "Microsoft.DiaSymReader (1.3.0);Newtonsoft.Json (13.0.1)";
             int chunkNumber = (assemblies.Length + chunksize - 1) / chunksize;
 
-            CompilerDataLogger logger = new CompilerDataLogger(context, targetFileSpecifier, this.telemetryConfiguration, this.telemetryClient, chunksize);
+            var logger = new CompilerDataLogger(context, targetFileSpecifier, setup.Item1, setup.Item2, chunksize);
             logger.Write(new CompilerData { CompilerName = ".NET Compiler", AssemblyReferences = assemblies });
 
-            this.sendItems.Count.Should().Be(chunkNumber + 1); // first item should be CompilerInformation
+            setup.Item3.Count.Should().Be(chunkNumber + 1); // first item should be CompilerInformation
+            CompilerDataLogger.Reset();
         }
 
         [Fact]
         public void CompilerDataLogger_Write_ShouldNotSend_IfNoAssemblyReferences()
         {
-            this.TestSetup();
+            (TelemetryConfiguration, TelemetryClient, List<ITelemetry>) setup = TestSetup();
 
             var context = new BinaryAnalyzerContext { };
             string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
             int chunksize = 10;
             string assemblies = null;
 
-            CompilerDataLogger logger = new CompilerDataLogger(context, targetFileSpecifier, this.telemetryConfiguration, this.telemetryClient, chunksize);
+            var logger = new CompilerDataLogger(context, targetFileSpecifier, setup.Item1, setup.Item2, chunksize);
             logger.Write(new CompilerData { CompilerName = ".NET Compiler", AssemblyReferences = assemblies });
 
-            this.sendItems.Count.Should().Be(1); // first item should be CompilerInformation
+            setup.Item3.Count.Should().Be(1); // first item should be CompilerInformation
+            CompilerDataLogger.Reset();
+        }
+
+        [Fact]
+        public void CompilerDataLogger_ShouldGenerateOnlyOneSessionPerRun()
+        {
+            string sessionId = string.Empty;
+            int numberOfCompilerDataLoggers = 1000;
+            var context = new BinaryAnalyzerContext { };
+            string[] targetFileSpecifier = new[] { @"E:\applications\Tool\*.exe" };
+
+            Environment.SetEnvironmentVariable("BinskimAppInsightsKey", Guid.NewGuid().ToString());
+
+            Parallel.For(0, numberOfCompilerDataLoggers, _ =>
+            {
+                var compilerDataLogger = new CompilerDataLogger(context, targetFileSpecifier);
+                if (string.IsNullOrEmpty(sessionId))
+                {
+                    sessionId = CompilerDataLogger.s_sessionId;
+                }
+
+                sessionId.Should().Be(CompilerDataLogger.s_sessionId);
+            });
+        }
+
+        private (TelemetryConfiguration, TelemetryClient, List<ITelemetry>) TestSetup()
+        {
+            List<ITelemetry> sendItems = null;
+            TelemetryClient telemetryClient = null;
+            TelemetryConfiguration telemetryConfiguration = null;
+
+            if (telemetryConfiguration == null && telemetryClient == null)
+            {
+                telemetryConfiguration = new TelemetryConfiguration();
+                sendItems = new List<ITelemetry>();
+                telemetryConfiguration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => sendItems.Add(item) };
+                telemetryConfiguration.InstrumentationKey = Guid.NewGuid().ToString();
+                telemetryConfiguration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
+                telemetryClient = new TelemetryClient(telemetryConfiguration);
+            }
+
+            return (telemetryConfiguration, telemetryClient, sendItems);
         }
     }
 }


### PR DESCRIPTION
# Description:

When we changed from single thread to multi-thread application, the reporting rule started to behave differently:
- many configurations were being created
- many sessions were being created
- hash wasn't showing correctly since the hash isn't calculated previously

# Fixes:

This PR will fix the following issues:
- session/telemetry objects should not be overridden if already exists
- session/telemetry objects should be created only once (even in a multithread environment)
- hash should have a reference to the context since it will be only created once we start loading a specific file