### PR TITLE
Fix the EnableSecureSourceCodeHashing description

### DIFF
--- a/docs/BinSkimRules.md
+++ b/docs/BinSkimRules.md
@@ -197,6 +197,8 @@ Binaries should not take dependencies on code with known security vulnerabilitie
 ### Description
 
 Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '<ChecksumAlgorithm>' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing.
+  
+_Note: This error will also result from BinSkim not having access to scan the PDBs._
 
 ### Messages
 


### PR DESCRIPTION
In my case the EnableSecureSourceCodeHashing error was not due to incorrect hashing. This added note would have saved me half a day trying to understand and find the cause:
_Note: This error will also result from BinSkim not having access to scan the PDBs._
