### PR TITLE
* BUGFIX: Fix over-aggressive parsing of DWARF compilation units even when all related rules are disabled.

### DIFF
--- a/src/BinaryParsers/ElfBinary/Elf/DebugFileType.cs
+++ b/src/BinaryParsers/ElfBinary/Elf/DebugFileType.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Elf
 {
     public enum DebugFileType
     {
+        TBD,
         FromDwo,
         NoDebug,
         Unknown,

--- a/src/BinaryParsers/ElfBinary/ElfBinary.cs
+++ b/src/BinaryParsers/ElfBinary/ElfBinary.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             return ulong.MaxValue;
         }
 
-        private List<DwarfCompilationUnit> LoadDebug(List<DwarfCompilationUnit> compilationUnits, string localSymbolDirectories = null)
+        private List<DwarfCompilationUnit> LoadDebug(List<DwarfCompilationUnit> currentCompilationUnits, string localSymbolDirectories = null)
         {
             DebugFileType = DebugFileType.Unknown;
             DebugFileLoaded = false;
@@ -404,15 +404,15 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             if (SectionExistsAndHasBits(SectionName.DebugInfoDwo))
             {
                 DebugFileType = DebugFileType.DebugOnlyFileDwo;
-                return compilationUnits;
+                return currentCompilationUnits;
             }
 
             string debugFileName = null;
 
-            if (compilationUnits.Count > 0)
+            if (currentCompilationUnits.Count > 0)
             {
                 // Load from Dwo
-                DwarfSymbol skeletonOrCompileSymbol = compilationUnits
+                DwarfSymbol skeletonOrCompileSymbol = currentCompilationUnits
                 .SelectMany(c => c.Symbols)
                 .FirstOrDefault(s => s.Tag == DwarfTag.SkeletonUnit || s.Tag == DwarfTag.CompileUnit);
                 KeyValuePair<DwarfAttribute, DwarfAttributeValue>? dwo = skeletonOrCompileSymbol?.Attributes?
@@ -460,10 +460,10 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
 
                         if (dwoBinary != null && dwoBinary.CompilationUnits.Count > 0)
                         {
-                            compilationUnits.AddRange(dwoBinary.CompilationUnits);
+                            currentCompilationUnits.AddRange(dwoBinary.CompilationUnits);
 
                             DebugFileLoaded = true;
-                            return compilationUnits;
+                            return currentCompilationUnits;
                         }
                     }
                 }
@@ -510,7 +510,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 }
             }
 
-            return compilationUnits;
+            return currentCompilationUnits;
         }
 
         private readonly Lazy<List<DwarfCompileCommandLineInfo>> commandLineInfos;

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -4,6 +4,7 @@
 * BUGFIX: Fix assertion failed with no clue when TargetFileSpecifiers is null or empty for BinSkim analyze.[763](https://github.com/microsoft/binskim/pull/763)
 * BUGFIX: fix `ERR997.ExceptionLoadingAnalysisTarget : Could not load analysis target` errors analyzing *nix binary resulting from failure to properly parse DWARF debug information.
 * Upgrade `Newtonsoft.JSON` package to 13.0.2 to resolve security alert.
+* BUGFIX: Fix over-aggressive parsing of DWARF compilation units even when all related rules are disabled. [769](https://github.com/microsoft/binskim/pull/769)
 
 ## **v2.0.0-rc1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/2.0.0-rc1)
 * BUGFIX: Eliminate `BA2004.EnableSecureSourceCodeHashing` false positives to Windows Runtime components (resulting from references to Win RT API metadata files).

--- a/src/Test.UnitTests.BinaryParsers/Elf/ElfBinaryTests.cs
+++ b/src/Test.UnitTests.BinaryParsers/Elf/ElfBinaryTests.cs
@@ -190,6 +190,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Elf
             // dwotest.cpp compiled using: gcc -Wall -O2 -g -gdwarf-4 dwotest.cpp -gsplit-dwarf -o dwotest.gcc.4.o
             string fileName = Path.Combine(TestData, "Dwarf/DwarfSplitV4/dwotest.gcc.4.o");
             using var binary = new ElfBinary(new Uri(fileName));
+            binary.DebugFileType.Should().Be(DebugFileType.FromDwo);
             binary.DwarfVersion.Should().Be(4);
             binary.GetLanguage().Should().Be(DwarfLanguage.CPlusPlus);
         }
@@ -200,6 +201,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Elf
             // dwotest.cpp compiled using: gcc -Wall -O2 -g -gdwarf-5 dwotest.cpp -gsplit-dwarf -o dwotest.gcc.5.o
             string fileName = Path.Combine(TestData, "Dwarf/DwarfSplitV5/dwotest.gcc.5.o");
             using var binary = new ElfBinary(new Uri(fileName));
+            binary.DebugFileType.Should().Be(DebugFileType.FromDwo);
             binary.DwarfVersion.Should().Be(5);
             binary.GetLanguage().Should().Be(DwarfLanguage.CPlusPlus14);
         }
@@ -238,6 +240,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Elf
                 "WithoutDwoFiles");
             var pathList = new List<string>() { localSymbolDirectory1, localSymbolDirectory2 };
             using var binary = new ElfBinary(new Uri(fileName), string.Join(';', pathList));
+            binary.DebugFileType.Should().Be(DebugFileType.FromDwo);
             binary.DwarfVersion.Should().Be(4);
             binary.GetLanguage().Should().Be(DwarfLanguage.CPlusPlus);
         }
@@ -262,12 +265,14 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Elf
                 "Dwarf/DwarfSplitV4DebugFileInAnotherDirectory/AnotherLocalSymbolDirectory");
             var pathListFound = new List<string>() { localSymbolDirectory1, localSymbolDirectory2, localSymbolDirectory3 };
             using var binaryFound = new ElfBinary(new Uri(fileName), string.Join(';', pathListFound));
+            binaryFound.DebugFileType.Should().Be(DebugFileType.FromDwo);
             binaryFound.DwarfVersion.Should().Be(4);
             binaryFound.GetLanguage().Should().Be(DwarfLanguage.CPlusPlus);
 
             // test for: when not able to find in any of the pass in directories, also not able to find in same directory
             var pathListNotFound = new List<string>() { localSymbolDirectory1, localSymbolDirectory2 };
             using var binaryNotFound = new ElfBinary(new Uri(fileName), string.Join(';', pathListNotFound));
+            binaryNotFound.DebugFileType.Should().Be(DebugFileType.FromDwo);
             binaryNotFound.GetLanguage().Should().Be(DwarfLanguage.Unknown);
         }
     }


### PR DESCRIPTION
When user disable all related rules, we are still reading DWARF compilation units,
when there is bug reading DWARF compilation units, there is no way user can get pass it by disable related rules.
This PR fix this issue.