### PR TITLE
Expose linker command line

### DIFF
--- a/src/BinaryParsers/PEBinary/ProgramDatabase/ObjectModuleDetails.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/ObjectModuleDetails.cs
@@ -90,6 +90,11 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
         public string RawCommandLine => this.compilerCommandLine.Raw;
 
         /// <summary>
+        /// The raw command line passed to the linker when building this object module.
+        /// </summary>
+        public string RawLinkerCommandLine => this.linkerCommandLine.Raw;
+
+        /// <summary>
         /// The name of the compiler.
         /// </summary>
         public string CompilerName { get; private set; }


### PR DESCRIPTION
The **linker** command line was not used in any rules and it is hidden as a private field.
Now I have a new internal rule need to use it, so exposing this field the same way as **compiler** command line, 2 lines above.

Did not add release history because not impacting user.