### PR TITLE
Fix Linux test issue

### DIFF
--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -6,9 +6,9 @@ if [[  "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]; then
   sed 's#\\#/#g' src/BinSkim.sln > src/BinSkimUnix.sln
 fi
 
-dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
+# dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
-dotnet test --no-build
+dotnet test src/BinSkimUnix.sln Release /p:Platform="x64"
 
 # dotnet test src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj --no-build --configuration Release /p:Platform="x64"
 # dotnet test src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -8,7 +8,7 @@ fi
 
 dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Rules.dll
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinaryParsers.dll
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinSkim.Rules.dll
+dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll
+dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Rules.dll
+dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinaryParsers.dll
+dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinSkim.Rules.dll

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -6,11 +6,9 @@ if [[  "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]; then
   sed 's#\\#/#g' src/BinSkim.sln > src/BinSkimUnix.sln
 fi
 
-# dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
+dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
-dotnet test src/BinSkimUnix.sln Release /p:Platform="x64"
-
-# dotnet test src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj --no-build --configuration Release /p:Platform="x64"
-# dotnet test src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"
-# dotnet test src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj --no-build --configuration Release /p:Platform="x64"
-# dotnet test src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll --configuration Release /p:Platform="x64"
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Rules.dll --no-build --configuration Release /p:Platform="x64"
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinaryParsers.dll --no-build --configuration Release /p:Platform="x64"
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinSkim.Rules.dll --no-build --configuration Release /p:Platform="x64"

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -8,7 +8,9 @@ fi
 
 dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
-dotnet test src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj --no-build --configuration Release /p:Platform="x64"
-dotnet test src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"
-dotnet test src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj --no-build --configuration Release /p:Platform="x64"
-dotnet test src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"
+dotnet test --no-build
+
+# dotnet test src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj --no-build --configuration Release /p:Platform="x64"
+# dotnet test src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"
+# dotnet test src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj --no-build --configuration Release /p:Platform="x64"
+# dotnet test src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -6,7 +6,7 @@ if [[  "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]; then
   sed 's#\\#/#g' src/BinSkim.sln > src/BinSkimUnix.sln
 fi
 
-dotnet build src/BinSkimUnix.sln --configuration Release
+dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
 dotnet test src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj --no-build --configuration Release /p:Platform="x64"
 dotnet test src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj --no-build --configuration Release /p:Platform="x64"

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -8,7 +8,7 @@ fi
 
 dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll --configuration Release /p:Platform="x64"
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Rules.dll --no-build --configuration Release /p:Platform="x64"
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinaryParsers.dll --no-build --configuration Release /p:Platform="x64"
-dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinSkim.Rules.dll --no-build --configuration Release /p:Platform="x64"
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Rules.dll
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinaryParsers.dll
+dotnet test /home/vsts/work/1/s/bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinSkim.Rules.dll


### PR DESCRIPTION
Linux test has been randomly success and fail, only starting these few days.
We have no related changes, wondering if there is new VM image testing.
The error is the test is randomly looking for AnyCpu and x64 folder of the dll and can not find it when it thinks AnyCpu is the one to look for.
(note: dotnet test ignores /p:platform so that is not the way to fix this)
The fix simply: Build as x64 and test x64 dll by specify path.
Test: have run the branch build 10 times all success. while main mostly fails.
