### PR TITLE
Fix `SarifLogger` artifacts generation when logging notifications

### DIFF
--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.linux-x64.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.linux-x64.dll.sarif
@@ -1617,7 +1617,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.linux-x64.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.linux-x64.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x64.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x64.dll.sarif
@@ -1617,7 +1617,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.win-x64.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.win-x64.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x86.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x86.dll.sarif
@@ -1613,7 +1613,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.win-x86.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.win-x86.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Corrupted_Native_x86_VS2013_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Corrupted_Native_x86_VS2013_Default.exe.sarif
@@ -21,7 +21,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe",
+                      "index": 0
                     }
                   }
                 }
@@ -36,6 +37,18 @@
             }
           ],
           "executionSuccessful": false
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Corrupted_Native_x86_VS2013_Default.exe"
+          },
+          "hashes": {
+            "md5": "992F5D2554195F9F19B9480A0E11AC78",
+            "sha-1": "A88412258FFEAC619F3FD960AD9A48AC2F29CBAE",
+            "sha-256": "9F92EDE722DC8740BFDF02CD199090B249BFBBF268DE3CD541FE9400A5652166"
+          }
         }
       ],
       "columnKind": "utf16CodeUnits"

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedInteropAssemblyForAtlTestLibrary.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedInteropAssemblyForAtlTestLibrary.dll.sarif
@@ -1613,7 +1613,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/ManagedInteropAssemblyForAtlTestLibrary.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedResourcesOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/ManagedResourcesOnly.dll.sarif
@@ -1616,7 +1616,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/ManagedResourcesOnly.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/ManagedResourcesOnly.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x64_VS2019_CSharp_DebugType_None.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x64_VS2019_CSharp_DebugType_None.dll.sarif
@@ -1613,7 +1613,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x64_VS2019_CSharp_DebugType_None.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x64_VS2019_CSharp_DebugType_None.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x64_VS2019_VB_DebugType_None.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Managed_x64_VS2019_VB_DebugType_None.dll.sarif
@@ -1613,7 +1613,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x64_VS2019_VB_DebugType_None.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Managed_x64_VS2019_VB_DebugType_None.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2013_NoPdb.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2013_NoPdb.exe.sarif
@@ -1150,7 +1150,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2013_NoPdb.exe",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2019_CPlusPlus_DEBUG_NONE.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x64_VS2019_CPlusPlus_DEBUG_NONE.dll.sarif
@@ -1152,7 +1152,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2019_CPlusPlus_DEBUG_NONE.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x64_VS2019_CPlusPlus_DEBUG_NONE.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2013_MissingPdb.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/MixedMode_x86_VS2013_MissingPdb.dll.sarif
@@ -1150,7 +1150,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/MixedMode_x86_VS2013_MissingPdb.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_ARM_VS2015_CvtresResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_ARM_VS2015_CvtresResourceOnly.dll.sarif
@@ -1615,7 +1615,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_ARM_VS2015_CvtresResourceOnly.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_ARM_VS2015_CvtresResourceOnly.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2015_CvtresResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2015_CvtresResourceOnly.dll.sarif
@@ -1615,7 +1615,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2015_CvtresResourceOnly.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2015_CvtresResourceOnly.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2019_Atl_NoPdbGenerated.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2019_Atl_NoPdbGenerated.dll.sarif
@@ -1149,7 +1149,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2019_Atl_NoPdbGenerated.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2019_Atl_NoPdbGenerated.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2019_CPlusPlus_DEBUG_NONE.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x64_VS2019_CPlusPlus_DEBUG_NONE.dll.sarif
@@ -1149,7 +1149,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2019_CPlusPlus_DEBUG_NONE.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x64_VS2019_CPlusPlus_DEBUG_NONE.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_PdbMissing.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2013_PdbMissing.exe.sarif
@@ -1150,7 +1150,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2013_PdbMissing.exe",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_CvtresResourceOnly.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2015_CvtresResourceOnly.dll.sarif
@@ -1615,7 +1615,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2015_CvtresResourceOnly.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2015_CvtresResourceOnly.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2017_15.5.4_PdbStripped.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Native_x86_VS2017_15.5.4_PdbStripped.dll.sarif
@@ -1148,7 +1148,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2017_15.5.4_PdbStripped.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Native_x86_VS2017_15.5.4_PdbStripped.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.dll.sarif
@@ -1310,7 +1310,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_ARM_VS2015_DefaultBlankApp.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_ARM_VS2015_DefaultBlankApp.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_ARM_VS2015_DefaultBlankApp.exe.sarif
@@ -1152,7 +1152,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_ARM_VS2015_DefaultBlankApp.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_ARM_VS2015_DefaultBlankApp.exe",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.dll.sarif
@@ -1310,7 +1310,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x64_VS2015_DefaultBlankApp.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x64_VS2015_DefaultBlankApp.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x64_VS2015_DefaultBlankApp.exe.sarif
@@ -1150,7 +1150,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x64_VS2015_DefaultBlankApp.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x64_VS2015_DefaultBlankApp.exe",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.dll.sarif
@@ -1308,7 +1308,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x86_VS2015_DefaultBlankApp.dll"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x86_VS2015_DefaultBlankApp.dll",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Uwp_x86_VS2015_DefaultBlankApp.exe.sarif
@@ -1150,7 +1150,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x86_VS2015_DefaultBlankApp.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Uwp_x86_VS2015_DefaultBlankApp.exe",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.a.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.a.sarif
@@ -21,7 +21,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.stack_protector.a"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.stack_protector.a",
+                      "index": 0
                     }
                   }
                 }
@@ -36,6 +37,18 @@
             }
           ],
           "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/clang.stack_protector.a"
+          },
+          "hashes": {
+            "md5": "2400EE99A6BB7B792A67A03A59385018",
+            "sha-1": "525CB4CBA8B8F80539BBC86C2D78A4275279D8F6",
+            "sha-256": "41BF336F8AB7D9A6246D37A6EC7210D4BE07893836890BAB0BFEDA98ACEDE87D"
+          }
         }
       ],
       "columnKind": "utf16CodeUnits"

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.pe.objectivec.dwarf.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.pe.objectivec.dwarf.exe.sarif
@@ -1148,7 +1148,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.pe.objectivec.dwarf.exe"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.pe.objectivec.dwarf.exe",
+                      "index": 0
                     }
                   }
                 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.a.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.a.sarif
@@ -21,7 +21,8 @@
                 {
                   "physicalLocation": {
                     "artifactLocation": {
-                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.stack_protector.a"
+                      "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.stack_protector.a",
+                      "index": 0
                     }
                   }
                 }
@@ -36,6 +37,18 @@
             }
           ],
           "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/gcc.stack_protector.a"
+          },
+          "hashes": {
+            "md5": "764B913022B393EAF22F96014401576F",
+            "sha-1": "4B49DA507C9212490EE09280A5A7AD1F1A389188",
+            "sha-256": "8548292CA34C14D090A1DE7327874010E3A7ACE5846B2E28D743CC0F35C069CB"
+          }
         }
       ],
       "columnKind": "utf16CodeUnits"


### PR DESCRIPTION
# Description
In the previous [PR](https://github.com/microsoft/binskim/pull/555), we saw an issue where toolNotifications with artifactLocations were not updating artifacts.

This change will fix that and make the proper link between notifications -> artifactLocation -> artifacts.

# Tests
We will see files where we are adding back the artifacts and updating the index if the artifacts exists.