### PR TITLE
BUGFIX: Fix missing item in MinimumToolVersionsMap when user only overwrite part of the settings

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,9 @@
 # BinSkim Release History
 
+## Unreleased
+
+* BUGFIX: Fix ` KeyNotFoundException` raised on `BA2006.BuildWithSecureTools` when required properties are removed from the config file. [#565](https://github.com/microsoft/binskim/pull/565)
+
 ## **v1.9.2** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/1.9.2)
 
 * BUGFIX: Fix `MultithreadedAnalyzeCommandBase` artifacts generation and enforcing JSON properties ordering. [#555](https://github.com/microsoft/binskim/pull/555)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* BUGFIX: Fix ` KeyNotFoundException` raised on `BA2006.BuildWithSecureTools` when required properties are removed from the config file. [#565](https://github.com/microsoft/binskim/pull/565)
+* BUGFIX: Fix `KeyNotFoundException` exception raised by `BA2006.BuildWithSecureTools` when individual `MinimumToolVersions` properties are removed from XML configuration. [#565](https://github.com/microsoft/binskim/pull/565)
 
 ## **v1.9.2** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/1.9.2)
 


### PR DESCRIPTION
# Description:

User reported issue by email:

new issue with Binskim 1.9.2
```
2022-02-10T15:55:59.5540580Z [Standard]   D:\a\_work\1\a\OpenSSH-Win64\sftp.exe : error ERR998.ExceptionInAnalyze : BA2006 : An exception of type 'KeyNotFoundException' was raised analyzing 'sftp.exe' for check 'BuildWithSecureTools' (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target, and not specific to the rule, however.
2022-02-10T15:55:59.5542301Z [Standard]   KeyNotFoundException: The given key 'C' was not present in the dictionary.
2022-02-10T15:55:59.5543351Z [Standard]      at System.Collections.Concurrent.ConcurrentDictionary`2.ThrowKeyNotFoundException(Object key)
2022-02-10T15:55:59.5544773Z [Standard]      at Microsoft.CodeAnalysis.IL.Rules.BuildWithSecureTools.AnalyzePortableExecutableAndPdb(BinaryAnalyzerContext context) in D:\a\r1\a\src\BinSkim.Rules\PERules\BA2006.BuildWithSecureTools.cs:line 86
2022-02-10T15:55:59.5546453Z [Standard]      at Microsoft.CodeAnalysis.IL.Rules.WindowsBinaryAndPdbSkimmerBase.Analyze(BinaryAnalyzerContext context) in D:\a\r1\a\src\BinSkim.Rules\PERules\WindowsBinaryAndPdbSkimmerBase.cs:line 63
2022-02-10T15:55:59.5548328Z [Standard]      at Microsoft.CodeAnalysis.Sarif.Driver.MultithreadedAnalyzeCommandBase`2.AnalyzeTargetHelper(TContext context, IEnumerable`1 skimmers, ISet`1 disabledSkimmers)
```


# Cause:

The issue is user has a config file and in config file:

```
<Properties Key="BA2006.BuildWithSecureTools.Options" Type="PropertiesDictionary">
    <Property Key="AdvancedMitigationsEnforced" Value="None" Type="AdvancedMitigations" />
    <Properties Key="AllowedLibraries" Type="IL.Rules.StringToVersionMap" />
    <Properties Key="MinimumToolVersions" Type="IL.Rules.StringToVersionMap">
      <Property Key="MinimumCompilerVersion" Value="17.0.65501.17013" Type="System.Version" />
      <Property Key="MinimumXboxCompilerVersion" Value="16.0.11886.0" Type="System.Version" />
    </Properties>
    <Property Key="RuleEnabled" Value="Default" Type="Driver.RuleEnabledState" />
  </Properties>
```

The MinimumToolVersions contains only the ones user want to overwrite, but it does not contain all possible settings, current code when read it, will not combine with the other settings that are not overwritten in the config file so we missed them.
e.g
[nameof(Language.C)] = new Version(17, 0, 65501, 17013),
[nameof(Language.Cxx)] = new Version(17, 0, 65501, 17013),
[nameof(Language.Unknown)] = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue),

# Fix:

propose to change the code to make sure the other settings that are not overwritten in the config file, are also added to the dictionary.