### PR TITLE
CodeQL Fix "This cast is redundant because the expression already has type"

### DIFF
--- a/src/BinaryParsers/ElfBinary/Dwarf/DwarfCompilationUnit.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/DwarfCompilationUnit.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
 
                         case DwarfFormat.Data8:
                             attributeValue.Type = DwarfAttributeValueType.Constant;
-                            attributeValue.Value = (ulong)debugData.ReadUlong();
+                            attributeValue.Value = debugData.ReadUlong();
                             break;
 
                         case DwarfFormat.SData:
@@ -206,27 +206,27 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
 
                         case DwarfFormat.Ref1:
                             attributeValue.Type = DwarfAttributeValueType.Reference;
-                            attributeValue.Value = (ulong)debugData.ReadByte() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.ReadByte() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.Ref2:
                             attributeValue.Type = DwarfAttributeValueType.Reference;
-                            attributeValue.Value = (ulong)debugData.ReadUshort() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.ReadUshort() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.Ref4:
                             attributeValue.Type = DwarfAttributeValueType.Reference;
-                            attributeValue.Value = (ulong)debugData.ReadUint() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.ReadUint() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.Ref8:
                             attributeValue.Type = DwarfAttributeValueType.Reference;
-                            attributeValue.Value = (ulong)debugData.ReadUlong() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.ReadUlong() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.RefUData:
                             attributeValue.Type = DwarfAttributeValueType.Reference;
-                            attributeValue.Value = (ulong)debugData.LEB128() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.LEB128() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.RefAddr:
@@ -255,12 +255,12 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
                         case DwarfFormat.Strx:
                         case DwarfFormat.GNUStrIndex:
                             attributeValue.Type = DwarfAttributeValueType.String;
-                            attributeValue.Value = (ulong)debugData.LEB128() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.LEB128() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.Addrx:
                             attributeValue.Type = DwarfAttributeValueType.String;
-                            attributeValue.Value = (ulong)debugData.LEB128() + (ulong)beginPosition;
+                            attributeValue.Value = debugData.LEB128() + (ulong)beginPosition;
                             break;
 
                         case DwarfFormat.Indirect:

--- a/src/BinaryParsers/MachOBinary/SingleMachOBinary.cs
+++ b/src/BinaryParsers/MachOBinary/SingleMachOBinary.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 Section section = segment.Sections.FirstOrDefault(sec => sec.Name == sectionName);
                 if (section != null)
                 {
-                    ulong CodeSegmentOffset = segment.Address - (ulong)segment.FileOffset;
+                    ulong CodeSegmentOffset = segment.Address - segment.FileOffset;
                     return section.Offset + CodeSegmentOffset;
                 }
             }

--- a/src/BinaryParsers/PEBinary/PortableExecutable/SafePointer.cs
+++ b/src/BinaryParsers/PEBinary/PortableExecutable/SafePointer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
 
         public static explicit operator uint(SafePointer sp)
         {
-            return (((uint)(byte)(sp + 3)) << 24) | (((uint)(byte)(sp + 2)) << 16) | (((uint)(byte)(sp + 1)) << 8) | ((uint)(byte)(sp));
+            return (((uint)(byte)(sp + 3)) << 24) | (((uint)(byte)(sp + 2)) << 16) | (((uint)(byte)(sp + 1)) << 8) | (byte)(sp);
         }
 
         public static explicit operator ushort(SafePointer sp)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.PortableExecutable
 
         public static explicit operator ulong(SafePointer sp)
         {
-            return ((ulong)(uint)(sp + 4) << 32) | ((ulong)(uint)(sp));
+            return ((ulong)(uint)(sp + 4) << 32) | (uint)(sp);
         }
 
         public static explicit operator string(SafePointer sp)


### PR DESCRIPTION
# Description:

CodeQL reports "This cast is redundant because the expression already has type"

# Fixes:

remove the redundant cast

# Tests:

There is No tests added because there is no behavioral implications of this specific type of  change "cast is redundant".
