### PR TITLE
BinSkim build fails fix: Change BinaryAnalyzerContext.MaxFileSizeInKilobytes from int to long

### DIFF
--- a/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
+++ b/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
@@ -135,6 +135,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 "A shared CompilerDataLogger instance that will be passed to all skimmers.");
 
 
-        public int MaxFileSizeInKilobytes { get; set; }
+        public long MaxFileSizeInKilobytes { get; set; }
     }
 }


### PR DESCRIPTION
Change BinaryAnalyzerContext.MaxFileSizeInKilobytes from int to long to match with the IAnalysisContext interface.