### PR TITLE
Improving common path function

### DIFF
--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -89,11 +89,22 @@ namespace Microsoft.CodeAnalysis.IL
                 }
             }
 
-            return smallestPath.Length == 0 || smallestPath[^1] != '\\'
-                ? string.Empty
-                : smallestPath.EndsWith(@"\\")
-                    ? smallestPath.Substring(0, smallestPath.Length - 1)
-                    : smallestPath;
+            if (smallestPath.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            if (smallestPath[^1] != '\\')
+            {
+                // In this case, smallestPath is equal to 'c:\path1\partial-path' (this is an incomplete path).
+                // Once we execute, our smallestPath will be transformed into 'c:\path1\'.
+                string[] parts = smallestPath.Split('\\');
+                smallestPath = string.Join(@"\", parts[..^1]) + @"\";
+            }
+
+            return smallestPath.EndsWith(@"\\")
+                ? smallestPath.Substring(0, smallestPath.Length - 1)
+                : smallestPath;
         }
 
         public override int Run(AnalyzeOptions analyzeOptions)

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.IL
 
             var fileSpecifierDirectories = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            // Normalizing all 'targetFileSpecifiers', guaranteeing that they will always end with only one slash.
+            // Normalizing all 'targetFileSpecifiers', ensuring that they will always end with only one slash.
             foreach (string targetFileSpecifier in targetFileSpecifiers)
             {
                 string targetFileDirectory = Path.GetDirectoryName(Path.GetFullPath(targetFileSpecifier));

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -79,6 +79,13 @@ namespace Microsoft.CodeAnalysis.IL
 
             for (int i = 0; i < smallestPath.Length; i++)
             {
+                // We don't need to iterate all characters of the smallestPath if we don't have anything
+                // to compare against.
+                if (fileSpecifierDirectories.Count == 0)
+                {
+                    break;
+                }
+
                 foreach (string specifier in fileSpecifierDirectories)
                 {
                     if (char.ToLowerInvariant(smallestPath[i]) != char.ToLowerInvariant(specifier[i]))

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Text;
 
 using FluentAssertions;
@@ -18,6 +19,14 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
         {
             var testCases = new[]
             {
+                new
+                {
+                    TargetFileSpecifiers = new[]
+                    {
+                        @"C:\*.dll"
+                    },
+                    ExpectedCommonPath = @"C:\"
+                },
                 new
                 {
                     TargetFileSpecifiers = new[]
@@ -107,9 +116,29 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                 {
                     sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}'.");
                 }
+
+                commonPath = MultithreadedAnalyzeCommand.ReturnCommonPathRootFromTargetSpecifiersIfOneExists(Shuffle(testCase.TargetFileSpecifiers));
+                if (commonPath != testCase.ExpectedCommonPath)
+                {
+                    sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}' when shuffed.");
+                }
             }
 
             sb.Length.Should().Be(0, sb.ToString());
+        }
+
+        private static string[] Shuffle(string[] data)
+        {
+            var rand = new Random();
+            for (int i = 0; i < data.Length; ++i)
+            {
+                int swapWith = rand.Next(i, data.Length);
+                string temp = data[i];
+                data[i] = data[swapWith];
+                data[swapWith] = temp;
+            }
+
+            return data;
         }
     }
 }

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -40,10 +40,20 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                 {
                     TargetFileSpecifiers = new[]
                     {
+                        @"c:\*.dll",
+                        @"c:\*.dll",
+                        @"C:\*.DLL"
+                    },
+                    ExpectedCommonPath = @"c:\"
+                },
+                new
+                {
+                    TargetFileSpecifiers = new[]
+                    {
                         @"C:\path1\",
                         @"C:\path1\path2\"
                     },
-                    ExpectedCommonPath = string.Empty
+                    ExpectedCommonPath = @"C:\path1\"
                 },
                 new
                 {
@@ -58,11 +68,34 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                 {
                     TargetFileSpecifiers = new[]
                     {
+                        @"C:\path1\",
                         @"C:\path1\1.dll",
                         @"C:\path1\2.exe",
-                        @"C:\path1\path2\1.exe"
+                        @"C:\path1\path2\",
+                        @"C:\path1\path2\1.exe",
+                        @"C:\path1\path2\path3\",
+                        @"C:\path1\path2\path3\1.sys",
+                        "c:\\path1\\path2\\path3\\path4\\"
                     },
-                    ExpectedCommonPath = string.Empty
+                    ExpectedCommonPath = @"C:\path1\"
+                },
+                new
+                {
+                    TargetFileSpecifiers = new[]
+                    {
+                        @"\\PC1\path1\",
+                        @"\\PC1\path1\path2\",
+                    },
+                    ExpectedCommonPath = @"\\PC1\path1\",
+                },
+                new
+                {
+                    TargetFileSpecifiers = new[]
+                    {
+                        @"C:\path1\..\*.dll",
+                        @"C:\*.dll",
+                    },
+                    ExpectedCommonPath = @"C:\",
                 },
             };
 

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -14,6 +14,15 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
 {
     public class MultithreadedAnalyzeCommandTests
     {
+        private static readonly Random s_random;
+        private static readonly double s_randomSeed;
+
+        static MultithreadedAnalyzeCommandTests()
+        {
+            s_randomSeed = DateTime.UtcNow.TimeOfDay.TotalMilliseconds;
+            s_random = new Random((int)s_randomSeed);
+        }
+
         [Fact]
         public void MultithreadedAnalyzeCommand_ReturnCommonPathRootFromTargetSpecifiersIfOneExists()
         {
@@ -122,7 +131,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                 commonPath = MultithreadedAnalyzeCommand.ReturnCommonPathRootFromTargetSpecifiersIfOneExists(Shuffle(testCase.TargetFileSpecifiers));
                 if (commonPath != testCase.ExpectedCommonPath)
                 {
-                    sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}' when shuffed.");
+                    sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}' when shuffed with seed '{s_randomSeed}'.");
                 }
             }
 
@@ -131,10 +140,9 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
 
         private static string[] Shuffle(string[] data)
         {
-            var rand = new Random();
             for (int i = 0; i < data.Length; ++i)
             {
-                int swapWith = rand.Next(i, data.Length);
+                int swapWith = s_random.Next(i, data.Length);
                 string temp = data[i];
                 data[i] = data[swapWith];
                 data[swapWith] = temp;

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                 commonPath = MultithreadedAnalyzeCommand.ReturnCommonPathRootFromTargetSpecifiersIfOneExists(Shuffle(testCase.TargetFileSpecifiers));
                 if (commonPath != testCase.ExpectedCommonPath)
                 {
-                    sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}' when shuffed with seed '{s_randomSeed}'.");
+                    sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}' when shuffled with seed '{s_randomSeed}'.");
                 }
             }
 

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -117,6 +117,8 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                     sb.AppendLine($"The test was expecting '{testCase.ExpectedCommonPath}' but found '{commonPath}'.");
                 }
 
+                // Testing the same string array in a random order.
+                // This will guarantee that the sorting is working as expected.
                 commonPath = MultithreadedAnalyzeCommand.ReturnCommonPathRootFromTargetSpecifiersIfOneExists(Shuffle(testCase.TargetFileSpecifiers));
                 if (commonPath != testCase.ExpectedCommonPath)
                 {

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
                         @"C:\path1\",
                         @"C:\path2\"
                     },
-                    ExpectedCommonPath = string.Empty
+                    ExpectedCommonPath = @"C:\"
                 },
                 new
                 {


### PR DESCRIPTION
# Description

In this change, I'm improving how the method `ReturnCommonPathRootFromTargetSpecifiersIfOneExists` generates the common path. The method will now generate the common path from the target specifiers if that exists.

The current behavior will generate the following:
```
c:\path1\ C:\path2\ -> no common path
c:\path1\ C:\path1\path2\ -> no common path
c:\path1\ C:\path1\path2\1.exe -> no common path
```

The new behavior will generate the following:
```
c:\path1\ c:\path2\ -> C:\
c:\path1\ c:\path1\path2\ -> c:\path1\
c:\path1\ c:\path1\path2\1.exe -> c:\path1\
```

# Tests

The following tests were added:
- Shuffling the array to guarantee that won't matter the order of the input
- UNC examples
- Paths with `..`
- Paths with duplicated information
- Paths that point to files and folders
- Paths with distinct cases