### PR TITLE
BUGFIX: Prevent exit with error `ERR997.ExceptionLoadingAnalysisTarget` when there is exception parsing Dwarf debugging info.

### DIFF
--- a/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
@@ -48,6 +48,12 @@ namespace Microsoft.CodeAnalysis.IL.Rules
         {
             CanAnalyzeDwarfResult result = default;
 
+            if (target.ErrorParsingCompilationUnits)
+            {
+                reasonForNotAnalyzing = MetadataConditions.ErrorParsingCompilationUnits;
+                return AnalysisApplicability.NotApplicableToSpecifiedTarget;
+            }
+
             if (target is ElfBinary)
             {
                 // Set result.Result to AnalysisApplicability.ApplicableToSpecifiedTarget for any case.

--- a/src/BinSkim.Rules/DwarfRules/BA3005.EnableStackClashProtection.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA3005.EnableStackClashProtection.cs
@@ -44,6 +44,12 @@ namespace Microsoft.CodeAnalysis.IL.Rules
         {
             CanAnalyzeDwarfResult result = default;
 
+            if (target.ErrorParsingCompilationUnits)
+            {
+                reasonForNotAnalyzing = MetadataConditions.ErrorParsingCompilationUnits;
+                return AnalysisApplicability.NotApplicableToSpecifiedTarget;
+            }
+
             if (target is ElfBinary elf)
             {
                 result = this.VerifyDwarfBinary(elf);

--- a/src/BinSkim.Sdk/MetadataConditions.cs
+++ b/src/BinSkim.Sdk/MetadataConditions.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         public static readonly string ImageIsResourceOnlyAssembly = SdkResources.MetadataCondition_ImageIsResourceOnlyAssembly;
         public static readonly string ElfNotBuiltWithGccV8OrLater = SdkResources.MetadataCondition_ElfNotBuiltWithGccV8OrLater;
         public static readonly string ImageIsKernelModeAndNot64Bit = SdkResources.MetadataCondition_ImageIsKernelModeAndNot64Bit;
+        public static readonly string ErrorParsingCompilationUnits = SdkResources.MetadataCondition_ErrorParsingCompilationUnits;
         public static readonly string ImageIsDotNetCoreBootstrapExe = SdkResources.MetadataCondition_ImageIsDotNetCoreBootstrapExe;
         public static readonly string ImageLikelyLoadsAs32BitProcess = SdkResources.MetadataCondition_ImageLikelyLoads32BitProcess;
         public static readonly string ElfNotBuiltWithDwarfDebugging = SdkResources.MetadataCondition_ElfNotBuiltWithDwarfDebugging;

--- a/src/BinSkim.Sdk/SdkResources.Designer.cs
+++ b/src/BinSkim.Sdk/SdkResources.Designer.cs
@@ -142,6 +142,15 @@ namespace Microsoft.CodeAnalysis.IL.Sdk {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to error parsing Compilation Units.
+        /// </summary>
+        internal static string MetadataCondition_ErrorParsingCompilationUnits {
+            get {
+                return ResourceManager.GetString("MetadataCondition_ErrorParsingCompilationUnits", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to image was compiled with a toolset version ({0}) that is not sufficiently recent ({1} or newer) to provide relevant settings.
         /// </summary>
         internal static string MetadataCondition_ImageCompiledWithOutdatedTools {

--- a/src/BinSkim.Sdk/SdkResources.resx
+++ b/src/BinSkim.Sdk/SdkResources.resx
@@ -255,4 +255,7 @@
   <data name="MetadataCondition_ImageIsNotBuiltWithMsvc" xml:space="preserve">
     <value>not compiled with Microsoft C/C++ compiler</value>
   </data>
+  <data name="MetadataCondition_ErrorParsingCompilationUnits" xml:space="preserve">
+    <value>error parsing Compilation Units</value>
+  </data>
 </root>

--- a/src/BinaryParsers/ElfBinary/Dwarf/IDwarfBinary.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/IDwarfBinary.cs
@@ -98,6 +98,11 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         public List<DwarfCompileCommandLineInfo> CommandLineInfos { get; }
 
         /// <summary>
+        /// If there is error parsing Compilation Units.
+        /// </summary>
+        public bool ErrorParsingCompilationUnits { get; set; }
+
+        /// <summary>
         /// Gets language from dwarf CompilationUnits.
         /// </summary>
         /// <returns>Dwarf language.</returns>

--- a/src/BinaryParsers/ElfBinary/ElfBinary.cs
+++ b/src/BinaryParsers/ElfBinary/ElfBinary.cs
@@ -56,7 +56,15 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 PublicSymbols = publicSymbols;
                 SectionRegions = ELF.Sections.Where(s => s.LoadAddress > 0).OrderBy(s => s.LoadAddress).ToArray();
 
-                CompilationUnits = DwarfSymbolProvider.ParseAllCompilationUnits(this, DebugData, DebugDataDescription, DebugDataStrings, NormalizeAddress);
+                try
+                {
+                    CompilationUnits = DwarfSymbolProvider.ParseAllCompilationUnits(this, DebugData, DebugDataDescription, DebugDataStrings, NormalizeAddress);
+                }
+                catch (ArgumentException)
+                {
+                    ErrorParsingCompilationUnits = true;
+                }
+
                 commandLineInfos = new Lazy<List<DwarfCompileCommandLineInfo>>(()
                     => DwarfSymbolProvider.ParseAllCommandLineInfos(CompilationUnits));
                 LineNumberPrograms = DwarfSymbolProvider.ParseLineNumberPrograms(DebugLine, NormalizeAddress);
@@ -238,6 +246,11 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
         /// Gets or sets the CompilationUnits.
         /// </summary>
         public List<DwarfCompilationUnit> CompilationUnits { get; set; } = new List<DwarfCompilationUnit>();
+
+        /// <summary>
+        /// If there is error parsing Compilation Units.
+        /// </summary>
+        public bool ErrorParsingCompilationUnits { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the CommandLineInfos.

--- a/src/BinaryParsers/MachOBinary/MachOBinary.cs
+++ b/src/BinaryParsers/MachOBinary/MachOBinary.cs
@@ -116,6 +116,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             set => throw new NotImplementedException();
         }
 
+        public bool ErrorParsingCompilationUnits { get => MachOs?.Any(m => m.ErrorParsingCompilationUnits) == true; set => throw new NotImplementedException(); }
+
         #endregion IDwarfBinary interface
     }
 }

--- a/src/BinaryParsers/MachOBinary/SingleMachOBinary.cs
+++ b/src/BinaryParsers/MachOBinary/SingleMachOBinary.cs
@@ -51,6 +51,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
 
         public List<DwarfCompileCommandLineInfo> CommandLineInfos => this.commandLineInfos.Value;
 
+        public bool ErrorParsingCompilationUnits { get; set; } = false;
+
         private List<DwarfLineNumberProgram> lineNumberPrograms;
 
         public List<DwarfLineNumberProgram> LineNumberPrograms
@@ -193,7 +195,16 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             byte[] debugData = this.LoadSection(SECTIONNAME_DEBUG_INFO);
             byte[] debugAbbrev = this.LoadSection(SECTIONNAME_DEBUG_ABBREV);
             byte[] debugStr = this.LoadSection(SECTIONNAME_DEBUG_STR);
-            return DwarfSymbolProvider.ParseAllCompilationUnits(this, debugData, debugAbbrev, debugStr, NormalizeAddress);
+            try
+            {
+                return DwarfSymbolProvider.ParseAllCompilationUnits(this, debugData, debugAbbrev, debugStr, NormalizeAddress);
+            }
+            catch (ArgumentException)
+            {
+                ErrorParsingCompilationUnits = true;
+            }
+
+            return new List<DwarfCompilationUnit>();
         }
 
         private byte[] LoadSection(string sectionName)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # BinSkim Release History
 
+## **v2.0.0-rc2** (Unreleased)
+* BUGFIX: Prevent exit with error `ERR997.ExceptionLoadingAnalysisTarget` when there is exception parsing Dwarf debugging info. [760](https://github.com/microsoft/binskim/pull/760)
+
 ## **v2.0.0-rc1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/2.0.0-rc1)
 * BUGFIX: Eliminate `BA2004.EnableSecureSourceCodeHashing` false positives to Windows Runtime components (resulting from references to Win RT API metadata files).
 * BREAKING: Removed SARIF 1.0 support from BinSkim. Now option `-v | --sarif-output-version` does not accept value `OneZeroZero`. [719](https://github.com/microsoft/binskim/pull/719)


### PR DESCRIPTION
1. Prevent exit with error `ERR997.ExceptionLoadingAnalysisTarget` when there is exception parsing Dwarf debugging info.
2. Disable related check when it happens.
3. I need to figure out how to create test files that can trigger this exception.