### PR TITLE
BugFix assertion failed with no clue when TargetFileSpecifiers is null or empty for BinSkim analyze

### DIFF
--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -128,11 +128,10 @@ namespace Microsoft.CodeAnalysis.IL
         }
 
         public override int Run(AnalyzeOptions analyzeOptions)
-        {
-            // Check whether target file is specified for BinSkim Analyze. If not, exit with code 1 (failure).
+        {            
             if (analyzeOptions.TargetFileSpecifiers == null || !analyzeOptions.TargetFileSpecifiers.Any())
             {
-                throw new ArgumentNullException("Please specify a targe file after BinSkim analyze", (Exception)null);
+                throw new ArgumentNullException("Please specify one or more files, directories, or filter patterns for BinSkim analyze.", (Exception)null);
             }
 
             if (!Environment.GetCommandLineArgs().

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.IL
         }
 
         public override int Run(AnalyzeOptions analyzeOptions)
-        {            
+        {
             if (analyzeOptions.TargetFileSpecifiers == null || !analyzeOptions.TargetFileSpecifiers.Any())
             {
                 throw new ArgumentNullException("Please specify one or more files, directories, or filter patterns for BinSkim analyze.", (Exception)null);

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -130,10 +130,9 @@ namespace Microsoft.CodeAnalysis.IL
         public override int Run(AnalyzeOptions analyzeOptions)
         {
             // Check whether target file is specified for BinSkim Analyze. If not, exit with code 1 (failure).
-            if (!analyzeOptions.TargetFileSpecifiers.Any())
+            if (analyzeOptions.TargetFileSpecifiers == null || !analyzeOptions.TargetFileSpecifiers.Any())
             {
-                Console.WriteLine("Please specify a targe file for BinSkim Analyze.");
-                return FAILURE;
+                throw new ArgumentNullException("Please specify a targe file after BinSkim analyze", (Exception)null);
             }
 
             if (!Environment.GetCommandLineArgs().

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.IL
 
         public override int Run(AnalyzeOptions analyzeOptions)
         {
-            if (analyzeOptions.TargetFileSpecifiers == null || !analyzeOptions.TargetFileSpecifiers.Any())
+            if (analyzeOptions.TargetFileSpecifiers?.Any() != true)
             {
                 throw new ArgumentNullException("Please specify one or more files, directories, or filter patterns for BinSkim analyze.", (Exception)null);
             }

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.IL
         {
             if (analyzeOptions.TargetFileSpecifiers?.Any() != true)
             {
-                throw new ArgumentNullException("Please specify one or more files, directories, or filter patterns for BinSkim analyze.", (Exception)null);
+                throw new ArgumentNullException(nameof(analyzeOptions.TargetFileSpecifiers), "Please specify one or more files, directories, or filter patterns for BinSkim analyze.");
             }
 
             if (!Environment.GetCommandLineArgs().

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -129,6 +129,13 @@ namespace Microsoft.CodeAnalysis.IL
 
         public override int Run(AnalyzeOptions analyzeOptions)
         {
+            // Check whether target file is specified for BinSkim Analyze. If not, exit with code 1 (failure).
+            if (!analyzeOptions.TargetFileSpecifiers.Any())
+            {
+                Console.WriteLine("Please specify a targe file for BinSkim Analyze.");
+                return FAILURE;
+            }
+
             if (!Environment.GetCommandLineArgs().
                 Any(arg => arg.Equals("--sarif-output-version", StringComparison.OrdinalIgnoreCase) ||
                 arg.Equals("-v", StringComparison.OrdinalIgnoreCase)))

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # BinSkim Release History
 
 ## **v2.0.0-rc2** (Unreleased)
-* BUGFIX: Errors in export-config command for BA2006. [763](https://github.com/microsoft/binskim/pull/763)
+* BUGFIX: Fix assertion failed with no clue when TargetFileSpecifiers is null or empty for BinSkim analyze.[763](https://github.com/microsoft/binskim/pull/763)
 
 ## **v2.0.0-rc1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/2.0.0-rc1)
 * BUGFIX: Eliminate `BA2004.EnableSecureSourceCodeHashing` false positives to Windows Runtime components (resulting from references to Win RT API metadata files).

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # BinSkim Release History
 
+## **v2.0.0-rc2** (Unreleased)
+* BUGFIX: Errors in export-config command for BA2006. [763](https://github.com/microsoft/binskim/pull/763)
+
 ## **v2.0.0-rc1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/2.0.0-rc1)
 * BUGFIX: Eliminate `BA2004.EnableSecureSourceCodeHashing` false positives to Windows Runtime components (resulting from references to Win RT API metadata files).
 * BREAKING: Removed SARIF 1.0 support from BinSkim. Now option `-v | --sarif-output-version` does not accept value `OneZeroZero`. [719](https://github.com/microsoft/binskim/pull/719)

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
@@ -52,10 +52,19 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         }
 
         [Fact]
+        public void AnalyzeCommand_ShouldThrowWithNoTargetFile()
+        {
+            var options = new AnalyzeOptions();
+            var command = new MultithreadedAnalyzeCommand();
+            Assert.Throws<ArgumentNullException>(() => command.Run(options));
+        }
+
+        [Fact]
         public void AnalyzeCommand_ShouldThrowWithVersionOne()
         {
             var options = new AnalyzeOptions
             {
+                TargetFileSpecifiers = new string[] { "dummy.dll" },
                 SarifOutputVersion = Sarif.SarifVersion.OneZeroZero
             };
             var command = new MultithreadedAnalyzeCommand();
@@ -70,6 +79,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         {
             var options = new AnalyzeOptions
             {
+                TargetFileSpecifiers = new string[] { "dummy.dll" },
                 Level = new[] { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note, FailureLevel.None },
                 Kind = new[] { ResultKind.Fail }
             };


### PR DESCRIPTION
Before this change, when no Target file is specified for BinSkim analyze, BinSkim will fail with no clue to users (as shown below)
![image](https://user-images.githubusercontent.com/119978670/207156750-6af62caa-bd74-48bd-86ee-f00d4137e10e.png)

The change is to check whether Target file is specified at the very beginning of running the analyze command. If target file is not specified, throw an exception with clear message.

After the change, when no target file is specified for BinSkim analyze, BinSkim will fail with clear clue (as shown below).
![image](https://user-images.githubusercontent.com/119978670/207158078-1f99a896-b2ba-453f-a3ef-3462b06c3466.png)

Add/Modify the test cases.