### PR TITLE
Updating CodeQL analysis for Dependabot on push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,8 @@ name: CodeQL Analysis
 on:
   push:
     branches: [ "**" ]
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches: [ main ]
   schedule:


### PR DESCRIPTION
Dependabot does not have access to "push" and it fails some actions.
With that in mind, the known way to fix this is to disable Dependabot branches from the analysis:

https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#error-403-resource-not-accessible-by-integration-when-using-dependabot