### PR TITLE
Draft - built DotNet Tool for BinSkim.

### DIFF
--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -3,9 +3,18 @@
 SETLOCAL
 
 call SetCurrentVersion.cmd
-
+echo Build NuGet Package using NuGet pack. OutputDirectory is bld\bin\Nuget
 %~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinSkim.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
 %~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinaryParsers.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
+
+echo Build DotNetTool NuGet Package using dotnet pack. OutputDirectory is bld\bin\DotNetToolNuget
+dotnet pack %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-build --output %~dp0bld\bin\DotNetToolNuget || goto :ExitFailed
+
+
+::dotnet pack %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-build --output %~dp0bld\bin\DotNetToolNuget --runtime win-x64 || goto :ExitFailed
+::dotnet pack %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-build -p:NuspecFile=%~dp0src\Nuget\BinSkim.nuspec -p:NuspecBasePath=%~dp0 --output %~dp0bld\bin\DotNetToolNuget --runtime win-x64 || goto :ExitFailed
+::dotnet pack %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-build -p:NuspecFile=%~dp0src\Nuget\BinSkimDotNetTool.nuspec -p:NuspecBasePath=%~dp0 --output %~dp0bld\bin\DotNetToolNuget  || goto :ExitFailed
+
 
 goto Exit
 

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -9,6 +9,7 @@
     <TargetLatestRuntimePatch>True</TargetLatestRuntimePatch>
     <OutputType>Exe</OutputType>
     <Platforms>x64</Platforms>
+    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -66,9 +67,7 @@
   </ItemGroup>
 
   <ItemGroup>   
-    <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(RuntimeIdentifier)'==''" />
-	<!-- Note: Official Release builds on Windows should specify a RID. Build using the BuildAndTest.cmd script. -->
-    <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(RuntimeIdentifier)'=='win-x64'" />
+    <MsDiaLibs Include="..\..\refs\x64\*" />
     <MsDiaLibs Include="..\..\refs\msdia140.dll.manifest" />
 
     <!-- Required DLLs for Microsoft Visual C++ runtime. -->
@@ -89,5 +88,7 @@
   <Target Name="PublishMsDiaLibs" AfterTargets="publish">
     <Copy SourceFiles="@(MsDiaLibs)" DestinationFolder="$(PublishDir)\" />
     <Copy SourceFiles="@(MsRuntime)" DestinationFolder="$(PublishDir)\" />
+    <Copy SourceFiles="@(MsDiaLibs)" DestinationFolder="$(PublishDirNoRID)\" />
+    <Copy SourceFiles="@(MsRuntime)" DestinationFolder="$(PublishDirNoRID)\" />
   </Target>
 </Project>

--- a/src/build.common.props
+++ b/src/build.common.props
@@ -8,6 +8,7 @@
     <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
     <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(Platform)_$(Configuration)\</OutputPath>
     <PublishDir>$(MsBuildThisFileDirectory)..\bld\bin\$(Platform)_$(Configuration)\Publish\$(TargetFramework)\$(RuntimeIdentifier)\</PublishDir>
+	<PublishDirNoRID>$(MsBuildThisFileDirectory)..\bld\bin\$(Platform)_$(Configuration)\Publish\$(TargetFramework)\</PublishDirNoRID>    
     <FileAlignment>512</FileAlignment>
     <RestorePackages>true</RestorePackages>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
It is a draft PR. 

After applying the changes locally, run BuildAndTest.cmd. 
A dotnet tool BinSkim.1.0.0.nupkg will be generated under the \repos\microsoft\binskim\bld\bin\DotNetToolNuget folder.

Move the BinSkim.1.0.0.nupkg to some folder where you want to install according to https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-use#use-the-tool-as-a-global-tool-installed-in-a-custom-location. 

Use the following command to install the tool:
dotnet tool install --tool-path TheFolderWhereToInstallAndInvokeTheCommand --add-source TheFolderWhereTheDotNetToolLocated BinSkim -v n --framework net6.0

Try to use "BinSkim analyze XXX.dll", the following error will appear: msdia140.dll is missing.
<img width="859" alt="image" src="https://user-images.githubusercontent.com/119978670/211385629-9085e45f-7381-4461-aac2-bedb5642ccf6.png">

Check the bld\bin folder, while the msdia140.dll is in the following publish folders, it cannot be found in .nupkg (after unzipped)  anywhere...
\repos\microsoft\binskim\bld\bin\x64_Release\Publish\net6.0
\repos\microsoft\binskim\bld\bin\x64_Release\Publish\net6.0\win-x64