### PR TITLE
Fix `JsonSerializationException' that occurs when saving SARIF v1 with telemetry enabled.

### DIFF
--- a/src/BinSkim.Driver/AnalyzeCommand.cs
+++ b/src/BinSkim.Driver/AnalyzeCommand.cs
@@ -10,6 +10,9 @@ using Microsoft.CodeAnalysis.IL.Rules;
 using Microsoft.CodeAnalysis.IL.Sdk;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Driver;
+using Microsoft.CodeAnalysis.Sarif.Readers;
+using Microsoft.CodeAnalysis.Sarif.VersionOne;
+using Microsoft.CodeAnalysis.Sarif.Visitors;
 
 namespace Microsoft.CodeAnalysis.IL
 {
@@ -102,7 +105,7 @@ namespace Microsoft.CodeAnalysis.IL
                     !string.IsNullOrEmpty(analyzeOptions.OutputFilePath) &&
                     this.FileSystem.FileExists(analyzeOptions.OutputFilePath))
                 {
-                    SarifLog sarifLog = SarifLog.Load(analyzeOptions.OutputFilePath);
+                    SarifLog sarifLog = ReadSarifLog(this.FileSystem, analyzeOptions);
 
                     AnalysisSummary summary = AnalysisSummaryExtractor.ExtractAnalysisSummary(
                         sarifLog, analyzeOptions);
@@ -132,6 +135,24 @@ namespace Microsoft.CodeAnalysis.IL
             return analyzeOptions.RichReturnCode
                 ? (int)((uint)result & ~(uint)RuntimeConditions.RuleNotApplicableToTarget)
                 : result;
+        }
+
+        internal static SarifLog ReadSarifLog(IFileSystem fileSystem, AnalyzeOptions analyzeOptions)
+        {
+            SarifLog sarifLog;
+            if (analyzeOptions.SarifOutputVersion == Sarif.SarifVersion.Current)
+            {
+                sarifLog = SarifLog.Load(analyzeOptions.OutputFilePath);
+            }
+            else
+            {
+                SarifLogVersionOne actualLog = ReadSarifFile<SarifLogVersionOne>(fileSystem, analyzeOptions.OutputFilePath, SarifContractResolverVersionOne.Instance);
+                var visitor = new SarifVersionOneToCurrentVisitor();
+                visitor.VisitSarifLogVersionOne(actualLog);
+                sarifLog = visitor.SarifLog;
+            }
+
+            return sarifLog;
         }
 
         internal static Sarif.SarifVersion s_UnitTestOutputVersion;

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* BUGFIX: Fix `JsonSerializationExxception` that occurs when saving SARIF v1 with telemetry is enabled. [#535](https://github.com/microsoft/binskim/pull/535)
+* BUGFIX: Fix `JsonSerializationException` that occurs when saving SARIF v1 with telemetry enabled. [#535](https://github.com/microsoft/binskim/pull/535)
 
 ## **v1.9.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/1.9.0)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* BUGFIX: Fix `JsonSerializationException` when reading Sarif v1.0.0 when telemetry is enabled. [#535](https://github.com/microsoft/binskim/pull/535)
+
 ## **v1.9.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/1.9.0)
 
 * BUGFIX: Fix telemetry session creation. [515](https://github.com/microsoft/binskim/pull/515)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* BUGFIX: Fix `JsonSerializationException` when reading Sarif v1.0.0 when telemetry is enabled. [#535](https://github.com/microsoft/binskim/pull/535)
+* BUGFIX: Fix `JsonSerializationExxception` that occurs when saving SARIF v1 with telemetry is enabled. [#535](https://github.com/microsoft/binskim/pull/535)
 
 ## **v1.9.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/1.9.0)
 

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTest.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTest.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Text;
 
 using FluentAssertions;
 
+using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.IL;
 using Microsoft.CodeAnalysis.Sarif;
 
@@ -52,6 +54,24 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
             });
             sarifLog.Version.Should().Be(Sarif.SarifVersion.Current);
             sarifLog.Runs[0].Tool.Driver.Name.Should().Be(ToolName);
+            sarifLog.Runs[0].Results.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AnalyzeCommand_ReadSarifLog_ShouldBeAbleToReadCurrent()
+        {
+            string sarifLogPath = Path.Combine(PEBinaryTests.BaselineTestsDataDirectory, "Expected", "Binskim.linux-x64.dll.sarif");
+
+            var fileSystem = new Mock<IFileSystem>();
+
+            SarifLog sarifLog = AnalyzeCommand.ReadSarifLog(fileSystem.Object, new AnalyzeOptions
+            {
+                SarifOutputVersion = Sarif.SarifVersion.Current,
+                OutputFilePath = sarifLogPath,
+            });
+            sarifLog.Version.Should().Be(Sarif.SarifVersion.Current);
+            sarifLog.Runs[0].Tool.Driver.Name.Should().NotBeEmpty();
+            sarifLog.Runs[0].Results.Should().NotBeEmpty();
         }
     }
 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTest.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTest.cs
@@ -1,15 +1,57 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.IL;
+using Microsoft.CodeAnalysis.Sarif;
+
+using Moq;
+
+using Newtonsoft.Json;
+
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.BinSkim.Driver
 {
     public class AnalyzeCommandTest
     {
+        private const string ToolName = "binskim";
+        private readonly string SarifLogV1 = $@"{{
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""version"": ""1.0.0"",
+  ""runs"": [
+    {{
+      ""tool"": {{
+        ""name"": ""{ToolName}""
+      }},
+      ""results"": []
+    }}
+  ]
+}}";
+
         [Fact]
-        public void AnalyzeCommand_Basic()
+        public void AnalyzeCommand_ReadSarifLog_ShouldBeAbleToReadOneZeroZero()
         {
+            var fileSystem = new Mock<IFileSystem>();
+
+            byte[] byteArray = Encoding.UTF8.GetBytes(SarifLogV1);
+
+            fileSystem
+                .Setup(f => f.FileOpenRead(It.IsAny<string>()))
+                .Returns(new MemoryStream(byteArray));
+
+            SarifLog sarifLog = AnalyzeCommand.ReadSarifLog(fileSystem.Object, new AnalyzeOptions
+            {
+                SarifOutputVersion = Sarif.SarifVersion.OneZeroZero,
+                OutputFilePath = Guid.NewGuid().ToString(),
+            });
+            sarifLog.Version.Should().Be(Sarif.SarifVersion.Current);
+            sarifLog.Runs[0].Tool.Driver.Name.Should().Be(ToolName);
         }
     }
 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
@@ -46,8 +46,6 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         {
             string sarifLogPath = Path.Combine(PEBinaryTests.BaselineTestsDataDirectory, "Expected", "Binskim.linux-x64.dll.sarif");
 
-            var fileSystem = new Mock<IFileSystem>();
-
             SarifLog sarifLog = AnalyzeCommand.ReadSarifLog(fileSystem: null, new AnalyzeOptions
             {
                 SarifOutputVersion = Sarif.SarifVersion.Current,

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.empty.v1.0.0.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.empty.v1.0.0.sarif
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "binskim"
+      },
+      "results": []
+    }
+  ]
+}

--- a/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Today, the guardian task always outputs the SARIF to v1.0.0 and our code wasn't prepared to read that, throwing the `JsonSerializationException` exception.

This change will verify what is the version that the user is exporting and will read based on that.