### PR TITLE
BinSkim - Fix Ubuntu test pipeline

### DIFF
--- a/ado-build.yml
+++ b/ado-build.yml
@@ -4,7 +4,7 @@ pr:
 jobs:
 - job: linux
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
   steps:
   - checkout: self
     submodules: true


### PR DESCRIPTION
New change from GitHub image, the latest now `22.04`, was `20.04`.
`22.04` image only have .NET 6 installed.
Change back to use `20.04`.
https://github.com/actions/runner-images/issues/6399
