### PR TITLE
FluentAssertions test code minor syntax change

### DIFF
--- a/src/Test.UnitTests.BinSkim.Driver/AnalysisSummaryExtractorUnitTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/AnalysisSummaryExtractorUnitTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
             summary.ToolVersion.Should().BeEquivalentTo(toolVersion);
             summary.NormalizedPath.Should().BeEquivalentTo(binaryPath);
             summary.SymbolPath.Should().BeEquivalentTo(symbolPath);
-            summary.StartTimeUtc.Should().Equals(currentTime.AddMinutes(-1).AddSeconds(-10));
-            summary.EndTimeUtc.Should().Equals(currentTime);
+            summary.StartTimeUtc.Should().Be(currentTime.AddMinutes(-1).AddSeconds(-10));
+            summary.EndTimeUtc.Should().Be(currentTime);
         }
 
         [Fact]


### PR DESCRIPTION
# Description:

FluentAssertions auto upgrade by dependabot, 
new version has a minor change that does not allow to use Should().Equals()
it need to use methods in the class like:
Should().Be
Should().BeEquivalentTo

# Fixes:

We only have 1 test method using it, changed to use Be() which is a exact match, base on the code logic.
