### PR TITLE
Fixes _FORTIFY_SOURCE macro

### DIFF
--- a/docs/BinSkimRules.md
+++ b/docs/BinSkimRules.md
@@ -200,7 +200,7 @@ The BIND_NOW flag is missing from this binary, so relocation sections in '{0}' w
 
 ### Description
 
-GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2').
+GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2').
 
 ### Messages
 

--- a/src/BinSkim.Rules/ElfRules/BA3030.UseGccCheckedFunctions.cs
+++ b/src/BinSkim.Rules/ElfRules/BA3030.UseGccCheckedFunctions.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
         }
 
         /// <summary>
-        /// Checks if Fortified functions are used--the -DFORTIFY_SOURCE=2 flag enables these when -O2 is enabled.
+        /// Checks if Fortified functions are used--the -D_FORTIFY_SOURCE=2 flag enables these when -O2 is enabled.
         ///
         /// Check implementation:
         /// -Get all function symbols in the ELF binary

--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -1286,7 +1286,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing &apos;-DFortify_Source=2&apos; when optimization level 2 is enabled (&apos;-O2&apos;)..
+        ///   Looks up a localized string similar to GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing &apos;-D_FORTIFY_SOURCE=2&apos; when optimization level 2 is enabled (&apos;-O2&apos;)..
         /// </summary>
         internal static string BA3030_UseGccCheckedFunctions_Description {
             get {

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -455,7 +455,7 @@ Modules did not meet the criteria: {1}</value>
     <value>Some checked functions were found in '{0}'; however, there were also some unchecked functions, which can occur when the compiler cannot statically determine the length of a buffer/string.  We recommend reviewing your usage of functions like memcpy or strcpy.</value>
   </data>
   <data name="BA3030_UseGccCheckedFunctions_Description" xml:space="preserve">
-    <value>GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2').</value>
+    <value>GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2').</value>
   </data>
   <data name="NotApplicable_InvalidMetadata" xml:space="preserve">
     <value>'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}.</value>

--- a/src/BuildSamples/ELF/build-test-binaries.sh
+++ b/src/BuildSamples/ELF/build-test-binaries.sh
@@ -82,8 +82,8 @@ echo "Building GCC Only flags"
 objdump -T /lib/x86_64-linux-gnu/libc.so.6 | grep -o "__[a-z]*_chk" | sort > $OUTPUT_DIR/glibc_chk_functions.txt
 # Build FORTIFY_SOURCE checks:
 gcc empty.c -o $OUTPUT_DIR/gcc.unfortified
-gcc empty.c -o $OUTPUT_DIR/gcc.fortified -DFORTIFY_SOURCE=2 -O2
-gcc no_fortify_func.c -o $OUTPUT_DIR/gcc.no_fortification_required -DFORTIFY_SOURCE=2 -O2
+gcc empty.c -o $OUTPUT_DIR/gcc.fortified -D_FORTIFY_SOURCE=2 -O2
+gcc no_fortify_func.c -o $OUTPUT_DIR/gcc.no_fortification_required -D_FORTIFY_SOURCE=2 -O2
 
 echo "Building invalid ELF file"
 # Invalid ELF file from haskell compiler

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.default_compilation.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.default_compilation.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector.sarif
@@ -394,10 +394,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.execstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.execstack.sarif
@@ -301,10 +301,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.execstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.execstack.so.sarif
@@ -302,10 +302,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.fortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.fortified.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.gsplitdwarf.5.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.gsplitdwarf.5.sarif
@@ -351,10 +351,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.4.o.no-stack-clash-protection.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.4.o.no-stack-clash-protection.sarif
@@ -394,10 +394,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.5.o.no-stack-clash-protection.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.5.o.no-stack-clash-protection.sarif
@@ -395,10 +395,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.execstack.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.execstack.5.o.sarif
@@ -393,10 +393,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.nodwarf.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.nodwarf.sarif
@@ -306,10 +306,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.noexecstack.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.helloworld.noexecstack.5.o.sarif
@@ -395,10 +395,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.immediate_binding.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.no_fortification_required.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.no_fortification_required.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.no_immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.no_immediate_binding.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.no_stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.no_stack_protector.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.noexecstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.noexecstack.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.noexecstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.noexecstack.so.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.non_pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.non_pie_executable.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.objcopy.stripall.addgnudebuglink.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.objcopy.stripall.addgnudebuglink.sarif
@@ -350,10 +350,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.pie_executable.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.relocationsro.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.relocationsro.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.relocationsrw.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.relocationsrw.sarif
@@ -302,10 +302,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.requiredsymbol.4.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.requiredsymbol.4.o.sarif
@@ -394,10 +394,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.requiredsymbol.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.requiredsymbol.5.o.sarif
@@ -395,10 +395,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.shared_library.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.shared_library.so.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.stack_protector.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.stack_protector.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.stack_protector.so.sarif
@@ -304,10 +304,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.unfortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/Expected/gcc.unfortified.sarif
@@ -303,10 +303,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.default_compilation.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.default_compilation.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.example2.fstackprotectorstrongsspbuffersize8+fnostackprotector.sarif
@@ -398,10 +398,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.execstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.execstack.sarif
@@ -261,10 +261,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.execstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.execstack.so.sarif
@@ -262,10 +262,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.fortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.fortified.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.gsplitdwarf.5.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.gsplitdwarf.5.sarif
@@ -311,10 +311,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.4.o.no-stack-clash-protection.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.4.o.no-stack-clash-protection.sarif
@@ -398,10 +398,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.5.o.no-stack-clash-protection.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.5.o.no-stack-clash-protection.sarif
@@ -399,10 +399,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.execstack.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.execstack.5.o.sarif
@@ -397,10 +397,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.nodwarf.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.nodwarf.sarif
@@ -266,10 +266,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.noexecstack.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.helloworld.noexecstack.5.o.sarif
@@ -399,10 +399,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.immediate_binding.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.no_fortification_required.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.no_fortification_required.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.no_immediate_binding.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.no_immediate_binding.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.no_stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.no_stack_protector.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.noexecstack.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.noexecstack.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.noexecstack.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.noexecstack.so.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.non_pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.non_pie_executable.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.objcopy.stripall.addgnudebuglink.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.objcopy.stripall.addgnudebuglink.sarif
@@ -354,10 +354,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.pie_executable.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.pie_executable.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.relocationsro.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.relocationsro.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.relocationsrw.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.relocationsrw.sarif
@@ -262,10 +262,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.requiredsymbol.4.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.requiredsymbol.4.o.sarif
@@ -398,10 +398,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.requiredsymbol.5.o.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.requiredsymbol.5.o.sarif
@@ -399,10 +399,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.shared_library.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.shared_library.so.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.stack_protector.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.stack_protector.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.stack_protector.so.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.stack_protector.so.sarif
@@ -264,10 +264,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.unfortified.sarif
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/NonWindowsExpected/gcc.unfortified.sarif
@@ -263,10 +263,10 @@
               "id": "BA3030",
               "name": "UseGccCheckedFunctions",
               "fullDescription": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "help": {
-                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-DFortify_Source=2' when optimization level 2 is enabled ('-O2')."
+                "text": "GCC can automatically replace unsafe functions with checked variants when it can statically determine the length of a buffer or string. In the case of an overflow, the checked version will safely exit the program (rather than potentially allowing an exploit). This feature can be enabled by passing '-D_FORTIFY_SOURCE=2' when optimization level 2 is enabled ('-O2')."
               },
               "messageStrings": {
                 "Pass_AllFunctionsChecked": {


### PR DESCRIPTION
This commit fixes the mistake in the `_FORTIFY_SOURCE` macro where it was not prefixed with underscore or spelled incorrectly.

Additionally, compilers recently added fortify source level 3 (`-D_FORTIFY_SOURCE=3`) which should be recommended if available.

You can read more about it here: https://developers.redhat.com/blog/2021/04/16/broadening-compiler-checks-for-buffer-overflows-in-_fortify_source.

You can also see the result of the correct vs incorrect macro along with optimizations and no optimizations on this screenshot ([source](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM6SuADJ4DJgAcj4ARpjEIABspAAOqAqETgwe3r7%2ByanpAiFhkSwxcYl2mA4ZQgRMxARZPn4BldUCtfUERRHRsQm2dQ1NOa1D3aG9pf3xAJS2qF7EyOwc5gDMocjeWADUJutuCgTEocAAdAgH2CYaAIK3d6EEuyxMoRDPu8ik3wj1ACpdvVgAA3EwAVisEIAIrN9gB2Kz3XZ/eq7KJeKiQixcDSQmEHZF3VHHZZJACeEExVF%2BIPBUPxsNmRMeJgRMI481onAhvD8HC0pFQnDc1msuwUi2WmH2ZnWPFIBE0XPmAGsJPFzhD1gAOLgKgCc8TMZmNkkN%2Bk4kn5KuFnF4ChAGiVKvmcFgMCgXogSDQLCSdFi5Eo/sD9DiwC4ptIWFBeBWADU8JgAO4AeSSjE4ipotAIsSd1LtUVC9QpOd4/rYgnTDFoFcFvCwbyM4ibsbwxCqjlBmCdHcwqiqXgLduemB5HdoeCixHLHiwdpOeBYlfmVAMwAUybTmez3F4/EEIjE7CkMkEihU6g7umkBiMKHFln0s6dkHmqCSjgEA4AtDCAD6ABi6YAEoACoAJIgQAmkBQjpnI4FuDc6wwlwuz/umiptL%2BfgQK4Ix%2BFwgQMOgPQlGUegpGkBEkbR%2BQEVRfRxGR%2BE1OMjEcZOPZcV0rHTOxgxdDxokNEJNFcPMUpLCsEjcrytodiKHC7KourxP%2B8SSLswDIMguzRucZi7BAuCECQcoKrMvDKk2szzAgmBMFgcQQOqIAQi6U42qQa7rFqhoaPEXC6VwUi6ZI8TGqQApCmpjrOq6jmkB6iAoKgAZBmQFAQGGuUgFGMZxgmmC7hmWYCrmdAFsQRZRCWZbEI2irVowBB1g2dotoYwDtkK%2BDdtUfYDkKQ4jmOHYTlOQoznOC4YKsQormuh4bluO4plVB65rIp7iBex7yEoah2roEL6P1z6WNYb5RB%2BnnCj%2BGQAcBYFQbBCFIShaEHJh2HpkKnHOERFHicEkzUf0ZF0QUmSeM0TH0RkUmw7YfHtAwnTDEjOS8fYBG4xMxRsXoxxifjpESaTUzSbJ0oKTJVocHy8V2mpGlaTpekGUZJlmRZ%2BBEMQNkyfZbrOa57mUEpHD%2BWuZrnAi8QaD5ZgQhCZgaGYXCGoa6wc6pDq2ClDlaO6Pp%2Btl4bBvlhURsV0YBGVSY7fuNVHnVhaUE1HalswrWVqQHW1vWjZDZgrYDStzZdvxY12pNyCjnH5CCJOdoLfOrWLuna3rnwW2VZ7IcnYd57SCd17nXeAyPsYL42AtT1fq9f6cIBn0wfBiHIah6GAzheFYwRLgQ9TehQ2Twkowj4nwyx0Pk4T/EdNxU9r9jJPoyJlN49kNMH3TMPsYz8nnvL7MJbwXOadpun6YZxlmKZ5mWaL4t2allvy4rIB1jrHOEA0BYDwHG0SqbJ0LoLaqlIBqHyrN1gqSgRwSWaUMpYJtjlCMIYCq2yKiVV2mB4zuz3NVcuPsGp%2B2akHNqVZso1i6hHXq0d%2BqDXjiNXs/Zk7DlTtNIUs1s6zlzhSfOy5TjrR4JtJg25S6UMPJeYQogjrV1kLXW8QpdBkUbrdKwr5W7wHbgRd6oEIK9x%2BgPf6GEzI4TMI6MeGQJ7uC3uRSiK855w2YhkRePjCieOkpjImAlD7I23sTcYe8KabyPjEwSgTYYXxlIpVmN9OacG5o/PmL9BYfxFtZDYEtf7wMQb5a0vBApagRIaMwkhta6nWBoLguotK6kgXfaB5s3TpWtllXB9tQyEKdsQ2MpDyoKL2t7fMvtiwBxagw0OTDOrdUjs2dhbZ07DUTrwwc/C07jkznNXgOclpLg7IXDaxc5HbQoVM5RlcJDqKvGdLROhch6NMHdQx75jEvVMV3D6Fjvr9z%2BkPOxwNHEhLBsRNxM96YYyXr4txSKAmzyCaDHGsTwnBPXlihJ6KMYn3EifaJLM5IpJZlOdJJt1IP15s/AWb8haf0KfKYpcCnKkBcm5foz0/KVP8Lqc4xp4i6hirrLWXAEQQnCh0%2B06CzawJ6dg/pds8pDIGZGF2YyyEVQ9oo2qMyaFzKFIHcsIcw4sJ6h2PqmzeoJ1Grsia%2BzBG8GEdOURZyC5SKLpuG5kyvYPNUVXZRmiLqAOuk%2BL5BiW6/M/P8t6gKe4gt%2BoPAGEKHG4uxi4yGFEyV5FRgIPxRaGAFsxSTElTiN4EoRfvbFBNaZkuScza%2BqDOl0p5k/fmr937CysmLIpP9OXS15R5f%2Bgr1iSFMpIDQCJmlSEkGaPU8qkpKpKVyspyD20KowX/BBIBGnnBii0sVGh1gInnesbWrMs1rjxC6W%2Bu6N3yyzU%2BtdI7SB9gas4yQQA%3D%3D%3D)): ![image](https://user-images.githubusercontent.com/10009354/209678087-977d494f-272c-4779-a3a5-994cf6da097a.png)