### PR TITLE
Rule `BA4001.ReportPortableExecutableCompilerData` will now analyze all PE binaries

### DIFF
--- a/src/BinSkim.Rules/PERules/BA4001.ReportPortableExecutableCompilerData.cs
+++ b/src/BinSkim.Rules/PERules/BA4001.ReportPortableExecutableCompilerData.cs
@@ -15,15 +15,13 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 namespace Microsoft.CodeAnalysis.IL.Rules
 {
     [Export(typeof(Skimmer<BinaryAnalyzerContext>)), Export(typeof(ReportingDescriptor)), Export(typeof(IOptionsProvider))]
-    public class ReportPECompilerData : WindowsBinaryAndPdbSkimmerBase, IOptionsProvider
+    public class ReportPortableExecutableCompilerData : PEBinarySkimmerBase, IOptionsProvider
     {
         /// <summary>
         /// BA4001. This reporting rule writes compiler data to AppInsights and 
         /// a CSV file (if configured) for every compilation unit that's scanned.
         /// </summary>
         public override string Id => RuleIds.ReportPortableExecutableCompilerData;
-
-        public override bool LogPdbLoadException => false;
 
         /// <summary>
         /// This rule emits CSV data to the console for every compiler/language/version
@@ -47,7 +45,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             return AnalysisApplicability.ApplicableToSpecifiedTarget;
         }
 
-        public override void AnalyzePortableExecutableAndPdb(BinaryAnalyzerContext context)
+        public override void Analyze(BinaryAnalyzerContext context)
         {
             if (!context.CompilerDataLogger.Enabled)
             {

--- a/src/BinSkim.Sdk/CompilerData.cs
+++ b/src/BinSkim.Sdk/CompilerData.cs
@@ -21,7 +21,9 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
         public override string ToString()
         {
-            return $"{CompilerName},{CompilerBackEndVersion},{CompilerFrontEndVersion},{FileVersion},{BinaryType},{Language},{DebuggingFileName},{DebuggingFileGuid},{CommandLine},{Dialect},{ModuleName},{(ModuleLibrary == ModuleName ? string.Empty : ModuleLibrary)},{AssemblyReferences}";
+            return $"{CompilerName},{CompilerBackEndVersion},{CompilerFrontEndVersion},{FileVersion},{BinaryType},{Language}," +
+                $"{DebuggingFileName},{DebuggingFileGuid},{CommandLine?.Replace(",", " ")},{Dialect},{ModuleName}," +
+                $"{(ModuleLibrary == ModuleName ? string.Empty : ModuleLibrary)},{AssemblyReferences}";
         }
     }
 }

--- a/src/BinSkim.Sdk/CompilerData.cs
+++ b/src/BinSkim.Sdk/CompilerData.cs
@@ -21,9 +21,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
         public override string ToString()
         {
-            return $"{CompilerName},{CompilerBackEndVersion},{CompilerFrontEndVersion},{FileVersion},{BinaryType},{Language}," +
-                $"{DebuggingFileName},{DebuggingFileGuid},{CommandLine?.Replace(",", " ")},{Dialect},{ModuleName}," +
-                $"{(ModuleLibrary == ModuleName ? string.Empty : ModuleLibrary)},{AssemblyReferences}";
+            return $"{CompilerName},{CompilerBackEndVersion},{CompilerFrontEndVersion},{FileVersion},{BinaryType},{Language},{DebuggingFileName},{DebuggingFileGuid},{CommandLine},{Dialect},{ModuleName},{(ModuleLibrary == ModuleName ? string.Empty : ModuleLibrary)},{AssemblyReferences}";
         }
     }
 }

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             string header = "" +
                 "Target,Compiler Name,Compiler BackEnd Version,Compiler FrontEnd Version," +
                 "File Version,Binary Type,Language,Debugging FileName,Debugging FileGuid," +
-                "Command Line,Dialect,Module Name,Module Library,Assembly References,Hash,Error";
+                "Command Line,Dialect,Module Name,Module Library,Hash,Error";
 
             WriteToCsv(header);
         }
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             string fileHash = context.Hashes?.Sha256;
             string filePath = context.TargetUri?.LocalPath.Replace(RootPathToElide, string.Empty);
 
-            WriteToCsv($"{filePath},,,,,,,,,,,,,,{fileHash},{errorMessage}");
+            WriteToCsv($"{filePath},,,,,,,,,,,,,{fileHash},{errorMessage}");
 
             if (this.telemetryClient == null)
             {

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             string header = "" +
                 "Target,Compiler Name,Compiler BackEnd Version,Compiler FrontEnd Version," +
                 "File Version,Binary Type,Language,Debugging FileName,Debugging FileGuid," +
-                "Command Line,Dialect,Module Name,Module Library,Hash,Error";
+                "Command Line,Dialect,Module Name,Module Library,Assembly References,Hash,Error";
 
             WriteToCsv(header);
         }
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             string fileHash = context.Hashes?.Sha256;
             string filePath = context.TargetUri?.LocalPath.Replace(RootPathToElide, string.Empty);
 
-            WriteToCsv($"{filePath},,,,,,,,,,,,,{fileHash},{errorMessage}");
+            WriteToCsv($"{filePath},,,,,,,,,,,,,,{fileHash},{errorMessage}");
 
             if (this.telemetryClient == null)
             {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/BinSkim.win-x64.ni.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/BinSkim.win-x64.ni.dll.sarif
@@ -557,32 +557,8 @@
           ]
         },
         {
-          "ruleId": "BA4001",
-          "ruleIndex": 23,
-          "kind": "notApplicable",
-          "level": "none",
-          "message": {
-            "id": "NotApplicable_InvalidMetadata",
-            "arguments": [
-              "BinSkim.win-x64.ni.dll",
-              "ReportPECompilerData",
-              "image is a managed IL library (i.e., ahead of time compiled) assembly"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/BinSkim.win-x64.ni.dll",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        {
           "ruleId": "BA5001",
-          "ruleIndex": 24,
+          "ruleIndex": 23,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -606,7 +582,7 @@
         },
         {
           "ruleId": "BA5002",
-          "ruleIndex": 25,
+          "ruleIndex": 24,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -630,7 +606,7 @@
         },
         {
           "ruleId": "BA2001",
-          "ruleIndex": 26,
+          "ruleIndex": 25,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -652,7 +628,7 @@
         },
         {
           "ruleId": "BA2005",
-          "ruleIndex": 27,
+          "ruleIndex": 26,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -674,7 +650,7 @@
         },
         {
           "ruleId": "BA2009",
-          "ruleIndex": 28,
+          "ruleIndex": 27,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -696,7 +672,7 @@
         },
         {
           "ruleId": "BA2010",
-          "ruleIndex": 29,
+          "ruleIndex": 28,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -718,7 +694,7 @@
         },
         {
           "ruleId": "BA2012",
-          "ruleIndex": 30,
+          "ruleIndex": 29,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -740,7 +716,7 @@
         },
         {
           "ruleId": "BA2019",
-          "ruleIndex": 31,
+          "ruleIndex": 30,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -762,7 +738,7 @@
         },
         {
           "ruleId": "BA2021",
-          "ruleIndex": 32,
+          "ruleIndex": 31,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -784,7 +760,7 @@
         },
         {
           "ruleId": "BA2022",
-          "ruleIndex": 33,
+          "ruleIndex": 32,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -1404,17 +1380,6 @@
                 }
               },
               "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
-            },
-            {
-              "id": "BA4001",
-              "name": "ReportPECompilerData",
-              "fullDescription": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "help": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/BinSkim.win-x86.ni.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/BinSkim.win-x86.ni.dll.sarif
@@ -533,32 +533,8 @@
           ]
         },
         {
-          "ruleId": "BA4001",
-          "ruleIndex": 22,
-          "kind": "notApplicable",
-          "level": "none",
-          "message": {
-            "id": "NotApplicable_InvalidMetadata",
-            "arguments": [
-              "BinSkim.win-x86.ni.dll",
-              "ReportPECompilerData",
-              "image is a managed IL library (i.e., ahead of time compiled) assembly"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/BinSkim.win-x86.ni.dll",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        {
           "ruleId": "BA5001",
-          "ruleIndex": 23,
+          "ruleIndex": 22,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -582,7 +558,7 @@
         },
         {
           "ruleId": "BA5002",
-          "ruleIndex": 24,
+          "ruleIndex": 23,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -606,7 +582,7 @@
         },
         {
           "ruleId": "BA2005",
-          "ruleIndex": 25,
+          "ruleIndex": 24,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -628,7 +604,7 @@
         },
         {
           "ruleId": "BA2009",
-          "ruleIndex": 26,
+          "ruleIndex": 25,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -650,7 +626,7 @@
         },
         {
           "ruleId": "BA2010",
-          "ruleIndex": 27,
+          "ruleIndex": 26,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -672,7 +648,7 @@
         },
         {
           "ruleId": "BA2012",
-          "ruleIndex": 28,
+          "ruleIndex": 27,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -694,7 +670,7 @@
         },
         {
           "ruleId": "BA2016",
-          "ruleIndex": 29,
+          "ruleIndex": 28,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -716,7 +692,7 @@
         },
         {
           "ruleId": "BA2018",
-          "ruleIndex": 30,
+          "ruleIndex": 29,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -738,7 +714,7 @@
         },
         {
           "ruleId": "BA2019",
-          "ruleIndex": 31,
+          "ruleIndex": 30,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -760,7 +736,7 @@
         },
         {
           "ruleId": "BA2021",
-          "ruleIndex": 32,
+          "ruleIndex": 31,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -782,7 +758,7 @@
         },
         {
           "ruleId": "BA2022",
-          "ruleIndex": 33,
+          "ruleIndex": 32,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -1374,17 +1350,6 @@
                 }
               },
               "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
-            },
-            {
-              "id": "BA4001",
-              "name": "ReportPECompilerData",
-              "fullDescription": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "help": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x64.RTR.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x64.RTR.dll.sarif
@@ -557,32 +557,8 @@
           ]
         },
         {
-          "ruleId": "BA4001",
-          "ruleIndex": 23,
-          "kind": "notApplicable",
-          "level": "none",
-          "message": {
-            "id": "NotApplicable_InvalidMetadata",
-            "arguments": [
-              "Binskim.win-x64.RTR.dll",
-              "ReportPECompilerData",
-              "image is a managed IL library (i.e., ahead of time compiled) assembly"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.win-x64.RTR.dll",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        {
           "ruleId": "BA5001",
-          "ruleIndex": 24,
+          "ruleIndex": 23,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -606,7 +582,7 @@
         },
         {
           "ruleId": "BA5002",
-          "ruleIndex": 25,
+          "ruleIndex": 24,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -630,7 +606,7 @@
         },
         {
           "ruleId": "BA2001",
-          "ruleIndex": 26,
+          "ruleIndex": 25,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -652,7 +628,7 @@
         },
         {
           "ruleId": "BA2005",
-          "ruleIndex": 27,
+          "ruleIndex": 26,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -674,7 +650,7 @@
         },
         {
           "ruleId": "BA2009",
-          "ruleIndex": 28,
+          "ruleIndex": 27,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -696,7 +672,7 @@
         },
         {
           "ruleId": "BA2010",
-          "ruleIndex": 29,
+          "ruleIndex": 28,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -718,7 +694,7 @@
         },
         {
           "ruleId": "BA2012",
-          "ruleIndex": 30,
+          "ruleIndex": 29,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -740,7 +716,7 @@
         },
         {
           "ruleId": "BA2019",
-          "ruleIndex": 31,
+          "ruleIndex": 30,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -762,7 +738,7 @@
         },
         {
           "ruleId": "BA2021",
-          "ruleIndex": 32,
+          "ruleIndex": 31,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -784,7 +760,7 @@
         },
         {
           "ruleId": "BA2022",
-          "ruleIndex": 33,
+          "ruleIndex": 32,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -1404,17 +1380,6 @@
                 }
               },
               "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
-            },
-            {
-              "id": "BA4001",
-              "name": "ReportPECompilerData",
-              "fullDescription": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "help": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x86.RTR.dll.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Binskim.win-x86.RTR.dll.sarif
@@ -533,32 +533,8 @@
           ]
         },
         {
-          "ruleId": "BA4001",
-          "ruleIndex": 22,
-          "kind": "notApplicable",
-          "level": "none",
-          "message": {
-            "id": "NotApplicable_InvalidMetadata",
-            "arguments": [
-              "Binskim.win-x86.RTR.dll",
-              "ReportPECompilerData",
-              "image is a managed IL library (i.e., ahead of time compiled) assembly"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Binskim.win-x86.RTR.dll",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        {
           "ruleId": "BA5001",
-          "ruleIndex": 23,
+          "ruleIndex": 22,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -582,7 +558,7 @@
         },
         {
           "ruleId": "BA5002",
-          "ruleIndex": 24,
+          "ruleIndex": 23,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -606,7 +582,7 @@
         },
         {
           "ruleId": "BA2005",
-          "ruleIndex": 25,
+          "ruleIndex": 24,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -628,7 +604,7 @@
         },
         {
           "ruleId": "BA2009",
-          "ruleIndex": 26,
+          "ruleIndex": 25,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -650,7 +626,7 @@
         },
         {
           "ruleId": "BA2010",
-          "ruleIndex": 27,
+          "ruleIndex": 26,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -672,7 +648,7 @@
         },
         {
           "ruleId": "BA2012",
-          "ruleIndex": 28,
+          "ruleIndex": 27,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -694,7 +670,7 @@
         },
         {
           "ruleId": "BA2016",
-          "ruleIndex": 29,
+          "ruleIndex": 28,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -716,7 +692,7 @@
         },
         {
           "ruleId": "BA2018",
-          "ruleIndex": 30,
+          "ruleIndex": 29,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -738,7 +714,7 @@
         },
         {
           "ruleId": "BA2019",
-          "ruleIndex": 31,
+          "ruleIndex": 30,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -760,7 +736,7 @@
         },
         {
           "ruleId": "BA2021",
-          "ruleIndex": 32,
+          "ruleIndex": 31,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -782,7 +758,7 @@
         },
         {
           "ruleId": "BA2022",
-          "ruleIndex": 33,
+          "ruleIndex": 32,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -1374,17 +1350,6 @@
                 }
               },
               "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
-            },
-            {
-              "id": "BA4001",
-              "name": "ReportPECompilerData",
-              "fullDescription": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "help": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/DotNetCore_win-x64_VS2019_Default.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/DotNetCore_win-x64_VS2019_Default.exe.sarif
@@ -509,32 +509,8 @@
           ]
         },
         {
-          "ruleId": "BA4001",
-          "ruleIndex": 21,
-          "kind": "notApplicable",
-          "level": "none",
-          "message": {
-            "id": "NotApplicable_InvalidMetadata",
-            "arguments": [
-              "DotNetCore_win-x64_VS2019_Default.exe",
-              "ReportPECompilerData",
-              "image is a .NET core native bootstrap exe"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/DotNetCore_win-x64_VS2019_Default.exe",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        {
           "ruleId": "BA5001",
-          "ruleIndex": 22,
+          "ruleIndex": 21,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -558,7 +534,7 @@
         },
         {
           "ruleId": "BA5002",
-          "ruleIndex": 23,
+          "ruleIndex": 22,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -582,7 +558,7 @@
         },
         {
           "ruleId": "BA2001",
-          "ruleIndex": 24,
+          "ruleIndex": 23,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -604,7 +580,7 @@
         },
         {
           "ruleId": "BA2005",
-          "ruleIndex": 25,
+          "ruleIndex": 24,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -626,7 +602,7 @@
         },
         {
           "ruleId": "BA2008",
-          "ruleIndex": 26,
+          "ruleIndex": 25,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -648,7 +624,7 @@
         },
         {
           "ruleId": "BA2009",
-          "ruleIndex": 27,
+          "ruleIndex": 26,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -670,7 +646,7 @@
         },
         {
           "ruleId": "BA2010",
-          "ruleIndex": 28,
+          "ruleIndex": 27,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -692,7 +668,7 @@
         },
         {
           "ruleId": "BA2012",
-          "ruleIndex": 29,
+          "ruleIndex": 28,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -714,7 +690,7 @@
         },
         {
           "ruleId": "BA2015",
-          "ruleIndex": 30,
+          "ruleIndex": 29,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -736,7 +712,7 @@
         },
         {
           "ruleId": "BA2019",
-          "ruleIndex": 31,
+          "ruleIndex": 30,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -758,7 +734,7 @@
         },
         {
           "ruleId": "BA2021",
-          "ruleIndex": 32,
+          "ruleIndex": 31,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -780,7 +756,7 @@
         },
         {
           "ruleId": "BA2022",
-          "ruleIndex": 33,
+          "ruleIndex": 32,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -1341,17 +1317,6 @@
                 }
               },
               "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
-            },
-            {
-              "id": "BA4001",
-              "name": "ReportPECompilerData",
-              "fullDescription": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "help": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Wix_3.11.1_VS2017_Bootstrapper.exe.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/Wix_3.11.1_VS2017_Bootstrapper.exe.sarif
@@ -533,32 +533,8 @@
           ]
         },
         {
-          "ruleId": "BA4001",
-          "ruleIndex": 22,
-          "kind": "notApplicable",
-          "level": "none",
-          "message": {
-            "id": "NotApplicable_InvalidMetadata",
-            "arguments": [
-              "Wix_3.11.1_VS2017_Bootstrapper.exe",
-              "ReportPECompilerData",
-              "image appears to be a WiX bootstrapper application"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///Z:/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Wix_3.11.1_VS2017_Bootstrapper.exe",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        {
           "ruleId": "BA5001",
-          "ruleIndex": 23,
+          "ruleIndex": 22,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -582,7 +558,7 @@
         },
         {
           "ruleId": "BA5002",
-          "ruleIndex": 24,
+          "ruleIndex": 23,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -606,7 +582,7 @@
         },
         {
           "ruleId": "BA2005",
-          "ruleIndex": 25,
+          "ruleIndex": 24,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -628,7 +604,7 @@
         },
         {
           "ruleId": "BA2009",
-          "ruleIndex": 26,
+          "ruleIndex": 25,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -650,7 +626,7 @@
         },
         {
           "ruleId": "BA2010",
-          "ruleIndex": 27,
+          "ruleIndex": 26,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -672,7 +648,7 @@
         },
         {
           "ruleId": "BA2012",
-          "ruleIndex": 28,
+          "ruleIndex": 27,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -694,7 +670,7 @@
         },
         {
           "ruleId": "BA2016",
-          "ruleIndex": 29,
+          "ruleIndex": 28,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -716,7 +692,7 @@
         },
         {
           "ruleId": "BA2018",
-          "ruleIndex": 30,
+          "ruleIndex": 29,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -738,7 +714,7 @@
         },
         {
           "ruleId": "BA2019",
-          "ruleIndex": 31,
+          "ruleIndex": 30,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -760,7 +736,7 @@
         },
         {
           "ruleId": "BA2021",
-          "ruleIndex": 32,
+          "ruleIndex": 31,
           "kind": "pass",
           "level": "none",
           "message": {
@@ -782,7 +758,7 @@
         },
         {
           "ruleId": "BA2022",
-          "ruleIndex": 33,
+          "ruleIndex": 32,
           "kind": "notApplicable",
           "level": "none",
           "message": {
@@ -1374,17 +1350,6 @@
                 }
               },
               "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
-            },
-            {
-              "id": "BA4001",
-              "name": "ReportPECompilerData",
-              "fullDescription": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "help": {
-                "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
-              },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.default_compilation.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.default_compilation.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.default_compilation",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.elf.objectivec.dwarf.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.elf.objectivec.dwarf.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.elf.objectivec.dwarf",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1493,14 +1493,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.execstack",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1469,14 +1469,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.execstack.so.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.execstack.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1470,14 +1470,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.immediate_binding.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.immediate_binding",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1472,14 +1472,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_immediate_binding.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.no_immediate_binding",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.no_stack_protector.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.no_stack_protector",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.noexecstack",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.noexecstack.so.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.noexecstack.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1472,14 +1472,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.non_pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.non_pie_executable.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.non_pie_executable",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.object_file.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.object_file.o.sarif
@@ -733,7 +733,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.object_file.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1599,14 +1599,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.pie_executable.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.pie_executable",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1472,14 +1472,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsro.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsro.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.relocationsro",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsrw.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.relocationsrw.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.relocationsrw",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1470,14 +1470,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.shared_library.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.shared_library.so.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.shared_library.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1472,14 +1472,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.stack_protector",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1471,14 +1471,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/clang.stack_protector.so.sarif
@@ -613,7 +613,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "clang.stack_protector.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1472,14 +1472,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.default_compilation.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.default_compilation.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.default_compilation",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1417,14 +1417,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.execstack",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1438,14 +1438,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.execstack.so.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.execstack.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1439,14 +1439,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.fortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.fortified.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.fortified",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.gsplitdwarf.5.dwo.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.gsplitdwarf.5.dwo.sarif
@@ -757,7 +757,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.gsplitdwarf.5.dwo",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1645,14 +1645,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.gsplitdwarf.5.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.gsplitdwarf.5.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.gsplitdwarf.5",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1466,14 +1466,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.4.o.no-stack-clash-protection.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.4.o.no-stack-clash-protection.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.helloworld.4.o.no-stack-clash-protection",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1417,14 +1417,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.5.o.no-stack-clash-protection.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.5.o.no-stack-clash-protection.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.helloworld.5.o.no-stack-clash-protection",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1418,14 +1418,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.execstack.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.execstack.5.o.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.helloworld.execstack.5.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1416,14 +1416,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.nodwarf.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.nodwarf.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.helloworld.nodwarf",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1443,14 +1443,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.noexecstack.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.helloworld.noexecstack.5.o.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.helloworld.noexecstack.5.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1418,14 +1418,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.immediate_binding.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.immediate_binding",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_fortification_required.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_fortification_required.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.no_fortification_required",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_immediate_binding.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.no_immediate_binding",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.no_stack_protector.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.no_stack_protector",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.noexecstack",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.noexecstack.so.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.noexecstack.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.non_pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.non_pie_executable.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.non_pie_executable",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.objcopy.stripall.addgnudebuglink.dbg.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.objcopy.stripall.addgnudebuglink.dbg.sarif
@@ -757,7 +757,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.objcopy.stripall.addgnudebuglink.dbg",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1645,14 +1645,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.objcopy.stripall.addgnudebuglink.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.objcopy.stripall.addgnudebuglink.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.objcopy.stripall.addgnudebuglink",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1395,14 +1395,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.object_file.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.object_file.o.sarif
@@ -733,7 +733,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.object_file.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1599,14 +1599,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.pie_executable.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.pie_executable",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsro.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsro.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.relocationsro",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsrw.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.relocationsrw.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.relocationsrw",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1439,14 +1439,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.requiredsymbol.4.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.requiredsymbol.4.o.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.requiredsymbol.4.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1417,14 +1417,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.requiredsymbol.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.requiredsymbol.5.o.sarif
@@ -541,7 +541,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.requiredsymbol.5.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1418,14 +1418,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.shared_library.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.shared_library.so.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.shared_library.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.stack_protector",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.stack_protector.so.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.stack_protector.so",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1441,14 +1441,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.unfortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/gcc.unfortified.sarif
@@ -589,7 +589,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "gcc.unfortified",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -1440,14 +1440,14 @@
             },
             {
               "id": "BA4001",
-              "name": "ReportPECompilerData",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/macho.clang-lib.fat.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/macho.clang-lib.fat.o.sarif
@@ -757,7 +757,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "macho.clang-lib.fat.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -830,10 +830,10 @@
           "rules": [
             {
               "id": "BA2001",
+              "name": "LoadImageAboveFourGigabyteAddress",
               "fullDescription": {
                 "text": "64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2001LoadImageAboveFourGigabyteAddress",
               "help": {
                 "text": "64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
               },
@@ -848,17 +848,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "LoadImageAboveFourGigabyteAddress",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2001LoadImageAboveFourGigabyteAddress",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "FourGbCheck"
               }
             },
             {
               "id": "BA2002",
+              "name": "DoNotIncorporateVulnerableDependencies",
               "fullDescription": {
                 "text": "Binaries should not take dependencies on code with known security vulnerabilities."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2002DoNotIncorporateVulnerableDependencies",
               "help": {
                 "text": "Binaries should not take dependencies on code with known security vulnerabilities."
               },
@@ -873,17 +873,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotIncorporateVulnerableDependencies",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2002DoNotIncorporateVulnerableDependencies",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ATLVersionCheck"
               }
             },
             {
               "id": "BA2004",
+              "name": "EnableSecureSourceCodeHashing",
               "fullDescription": {
                 "text": "Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2004EnableSecureSourceCodeHashing",
               "help": {
                 "text": "Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing."
               },
@@ -904,14 +904,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSecureSourceCodeHashing"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2004EnableSecureSourceCodeHashing"
             },
             {
               "id": "BA2005",
+              "name": "DoNotShipVulnerableBinaries",
               "fullDescription": {
                 "text": "Do not ship obsolete libraries for which there are known security vulnerabilities."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2005DoNotShipVulnerableBinaries",
               "help": {
                 "text": "Do not ship obsolete libraries for which there are known security vulnerabilities."
               },
@@ -929,17 +929,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotShipVulnerableBinaries",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2005DoNotShipVulnerableBinaries",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "BinaryVersionsCheck"
               }
             },
             {
               "id": "BA2006",
+              "name": "BuildWithSecureTools",
               "fullDescription": {
                 "text": "Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2006BuildWithSecureTools",
               "help": {
                 "text": "Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks."
               },
@@ -957,17 +957,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "BuildWithSecureTools",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2006BuildWithSecureTools",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "CompilerVersionCheck"
               }
             },
             {
               "id": "BA2007",
+              "name": "EnableCriticalCompilerWarnings",
               "fullDescription": {
                 "text": "Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings",
               "help": {
                 "text": "Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted."
               },
@@ -988,17 +988,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableCriticalCompilerWarnings",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "CompilerWarningsCheck"
               }
             },
             {
               "id": "BA2008",
+              "name": "EnableControlFlowGuard",
               "fullDescription": {
                 "text": "Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard",
               "help": {
                 "text": "Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program."
               },
@@ -1016,17 +1016,17 @@
                   "text": "'{0}' is a kernel mode portable executable compiled for a version of Windows that does not support the control flow guard feature for kernel mode binaries."
                 }
               },
-              "name": "EnableControlFlowGuard",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ControlFlowGuardCheck"
               }
             },
             {
               "id": "BA2009",
+              "name": "EnableAddressSpaceLayoutRandomization",
               "fullDescription": {
                 "text": "Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2009EnableAddressSpaceLayoutRandomization",
               "help": {
                 "text": "Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later."
               },
@@ -1047,17 +1047,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableAddressSpaceLayoutRandomization",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2009EnableAddressSpaceLayoutRandomization",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "DBCheck"
               }
             },
             {
               "id": "BA2010",
+              "name": "DoNotMarkImportsSectionAsExecutable",
               "fullDescription": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2010DoNotMarkImportsSectionAsExecutable",
               "help": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
               },
@@ -1072,17 +1072,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkImportsSectionAsExecutable",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2010DoNotMarkImportsSectionAsExecutable",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ExecutableImportsCheck"
               }
             },
             {
               "id": "BA2011",
+              "name": "EnableStackProtection",
               "fullDescription": {
                 "text": "Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2011EnableStackProtection",
               "help": {
                 "text": "Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line."
               },
@@ -1100,17 +1100,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackProtection",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2011EnableStackProtection",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSCheck"
               }
             },
             {
               "id": "BA2012",
+              "name": "DoNotModifyStackProtectionCookie",
               "fullDescription": {
                 "text": "Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2012DoNotModifyStackProtectionCookie",
               "help": {
                 "text": "Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement."
               },
@@ -1134,17 +1134,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotModifyStackProtectionCookie",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2012DoNotModifyStackProtectionCookie",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "DefaultGSCookieCheck"
               }
             },
             {
               "id": "BA2013",
+              "name": "InitializeStackProtection",
               "fullDescription": {
                 "text": "Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2013InitializeStackProtection",
               "help": {
                 "text": "Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
               },
@@ -1165,17 +1165,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "InitializeStackProtection",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2013InitializeStackProtection",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSFriendlyInitCheck"
               }
             },
             {
               "id": "BA2014",
+              "name": "DoNotDisableStackProtectionForFunctions",
               "fullDescription": {
                 "text": "Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2014DoNotDisableStackProtectionForFunctions",
               "help": {
                 "text": "Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
               },
@@ -1190,17 +1190,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotDisableStackProtectionForFunctions",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2014DoNotDisableStackProtectionForFunctions",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSFunctionSafeBuffersCheck"
               }
             },
             {
               "id": "BA2015",
+              "name": "EnableHighEntropyVirtualAddresses",
               "fullDescription": {
                 "text": "Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2015EnableHighEntropyVirtualAddresses",
               "help": {
                 "text": "Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR."
               },
@@ -1221,17 +1221,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableHighEntropyVirtualAddresses",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2015EnableHighEntropyVirtualAddresses",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "HighEntropyVACheck"
               }
             },
             {
               "id": "BA2016",
+              "name": "MarkImageAsNXCompatible",
               "fullDescription": {
                 "text": "Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2016MarkImageAsNXCompatible",
               "help": {
                 "text": "Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
               },
@@ -1246,17 +1246,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "MarkImageAsNXCompatible",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2016MarkImageAsNXCompatible",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "NXCheck"
               }
             },
             {
               "id": "BA2018",
+              "name": "EnableSafeSEH",
               "fullDescription": {
                 "text": "X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2018EnableSafeSEH",
               "help": {
                 "text": "X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
               },
@@ -1274,17 +1274,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSafeSEH",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2018EnableSafeSEH",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "SafeSEHCheck"
               }
             },
             {
               "id": "BA2019",
+              "name": "DoNotMarkWritableSectionsAsShared",
               "fullDescription": {
                 "text": "Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2019DoNotMarkWritableSectionsAsShared",
               "help": {
                 "text": "Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
               },
@@ -1299,17 +1299,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkWritableSectionsAsShared",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2019DoNotMarkWritableSectionsAsShared",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "SharedSectionCheck"
               }
             },
             {
               "id": "BA2021",
+              "name": "DoNotMarkWritableSectionsAsExecutable",
               "fullDescription": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2021DoNotMarkWritableSectionsAsExecutable",
               "help": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function."
               },
@@ -1327,17 +1327,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkWritableSectionsAsExecutable",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2021DoNotMarkWritableSectionsAsExecutable",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "WXCheck"
               }
             },
             {
               "id": "BA2022",
+              "name": "SignSecurely",
               "fullDescription": {
                 "text": "Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2022SignSecurely",
               "help": {
                 "text": "Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds."
               },
@@ -1358,14 +1358,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "SignSecurely"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2022SignSecurely"
             },
             {
               "id": "BA2024",
+              "name": "EnableSpectreMitigations",
               "fullDescription": {
                 "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations",
               "help": {
                 "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
               },
@@ -1389,14 +1389,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSpectreMitigations"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations"
             },
             {
               "id": "BA2025",
+              "name": "EnableShadowStack",
               "fullDescription": {
                 "text": "Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack",
               "help": {
                 "text": "Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks."
               },
@@ -1411,14 +1411,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableShadowStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack"
             },
             {
               "id": "BA2026",
+              "name": "EnableAdditionalSdlSecurityChecks",
               "fullDescription": {
                 "text": "/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2026EnableAdditionalSdlSecurityChecks",
               "help": {
                 "text": "/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks."
               },
@@ -1433,14 +1433,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableAdditionalSdlSecurityChecks"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2026EnableAdditionalSdlSecurityChecks"
             },
             {
               "id": "BA3001",
+              "name": "EnablePositionIndependentExecutable",
               "fullDescription": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3001EnablePositionIndependentExecutable",
               "help": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
@@ -1458,14 +1458,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnablePositionIndependentExecutable"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3001EnablePositionIndependentExecutable"
             },
             {
               "id": "BA3002",
+              "name": "DoNotMarkStackAsExecutable",
               "fullDescription": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure you are compiling with '-z noexecstack' to mark the stack as non-executable."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3002DoNotMarkStackAsExecutable",
               "help": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure you are compiling with '-z noexecstack' to mark the stack as non-executable."
               },
@@ -1483,14 +1483,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkStackAsExecutable"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3002DoNotMarkStackAsExecutable"
             },
             {
               "id": "BA3003",
+              "name": "EnableStackProtector",
               "fullDescription": {
                 "text": "The stack protector ensures that all functions that use buffers over a certain size will use a stack cookie (and check it) to prevent stack based buffer overflows, exiting if stack smashing is detected. Use '--fstack-protector-strong' (all buffers of 4 bytes or more) or '--fstack-protector-all' (all functions) to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3003EnableStackProtector",
               "help": {
                 "text": "The stack protector ensures that all functions that use buffers over a certain size will use a stack cookie (and check it) to prevent stack based buffer overflows, exiting if stack smashing is detected. Use '--fstack-protector-strong' (all buffers of 4 bytes or more) or '--fstack-protector-all' (all functions) to enable this."
               },
@@ -1505,14 +1505,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackProtector"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3003EnableStackProtector"
             },
             {
               "id": "BA3004",
+              "name": "GenerateRequiredSymbolFormat",
               "fullDescription": {
                 "text": "This check ensures that debugging dwarf version used is 5. The dwarf version 5 contains more information and should be used. Use the compiler flags '-gdwarf-5' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3004GenerateRequiredSymbolFormat",
               "help": {
                 "text": "This check ensures that debugging dwarf version used is 5. The dwarf version 5 contains more information and should be used. Use the compiler flags '-gdwarf-5' to enable this."
               },
@@ -1527,14 +1527,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "GenerateRequiredSymbolFormat"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3004GenerateRequiredSymbolFormat"
             },
             {
               "id": "BA3005",
+              "name": "EnableStackClashProtection",
               "fullDescription": {
                 "text": "This check ensures that stack clash protection is enabled. Each program running on a computer uses a special memory region called the stack. This memory region is special because it grows automatically when the program needs more stack memory. But if it grows too much and gets too close to another memory region, the program may confuse the stack with the other memory region. An attacker can exploit this confusion to overwrite the stack with the other memory region, or the other way around. Use the compiler flags '-fstack-clash-protection' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3005EnableStackClashProtection",
               "help": {
                 "text": "This check ensures that stack clash protection is enabled. Each program running on a computer uses a special memory region called the stack. This memory region is special because it grows automatically when the program needs more stack memory. But if it grows too much and gets too close to another memory region, the program may confuse the stack with the other memory region. An attacker can exploit this confusion to overwrite the stack with the other memory region, or the other way around. Use the compiler flags '-fstack-clash-protection' to enable this."
               },
@@ -1549,14 +1549,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackClashProtection"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3005EnableStackClashProtection"
             },
             {
               "id": "BA3006",
+              "name": "EnableNonExecutableStack",
               "fullDescription": {
                 "text": "This check ensures that non-executable stack is enabled. A common type of exploit is the stack buffer overflow. An application receives, from an attacker, more data than it is prepared for and stores this information on its stack, writing beyond the space reserved for it. This can be designed to cause execution of the data written on the stack. One mechanism to mitigate this vulnerability is for the system to not allow the execution of instructions in sections of memory identified as part of the stack. Use the compiler flags '-z noexecstack' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3006EnableNonExecutableStack",
               "help": {
                 "text": "This check ensures that non-executable stack is enabled. A common type of exploit is the stack buffer overflow. An application receives, from an attacker, more data than it is prepared for and stores this information on its stack, writing beyond the space reserved for it. This can be designed to cause execution of the data written on the stack. One mechanism to mitigate this vulnerability is for the system to not allow the execution of instructions in sections of memory identified as part of the stack. Use the compiler flags '-z noexecstack' to enable this."
               },
@@ -1571,14 +1571,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableNonExecutableStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3006EnableNonExecutableStack"
             },
             {
               "id": "BA3010",
+              "name": "EnableReadOnlyRelocations",
               "fullDescription": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,relro' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3010EnableReadOnlyRelocations",
               "help": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,relro' to enable this."
               },
@@ -1593,14 +1593,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableReadOnlyRelocations"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3010EnableReadOnlyRelocations"
             },
             {
               "id": "BA3011",
+              "name": "EnableBindNow",
               "fullDescription": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,now' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3011EnableBindNow",
               "help": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,now' to enable this."
               },
@@ -1615,14 +1615,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableBindNow"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3011EnableBindNow"
             },
             {
               "id": "BA3030",
+              "name": "UseCheckedFunctionsWithGcc",
               "fullDescription": {
                 "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc",
               "help": {
                 "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
               },
@@ -1643,25 +1643,25 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "UseCheckedFunctionsWithGcc"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
             },
             {
               "id": "BA4001",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData",
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "name": "ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",
+              "name": "EnablePositionIndependentExecutableMachO",
               "fullDescription": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5001EnablePositionIndependentExecutableMachO",
               "help": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
@@ -1676,14 +1676,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnablePositionIndependentExecutableMachO"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5001EnablePositionIndependentExecutableMachO"
             },
             {
               "id": "BA5002",
+              "name": "DoNotAllowExecutableStack",
               "fullDescription": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure do not enable flag \"--allow_stack_execute\"."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5002DoNotAllowExecutableStack",
               "help": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure do not enable flag \"--allow_stack_execute\"."
               },
@@ -1698,7 +1698,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotAllowExecutableStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5002DoNotAllowExecutableStack"
             }
           ]
         }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/macho.clang_exe.pie.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/macho.clang_exe.pie.sarif
@@ -757,7 +757,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "macho.clang_exe.pie",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -826,10 +826,10 @@
           "rules": [
             {
               "id": "BA2001",
+              "name": "LoadImageAboveFourGigabyteAddress",
               "fullDescription": {
                 "text": "64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2001LoadImageAboveFourGigabyteAddress",
               "help": {
                 "text": "64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
               },
@@ -844,17 +844,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "LoadImageAboveFourGigabyteAddress",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2001LoadImageAboveFourGigabyteAddress",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "FourGbCheck"
               }
             },
             {
               "id": "BA2002",
+              "name": "DoNotIncorporateVulnerableDependencies",
               "fullDescription": {
                 "text": "Binaries should not take dependencies on code with known security vulnerabilities."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2002DoNotIncorporateVulnerableDependencies",
               "help": {
                 "text": "Binaries should not take dependencies on code with known security vulnerabilities."
               },
@@ -869,17 +869,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotIncorporateVulnerableDependencies",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2002DoNotIncorporateVulnerableDependencies",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ATLVersionCheck"
               }
             },
             {
               "id": "BA2004",
+              "name": "EnableSecureSourceCodeHashing",
               "fullDescription": {
                 "text": "Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2004EnableSecureSourceCodeHashing",
               "help": {
                 "text": "Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing."
               },
@@ -900,14 +900,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSecureSourceCodeHashing"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2004EnableSecureSourceCodeHashing"
             },
             {
               "id": "BA2005",
+              "name": "DoNotShipVulnerableBinaries",
               "fullDescription": {
                 "text": "Do not ship obsolete libraries for which there are known security vulnerabilities."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2005DoNotShipVulnerableBinaries",
               "help": {
                 "text": "Do not ship obsolete libraries for which there are known security vulnerabilities."
               },
@@ -925,17 +925,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotShipVulnerableBinaries",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2005DoNotShipVulnerableBinaries",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "BinaryVersionsCheck"
               }
             },
             {
               "id": "BA2006",
+              "name": "BuildWithSecureTools",
               "fullDescription": {
                 "text": "Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2006BuildWithSecureTools",
               "help": {
                 "text": "Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks."
               },
@@ -953,17 +953,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "BuildWithSecureTools",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2006BuildWithSecureTools",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "CompilerVersionCheck"
               }
             },
             {
               "id": "BA2007",
+              "name": "EnableCriticalCompilerWarnings",
               "fullDescription": {
                 "text": "Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings",
               "help": {
                 "text": "Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted."
               },
@@ -984,17 +984,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableCriticalCompilerWarnings",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "CompilerWarningsCheck"
               }
             },
             {
               "id": "BA2008",
+              "name": "EnableControlFlowGuard",
               "fullDescription": {
                 "text": "Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard",
               "help": {
                 "text": "Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program."
               },
@@ -1012,17 +1012,17 @@
                   "text": "'{0}' is a kernel mode portable executable compiled for a version of Windows that does not support the control flow guard feature for kernel mode binaries."
                 }
               },
-              "name": "EnableControlFlowGuard",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ControlFlowGuardCheck"
               }
             },
             {
               "id": "BA2009",
+              "name": "EnableAddressSpaceLayoutRandomization",
               "fullDescription": {
                 "text": "Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2009EnableAddressSpaceLayoutRandomization",
               "help": {
                 "text": "Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later."
               },
@@ -1043,17 +1043,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableAddressSpaceLayoutRandomization",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2009EnableAddressSpaceLayoutRandomization",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "DBCheck"
               }
             },
             {
               "id": "BA2010",
+              "name": "DoNotMarkImportsSectionAsExecutable",
               "fullDescription": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2010DoNotMarkImportsSectionAsExecutable",
               "help": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
               },
@@ -1068,17 +1068,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkImportsSectionAsExecutable",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2010DoNotMarkImportsSectionAsExecutable",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ExecutableImportsCheck"
               }
             },
             {
               "id": "BA2011",
+              "name": "EnableStackProtection",
               "fullDescription": {
                 "text": "Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2011EnableStackProtection",
               "help": {
                 "text": "Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line."
               },
@@ -1096,17 +1096,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackProtection",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2011EnableStackProtection",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSCheck"
               }
             },
             {
               "id": "BA2012",
+              "name": "DoNotModifyStackProtectionCookie",
               "fullDescription": {
                 "text": "Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2012DoNotModifyStackProtectionCookie",
               "help": {
                 "text": "Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement."
               },
@@ -1130,17 +1130,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotModifyStackProtectionCookie",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2012DoNotModifyStackProtectionCookie",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "DefaultGSCookieCheck"
               }
             },
             {
               "id": "BA2013",
+              "name": "InitializeStackProtection",
               "fullDescription": {
                 "text": "Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2013InitializeStackProtection",
               "help": {
                 "text": "Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
               },
@@ -1161,17 +1161,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "InitializeStackProtection",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2013InitializeStackProtection",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSFriendlyInitCheck"
               }
             },
             {
               "id": "BA2014",
+              "name": "DoNotDisableStackProtectionForFunctions",
               "fullDescription": {
                 "text": "Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2014DoNotDisableStackProtectionForFunctions",
               "help": {
                 "text": "Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
               },
@@ -1186,17 +1186,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotDisableStackProtectionForFunctions",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2014DoNotDisableStackProtectionForFunctions",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSFunctionSafeBuffersCheck"
               }
             },
             {
               "id": "BA2015",
+              "name": "EnableHighEntropyVirtualAddresses",
               "fullDescription": {
                 "text": "Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2015EnableHighEntropyVirtualAddresses",
               "help": {
                 "text": "Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR."
               },
@@ -1217,17 +1217,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableHighEntropyVirtualAddresses",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2015EnableHighEntropyVirtualAddresses",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "HighEntropyVACheck"
               }
             },
             {
               "id": "BA2016",
+              "name": "MarkImageAsNXCompatible",
               "fullDescription": {
                 "text": "Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2016MarkImageAsNXCompatible",
               "help": {
                 "text": "Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
               },
@@ -1242,17 +1242,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "MarkImageAsNXCompatible",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2016MarkImageAsNXCompatible",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "NXCheck"
               }
             },
             {
               "id": "BA2018",
+              "name": "EnableSafeSEH",
               "fullDescription": {
                 "text": "X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2018EnableSafeSEH",
               "help": {
                 "text": "X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
               },
@@ -1270,17 +1270,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSafeSEH",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2018EnableSafeSEH",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "SafeSEHCheck"
               }
             },
             {
               "id": "BA2019",
+              "name": "DoNotMarkWritableSectionsAsShared",
               "fullDescription": {
                 "text": "Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2019DoNotMarkWritableSectionsAsShared",
               "help": {
                 "text": "Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
               },
@@ -1295,17 +1295,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkWritableSectionsAsShared",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2019DoNotMarkWritableSectionsAsShared",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "SharedSectionCheck"
               }
             },
             {
               "id": "BA2021",
+              "name": "DoNotMarkWritableSectionsAsExecutable",
               "fullDescription": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2021DoNotMarkWritableSectionsAsExecutable",
               "help": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function."
               },
@@ -1323,17 +1323,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkWritableSectionsAsExecutable",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2021DoNotMarkWritableSectionsAsExecutable",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "WXCheck"
               }
             },
             {
               "id": "BA2022",
+              "name": "SignSecurely",
               "fullDescription": {
                 "text": "Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2022SignSecurely",
               "help": {
                 "text": "Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds."
               },
@@ -1354,14 +1354,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "SignSecurely"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2022SignSecurely"
             },
             {
               "id": "BA2024",
+              "name": "EnableSpectreMitigations",
               "fullDescription": {
                 "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations",
               "help": {
                 "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
               },
@@ -1385,14 +1385,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSpectreMitigations"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations"
             },
             {
               "id": "BA2025",
+              "name": "EnableShadowStack",
               "fullDescription": {
                 "text": "Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack",
               "help": {
                 "text": "Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks."
               },
@@ -1407,14 +1407,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableShadowStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack"
             },
             {
               "id": "BA2026",
+              "name": "EnableAdditionalSdlSecurityChecks",
               "fullDescription": {
                 "text": "/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2026EnableAdditionalSdlSecurityChecks",
               "help": {
                 "text": "/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks."
               },
@@ -1429,14 +1429,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableAdditionalSdlSecurityChecks"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2026EnableAdditionalSdlSecurityChecks"
             },
             {
               "id": "BA3001",
+              "name": "EnablePositionIndependentExecutable",
               "fullDescription": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3001EnablePositionIndependentExecutable",
               "help": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
@@ -1454,14 +1454,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnablePositionIndependentExecutable"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3001EnablePositionIndependentExecutable"
             },
             {
               "id": "BA3002",
+              "name": "DoNotMarkStackAsExecutable",
               "fullDescription": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure you are compiling with '-z noexecstack' to mark the stack as non-executable."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3002DoNotMarkStackAsExecutable",
               "help": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure you are compiling with '-z noexecstack' to mark the stack as non-executable."
               },
@@ -1479,14 +1479,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkStackAsExecutable"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3002DoNotMarkStackAsExecutable"
             },
             {
               "id": "BA3003",
+              "name": "EnableStackProtector",
               "fullDescription": {
                 "text": "The stack protector ensures that all functions that use buffers over a certain size will use a stack cookie (and check it) to prevent stack based buffer overflows, exiting if stack smashing is detected. Use '--fstack-protector-strong' (all buffers of 4 bytes or more) or '--fstack-protector-all' (all functions) to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3003EnableStackProtector",
               "help": {
                 "text": "The stack protector ensures that all functions that use buffers over a certain size will use a stack cookie (and check it) to prevent stack based buffer overflows, exiting if stack smashing is detected. Use '--fstack-protector-strong' (all buffers of 4 bytes or more) or '--fstack-protector-all' (all functions) to enable this."
               },
@@ -1501,14 +1501,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackProtector"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3003EnableStackProtector"
             },
             {
               "id": "BA3004",
+              "name": "GenerateRequiredSymbolFormat",
               "fullDescription": {
                 "text": "This check ensures that debugging dwarf version used is 5. The dwarf version 5 contains more information and should be used. Use the compiler flags '-gdwarf-5' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3004GenerateRequiredSymbolFormat",
               "help": {
                 "text": "This check ensures that debugging dwarf version used is 5. The dwarf version 5 contains more information and should be used. Use the compiler flags '-gdwarf-5' to enable this."
               },
@@ -1523,14 +1523,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "GenerateRequiredSymbolFormat"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3004GenerateRequiredSymbolFormat"
             },
             {
               "id": "BA3005",
+              "name": "EnableStackClashProtection",
               "fullDescription": {
                 "text": "This check ensures that stack clash protection is enabled. Each program running on a computer uses a special memory region called the stack. This memory region is special because it grows automatically when the program needs more stack memory. But if it grows too much and gets too close to another memory region, the program may confuse the stack with the other memory region. An attacker can exploit this confusion to overwrite the stack with the other memory region, or the other way around. Use the compiler flags '-fstack-clash-protection' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3005EnableStackClashProtection",
               "help": {
                 "text": "This check ensures that stack clash protection is enabled. Each program running on a computer uses a special memory region called the stack. This memory region is special because it grows automatically when the program needs more stack memory. But if it grows too much and gets too close to another memory region, the program may confuse the stack with the other memory region. An attacker can exploit this confusion to overwrite the stack with the other memory region, or the other way around. Use the compiler flags '-fstack-clash-protection' to enable this."
               },
@@ -1545,14 +1545,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackClashProtection"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3005EnableStackClashProtection"
             },
             {
               "id": "BA3006",
+              "name": "EnableNonExecutableStack",
               "fullDescription": {
                 "text": "This check ensures that non-executable stack is enabled. A common type of exploit is the stack buffer overflow. An application receives, from an attacker, more data than it is prepared for and stores this information on its stack, writing beyond the space reserved for it. This can be designed to cause execution of the data written on the stack. One mechanism to mitigate this vulnerability is for the system to not allow the execution of instructions in sections of memory identified as part of the stack. Use the compiler flags '-z noexecstack' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3006EnableNonExecutableStack",
               "help": {
                 "text": "This check ensures that non-executable stack is enabled. A common type of exploit is the stack buffer overflow. An application receives, from an attacker, more data than it is prepared for and stores this information on its stack, writing beyond the space reserved for it. This can be designed to cause execution of the data written on the stack. One mechanism to mitigate this vulnerability is for the system to not allow the execution of instructions in sections of memory identified as part of the stack. Use the compiler flags '-z noexecstack' to enable this."
               },
@@ -1567,14 +1567,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableNonExecutableStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3006EnableNonExecutableStack"
             },
             {
               "id": "BA3010",
+              "name": "EnableReadOnlyRelocations",
               "fullDescription": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,relro' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3010EnableReadOnlyRelocations",
               "help": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,relro' to enable this."
               },
@@ -1589,14 +1589,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableReadOnlyRelocations"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3010EnableReadOnlyRelocations"
             },
             {
               "id": "BA3011",
+              "name": "EnableBindNow",
               "fullDescription": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,now' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3011EnableBindNow",
               "help": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,now' to enable this."
               },
@@ -1611,14 +1611,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableBindNow"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3011EnableBindNow"
             },
             {
               "id": "BA3030",
+              "name": "UseCheckedFunctionsWithGcc",
               "fullDescription": {
                 "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc",
               "help": {
                 "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
               },
@@ -1639,25 +1639,25 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "UseCheckedFunctionsWithGcc"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
             },
             {
               "id": "BA4001",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData",
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "name": "ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5001",
+              "name": "EnablePositionIndependentExecutableMachO",
               "fullDescription": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5001EnablePositionIndependentExecutableMachO",
               "help": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
@@ -1672,14 +1672,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnablePositionIndependentExecutableMachO"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5001EnablePositionIndependentExecutableMachO"
             },
             {
               "id": "BA5002",
+              "name": "DoNotAllowExecutableStack",
               "fullDescription": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure do not enable flag \"--allow_stack_execute\"."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5002DoNotAllowExecutableStack",
               "help": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure do not enable flag \"--allow_stack_execute\"."
               },
@@ -1694,7 +1694,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotAllowExecutableStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5002DoNotAllowExecutableStack"
             }
           ]
         }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/macho.gcc-lib.nostackclashprotect.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestsData/Expected/macho.gcc-lib.nostackclashprotect.o.sarif
@@ -709,7 +709,7 @@
             "id": "NotApplicable_InvalidMetadata",
             "arguments": [
               "macho.gcc-lib.nostackclashprotect.o",
-              "ReportPECompilerData",
+              "ReportPortableExecutableCompilerData",
               "image is not a PE binary"
             ]
           },
@@ -824,10 +824,10 @@
           "rules": [
             {
               "id": "BA2001",
+              "name": "LoadImageAboveFourGigabyteAddress",
               "fullDescription": {
                 "text": "64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2001LoadImageAboveFourGigabyteAddress",
               "help": {
                 "text": "64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries."
               },
@@ -842,17 +842,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "LoadImageAboveFourGigabyteAddress",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2001LoadImageAboveFourGigabyteAddress",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "FourGbCheck"
               }
             },
             {
               "id": "BA2002",
+              "name": "DoNotIncorporateVulnerableDependencies",
               "fullDescription": {
                 "text": "Binaries should not take dependencies on code with known security vulnerabilities."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2002DoNotIncorporateVulnerableDependencies",
               "help": {
                 "text": "Binaries should not take dependencies on code with known security vulnerabilities."
               },
@@ -867,17 +867,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotIncorporateVulnerableDependencies",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2002DoNotIncorporateVulnerableDependencies",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ATLVersionCheck"
               }
             },
             {
               "id": "BA2004",
+              "name": "EnableSecureSourceCodeHashing",
               "fullDescription": {
                 "text": "Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2004EnableSecureSourceCodeHashing",
               "help": {
                 "text": "Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing."
               },
@@ -898,14 +898,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSecureSourceCodeHashing"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2004EnableSecureSourceCodeHashing"
             },
             {
               "id": "BA2005",
+              "name": "DoNotShipVulnerableBinaries",
               "fullDescription": {
                 "text": "Do not ship obsolete libraries for which there are known security vulnerabilities."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2005DoNotShipVulnerableBinaries",
               "help": {
                 "text": "Do not ship obsolete libraries for which there are known security vulnerabilities."
               },
@@ -923,17 +923,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotShipVulnerableBinaries",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2005DoNotShipVulnerableBinaries",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "BinaryVersionsCheck"
               }
             },
             {
               "id": "BA2006",
+              "name": "BuildWithSecureTools",
               "fullDescription": {
                 "text": "Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2006BuildWithSecureTools",
               "help": {
                 "text": "Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks."
               },
@@ -951,17 +951,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "BuildWithSecureTools",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2006BuildWithSecureTools",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "CompilerVersionCheck"
               }
             },
             {
               "id": "BA2007",
+              "name": "EnableCriticalCompilerWarnings",
               "fullDescription": {
                 "text": "Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings",
               "help": {
                 "text": "Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted."
               },
@@ -982,17 +982,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableCriticalCompilerWarnings",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2007EnableCriticalCompilerWarnings",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "CompilerWarningsCheck"
               }
             },
             {
               "id": "BA2008",
+              "name": "EnableControlFlowGuard",
               "fullDescription": {
                 "text": "Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard",
               "help": {
                 "text": "Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program."
               },
@@ -1010,17 +1010,17 @@
                   "text": "'{0}' is a kernel mode portable executable compiled for a version of Windows that does not support the control flow guard feature for kernel mode binaries."
                 }
               },
-              "name": "EnableControlFlowGuard",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ControlFlowGuardCheck"
               }
             },
             {
               "id": "BA2009",
+              "name": "EnableAddressSpaceLayoutRandomization",
               "fullDescription": {
                 "text": "Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2009EnableAddressSpaceLayoutRandomization",
               "help": {
                 "text": "Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later."
               },
@@ -1041,17 +1041,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableAddressSpaceLayoutRandomization",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2009EnableAddressSpaceLayoutRandomization",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "DBCheck"
               }
             },
             {
               "id": "BA2010",
+              "name": "DoNotMarkImportsSectionAsExecutable",
               "fullDescription": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2010DoNotMarkImportsSectionAsExecutable",
               "help": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the \".rdata\" segment into an executable section."
               },
@@ -1066,17 +1066,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkImportsSectionAsExecutable",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2010DoNotMarkImportsSectionAsExecutable",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "ExecutableImportsCheck"
               }
             },
             {
               "id": "BA2011",
+              "name": "EnableStackProtection",
               "fullDescription": {
                 "text": "Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2011EnableStackProtection",
               "help": {
                 "text": "Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line."
               },
@@ -1094,17 +1094,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackProtection",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2011EnableStackProtection",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSCheck"
               }
             },
             {
               "id": "BA2012",
+              "name": "DoNotModifyStackProtectionCookie",
               "fullDescription": {
                 "text": "Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2012DoNotModifyStackProtectionCookie",
               "help": {
                 "text": "Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the \"security cookie\", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement."
               },
@@ -1128,17 +1128,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotModifyStackProtectionCookie",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2012DoNotModifyStackProtectionCookie",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "DefaultGSCookieCheck"
               }
             },
             {
               "id": "BA2013",
+              "name": "InitializeStackProtection",
               "fullDescription": {
                 "text": "Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2013InitializeStackProtection",
               "help": {
                 "text": "Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point."
               },
@@ -1159,17 +1159,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "InitializeStackProtection",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2013InitializeStackProtection",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSFriendlyInitCheck"
               }
             },
             {
               "id": "BA2014",
+              "name": "DoNotDisableStackProtectionForFunctions",
               "fullDescription": {
                 "text": "Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2014DoNotDisableStackProtectionForFunctions",
               "help": {
                 "text": "Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether."
               },
@@ -1184,17 +1184,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotDisableStackProtectionForFunctions",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2014DoNotDisableStackProtectionForFunctions",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "GSFunctionSafeBuffersCheck"
               }
             },
             {
               "id": "BA2015",
+              "name": "EnableHighEntropyVirtualAddresses",
               "fullDescription": {
                 "text": "Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2015EnableHighEntropyVirtualAddresses",
               "help": {
                 "text": "Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR."
               },
@@ -1215,17 +1215,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableHighEntropyVirtualAddresses",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2015EnableHighEntropyVirtualAddresses",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "HighEntropyVACheck"
               }
             },
             {
               "id": "BA2016",
+              "name": "MarkImageAsNXCompatible",
               "fullDescription": {
                 "text": "Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2016MarkImageAsNXCompatible",
               "help": {
                 "text": "Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as \"Data Execution Prevention\" (DEP) or \"Execute Disable\" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker."
               },
@@ -1240,17 +1240,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "MarkImageAsNXCompatible",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2016MarkImageAsNXCompatible",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "NXCheck"
               }
             },
             {
               "id": "BA2018",
+              "name": "EnableSafeSEH",
               "fullDescription": {
                 "text": "X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2018EnableSafeSEH",
               "help": {
                 "text": "X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64."
               },
@@ -1268,17 +1268,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSafeSEH",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2018EnableSafeSEH",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "SafeSEHCheck"
               }
             },
             {
               "id": "BA2019",
+              "name": "DoNotMarkWritableSectionsAsShared",
               "fullDescription": {
                 "text": "Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2019DoNotMarkWritableSectionsAsShared",
               "help": {
                 "text": "Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.)."
               },
@@ -1293,17 +1293,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkWritableSectionsAsShared",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2019DoNotMarkWritableSectionsAsShared",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "SharedSectionCheck"
               }
             },
             {
               "id": "BA2021",
+              "name": "DoNotMarkWritableSectionsAsExecutable",
               "fullDescription": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2021DoNotMarkWritableSectionsAsExecutable",
               "help": {
                 "text": "PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function."
               },
@@ -1321,17 +1321,17 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkWritableSectionsAsExecutable",
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2021DoNotMarkWritableSectionsAsExecutable",
               "properties": {
                 "equivalentBinScopeRuleReadableName": "WXCheck"
               }
             },
             {
               "id": "BA2022",
+              "name": "SignSecurely",
               "fullDescription": {
                 "text": "Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2022SignSecurely",
               "help": {
                 "text": "Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds."
               },
@@ -1352,14 +1352,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "SignSecurely"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2022SignSecurely"
             },
             {
               "id": "BA2024",
+              "name": "EnableSpectreMitigations",
               "fullDescription": {
                 "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations",
               "help": {
                 "text": "Application code should be compiled with the Spectre mitigations switch (/Qspectre) and toolsets that support it."
               },
@@ -1383,14 +1383,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableSpectreMitigations"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2024EnableSpectreMitigations"
             },
             {
               "id": "BA2025",
+              "name": "EnableShadowStack",
               "fullDescription": {
                 "text": "Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack",
               "help": {
                 "text": "Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks."
               },
@@ -1405,14 +1405,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableShadowStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack"
             },
             {
               "id": "BA2026",
+              "name": "EnableAdditionalSdlSecurityChecks",
               "fullDescription": {
                 "text": "/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2026EnableAdditionalSdlSecurityChecks",
               "help": {
                 "text": "/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks."
               },
@@ -1427,14 +1427,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableAdditionalSdlSecurityChecks"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2026EnableAdditionalSdlSecurityChecks"
             },
             {
               "id": "BA3001",
+              "name": "EnablePositionIndependentExecutable",
               "fullDescription": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3001EnablePositionIndependentExecutable",
               "help": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
@@ -1452,14 +1452,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnablePositionIndependentExecutable"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3001EnablePositionIndependentExecutable"
             },
             {
               "id": "BA3002",
+              "name": "DoNotMarkStackAsExecutable",
               "fullDescription": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure you are compiling with '-z noexecstack' to mark the stack as non-executable."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3002DoNotMarkStackAsExecutable",
               "help": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure you are compiling with '-z noexecstack' to mark the stack as non-executable."
               },
@@ -1477,14 +1477,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotMarkStackAsExecutable"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3002DoNotMarkStackAsExecutable"
             },
             {
               "id": "BA3004",
+              "name": "GenerateRequiredSymbolFormat",
               "fullDescription": {
                 "text": "This check ensures that debugging dwarf version used is 5. The dwarf version 5 contains more information and should be used. Use the compiler flags '-gdwarf-5' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3004GenerateRequiredSymbolFormat",
               "help": {
                 "text": "This check ensures that debugging dwarf version used is 5. The dwarf version 5 contains more information and should be used. Use the compiler flags '-gdwarf-5' to enable this."
               },
@@ -1499,14 +1499,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "GenerateRequiredSymbolFormat"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3004GenerateRequiredSymbolFormat"
             },
             {
               "id": "BA3006",
+              "name": "EnableNonExecutableStack",
               "fullDescription": {
                 "text": "This check ensures that non-executable stack is enabled. A common type of exploit is the stack buffer overflow. An application receives, from an attacker, more data than it is prepared for and stores this information on its stack, writing beyond the space reserved for it. This can be designed to cause execution of the data written on the stack. One mechanism to mitigate this vulnerability is for the system to not allow the execution of instructions in sections of memory identified as part of the stack. Use the compiler flags '-z noexecstack' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3006EnableNonExecutableStack",
               "help": {
                 "text": "This check ensures that non-executable stack is enabled. A common type of exploit is the stack buffer overflow. An application receives, from an attacker, more data than it is prepared for and stores this information on its stack, writing beyond the space reserved for it. This can be designed to cause execution of the data written on the stack. One mechanism to mitigate this vulnerability is for the system to not allow the execution of instructions in sections of memory identified as part of the stack. Use the compiler flags '-z noexecstack' to enable this."
               },
@@ -1521,14 +1521,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableNonExecutableStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3006EnableNonExecutableStack"
             },
             {
               "id": "BA3010",
+              "name": "EnableReadOnlyRelocations",
               "fullDescription": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,relro' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3010EnableReadOnlyRelocations",
               "help": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,relro' to enable this."
               },
@@ -1543,14 +1543,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableReadOnlyRelocations"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3010EnableReadOnlyRelocations"
             },
             {
               "id": "BA3011",
+              "name": "EnableBindNow",
               "fullDescription": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,now' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3011EnableBindNow",
               "help": {
                 "text": "This check ensures that some relocation data is marked as read only after the executable is loaded, and moved below the '.data' section in memory. This prevents them from being overwritten, which can redirect control flow. Use the compiler flags '-Wl,z,now' to enable this."
               },
@@ -1565,14 +1565,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableBindNow"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3011EnableBindNow"
             },
             {
               "id": "BA3030",
+              "name": "UseCheckedFunctionsWithGcc",
               "fullDescription": {
                 "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc",
               "help": {
                 "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
               },
@@ -1593,25 +1593,25 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "UseCheckedFunctionsWithGcc"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3030UseCheckedFunctionsWithGcc"
             },
             {
               "id": "BA4001",
+              "name": "ReportPortableExecutableCompilerData",
               "fullDescription": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPECompilerData",
               "help": {
                 "text": "This rule emits CSV data to the console for every compiler/language/version combination that's observed in any PDB-linked compiland."
               },
-              "name": "ReportPECompilerData"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA4001ReportPortableExecutableCompilerData"
             },
             {
               "id": "BA5002",
+              "name": "DoNotAllowExecutableStack",
               "fullDescription": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure do not enable flag \"--allow_stack_execute\"."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5002DoNotAllowExecutableStack",
               "help": {
                 "text": "This checks if a binary has an executable stack; an executable stack allows attackers to redirect code flow into stack memory, which is an easy place for an attacker to store shellcode. Ensure do not enable flag \"--allow_stack_execute\"."
               },
@@ -1626,14 +1626,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "DoNotAllowExecutableStack"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5002DoNotAllowExecutableStack"
             },
             {
               "id": "BA3003",
+              "name": "EnableStackProtector",
               "fullDescription": {
                 "text": "The stack protector ensures that all functions that use buffers over a certain size will use a stack cookie (and check it) to prevent stack based buffer overflows, exiting if stack smashing is detected. Use '--fstack-protector-strong' (all buffers of 4 bytes or more) or '--fstack-protector-all' (all functions) to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3003EnableStackProtector",
               "help": {
                 "text": "The stack protector ensures that all functions that use buffers over a certain size will use a stack cookie (and check it) to prevent stack based buffer overflows, exiting if stack smashing is detected. Use '--fstack-protector-strong' (all buffers of 4 bytes or more) or '--fstack-protector-all' (all functions) to enable this."
               },
@@ -1648,14 +1648,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackProtector"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3003EnableStackProtector"
             },
             {
               "id": "BA3005",
+              "name": "EnableStackClashProtection",
               "fullDescription": {
                 "text": "This check ensures that stack clash protection is enabled. Each program running on a computer uses a special memory region called the stack. This memory region is special because it grows automatically when the program needs more stack memory. But if it grows too much and gets too close to another memory region, the program may confuse the stack with the other memory region. An attacker can exploit this confusion to overwrite the stack with the other memory region, or the other way around. Use the compiler flags '-fstack-clash-protection' to enable this."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3005EnableStackClashProtection",
               "help": {
                 "text": "This check ensures that stack clash protection is enabled. Each program running on a computer uses a special memory region called the stack. This memory region is special because it grows automatically when the program needs more stack memory. But if it grows too much and gets too close to another memory region, the program may confuse the stack with the other memory region. An attacker can exploit this confusion to overwrite the stack with the other memory region, or the other way around. Use the compiler flags '-fstack-clash-protection' to enable this."
               },
@@ -1670,14 +1670,14 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnableStackClashProtection"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA3005EnableStackClashProtection"
             },
             {
               "id": "BA5001",
+              "name": "EnablePositionIndependentExecutableMachO",
               "fullDescription": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
-              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5001EnablePositionIndependentExecutableMachO",
               "help": {
                 "text": "A Position Independent Executable (PIE) relocates all of its sections at load time, including the code section, if ASLR is enabled in the Linux kernel (instead of just the stack/heap). This makes ROP-style attacks more difficult. This can be enabled by passing '-f pie' to clang/gcc."
               },
@@ -1692,7 +1692,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}."
                 }
               },
-              "name": "EnablePositionIndependentExecutableMachO"
+              "helpUri": "https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA5001EnablePositionIndependentExecutableMachO"
             }
           ]
         }


### PR DESCRIPTION
# Description

This change will enable us to analyze any PE file.

We discovered this issue in this [PR](https://github.com/microsoft/binskim/pull/552) where we saw valid PEs being skipped for being a managed IL library.

Previously, the rule `BA4001.ReportPortableExecutableCompilerData` was inheriting from `WindowsBinaryAndPdbSkimmerBase`. Looking at the `CanAnalyze`, we can see a few cases where a binary might be rejected (generate the result `NotApplicable`): `IsWixBinary`, `IsILLibrary`, or `IsDotNetCoreBootstrapExe`.

Now, I'm changing its implementation to inherit from `PEBinarySkimmerBase`, which will just check if we have a Portable Executable or not: https://github.com/microsoft/binskim/blob/2ae90725e27667593d6071b74e53609f31130b85/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs#L9-L24