### PR TITLE
LinkerCommandLine fails to populate in some cases due to case sensitivity

### DIFF
--- a/src/BinaryParsers/PEBinary/ProgramDatabase/LinkerCommandLine.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/LinkerCommandLine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -122,7 +123,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
                 return false;
             }
 
-            return target.Substring(1).StartsWith(argument, System.StringComparison.OrdinalIgnoreCase);
+            return target.AsSpan().Slice(1).StartsWith(argument, System.StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool ArgumentEquals(string target, string argument)
@@ -137,7 +138,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
                 return false;
             }
 
-            return target.Substring(1).Equals(argument, System.StringComparison.OrdinalIgnoreCase);
+            return target.AsSpan().Slice(1).Equals(argument, System.StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/LinkerCommandLine.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/LinkerCommandLine.cs
@@ -48,32 +48,32 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
                 }
 
                 // There are multiple /debug options so use StartsWith
-                if (argument.StartsWith("/debug", System.StringComparison.OrdinalIgnoreCase) || argument.StartsWith("-debug", System.StringComparison.OrdinalIgnoreCase))
+                if (ArgumentStartsWith(argument, "debug"))
                 {
                     debugSet = true;
                 }
-                else if (string.Equals(argument, "/opt:ref", System.StringComparison.OrdinalIgnoreCase) || string.Equals(argument, "-opt:ref", System.StringComparison.OrdinalIgnoreCase))
+                else if (ArgumentEquals(argument, "opt:ref"))
                 {
                     optRef = true;
                 }
-                else if (string.Equals(argument, "/opt:icf", System.StringComparison.OrdinalIgnoreCase) || string.Equals(argument, "-opt:icf", System.StringComparison.OrdinalIgnoreCase))
+                else if (ArgumentEquals(argument, "opt:icf"))
                 {
                     optIcf = true;
                 }
-                else if (string.Equals(argument, "/opt:lbr", System.StringComparison.OrdinalIgnoreCase) || string.Equals(argument, "-opt:lbr", System.StringComparison.OrdinalIgnoreCase))
+                else if (ArgumentEquals(argument, "opt:lbr"))
                 {
                     optLbr = true;
                 }
-                else if (string.Equals(argument, "/order", System.StringComparison.OrdinalIgnoreCase) || string.Equals(argument, "-order", System.StringComparison.OrdinalIgnoreCase))
+                else if (ArgumentEquals(argument, "order"))
                 {
                     order = true;
                 }
-                else if (string.Equals(argument, "/incremental", System.StringComparison.OrdinalIgnoreCase) || string.Equals(argument, "-incremental", System.StringComparison.OrdinalIgnoreCase))
+                else if (ArgumentEquals(argument, "incremental"))
                 {
                     explicitlyEnabled = true;
                     explicitlyDisabled = false; // Assume that if specified multiple times the last wins
                 }
-                else if (string.Equals(argument, "/incremental:no", System.StringComparison.OrdinalIgnoreCase) || string.Equals(argument, "-incremental:no", System.StringComparison.OrdinalIgnoreCase))
+                else if (ArgumentEquals(argument, "incremental:no"))
                 {
                     explicitlyDisabled = true;
                     explicitlyEnabled = false; // Assume that if specified multiple times the last wins
@@ -99,6 +99,45 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
             {
                 this.IncrementalLinking = false;
             }
+        }
+
+        public static bool IsLinkerCommandLine(string commandLine)
+        {
+            // The command line for link.exe should contain /OUT with the final binary name.  Use that to separate compiler and linker command lines.
+            // We should accept both / and - as the argument prefix.  The argument is case insensitive.  We do not know where in the command-line the
+            // OUT argument will be provided so we use Contains.
+            return ((commandLine != null) &&
+                    (commandLine.Contains("/OUT", System.StringComparison.OrdinalIgnoreCase) || commandLine.Contains("-OUT", System.StringComparison.OrdinalIgnoreCase)));
+        }
+
+        private static bool ArgumentStartsWith(string target, string argument)
+        {
+            // Arguments are expected to begin with a - or a /.  Accept either.  They are not case sensitive.
+            if (target.Length == 0)
+            {
+                return false;
+            }
+            else if ((target[0] != '/') && (target[0] != '-'))
+            {
+                return false;
+            }
+
+            return target.Substring(1).StartsWith(argument, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool ArgumentEquals(string target, string argument)
+        {
+            // Arguments are expected to begin with a - or a /.  Accept either.  They are not case sensitive.
+            if (target.Length == 0)
+            {
+                return false;
+            }
+            else if ((target[0] != '/') && (target[0] != '-'))
+            {
+                return false;
+            }
+
+            return target.Substring(1).Equals(argument, System.StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/ObjectModuleDetails.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/ObjectModuleDetails.cs
@@ -40,7 +40,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
             this.CompilerBackEndVersion = backEndVersion ?? new Version();
 
             // The command line for link.exe should contain /OUT with the final binary name.  Use that to separate compiler and linker command lines.
-            if ((commandLine != null) && commandLine.Contains("/OUT"))
+            if ((commandLine != null) &&
+                (commandLine.Contains("/OUT", System.StringComparison.OrdinalIgnoreCase) || commandLine.Contains("-OUT", System.StringComparison.OrdinalIgnoreCase)))
             {
                 this.linkerCommandLine = new LinkerCommandLine(commandLine);
                 this.compilerCommandLine = new CompilerCommandLine(String.Empty);

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/ObjectModuleDetails.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/ObjectModuleDetails.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
             this.CompilerFrontEndVersion = compilerFrontEndVersion ?? new Version();
             this.CompilerBackEndVersion = backEndVersion ?? new Version();
 
-            // The command line for link.exe should contain /OUT with the final binary name.  Use that to separate compiler and linker command lines.
-            if ((commandLine != null) &&
-                (commandLine.Contains("/OUT", System.StringComparison.OrdinalIgnoreCase) || commandLine.Contains("-OUT", System.StringComparison.OrdinalIgnoreCase)))
+            if (LinkerCommandLine.IsLinkerCommandLine(commandLine))
             {
                 this.linkerCommandLine = new LinkerCommandLine(commandLine);
                 this.compilerCommandLine = new CompilerCommandLine(String.Empty);


### PR DESCRIPTION
Closes #675

This is a mistake in the new `LinkerCommandLine` extractor that I recently added to support performance rules.  Our learnings about case (in)sensitivity and both `/out` and `-out` being equivalent was not applied to ObjectModuleDetails.cs.  As a result it is not possible to isolate the linker command line arguments for certain binaries.

The fix is to make these comparisons case-insensitive and to check for both - and /.