### PR TITLE
A working prototype for BinSkim dotnet tool

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -63,6 +63,11 @@ call :CreatePublishPackage net6.0 win-x64 || goto :ExitFailed
 call :CreatePublishPackage net6.0 linux-x64 || goto :ExitFailed
 call :CreatePublishPackage net6.0 osx-x64 || goto :ExitFailed
 
+::Create the BinSkim dotnet tool publish packages
+echo Creating BinSkim dotnet tool publish packages
+dotnet publish %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-restore -c %Configuration% -f net6.0 -p:PublishDir=%~dp0bld\bin\%Platform%_%Configuration%\DotNetToolPublish\net6.0\any
+dotnet publish %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-restore -c %Configuration% -f netcoreapp3.1 -p:PublishDir=%~dp0bld\bin\%Platform%_%Configuration%\DotNetToolPublish\netcoreapp3.1\any
+
 ::Build NuGet package
 echo BuildPackages.cmd
 call BuildPackages.cmd || goto :ExitFailed

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -7,6 +7,9 @@ call SetCurrentVersion.cmd
 %~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinSkim.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
 %~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinaryParsers.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
 
+echo Build DotNetTool NuGet Package using dotnet pack. OutputDirectory is bld\bin\DotNetToolNuget
+dotnet pack %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-restore --no-build -p:NuspecFile=%~dp0src\Nuget\BinSkimDotNetTool.nuspec -p:NuspecBasePath=%~dp0 -p:NuspecProperties="configuration=%Configuration%" --output %~dp0bld\bin\DotNetToolNuget  || goto :ExitFailed
+
 goto Exit
 
 :ExitFailed

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/Microsoft/binskim</RepositoryUrl>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup>    
     <Content Include="README.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -74,7 +74,7 @@
     <!-- Required DLLs for Microsoft Visual C++ runtime. -->
     <MsRuntime Include="..\..\refs\runtime\*" />
   </ItemGroup>
-
+	
   <ItemGroup>
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -89,5 +89,6 @@
   <Target Name="PublishMsDiaLibs" AfterTargets="publish">
     <Copy SourceFiles="@(MsDiaLibs)" DestinationFolder="$(PublishDir)\" />
     <Copy SourceFiles="@(MsRuntime)" DestinationFolder="$(PublishDir)\" />
+    <Copy SourceFiles="..\..\src\Nuget\DotnetToolSettings.xml" DestinationFolder="$(PublishDir)\" />
   </Target>
 </Project>

--- a/src/Nuget/BinSkimDotNetTool.nuspec
+++ b/src/Nuget/BinSkimDotNetTool.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.CodeAnalysis.BinSkim.DotNetTool</id>
+    <version>1.0.0</version>
+    <title>Microsoft BinSkim Binary Analysis Security Tool</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,TSE-SecurityTools</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A correctness and security checker for Windows portable executables and Linux ELF binaries. BinSkim scans binaries to ensure they have been compiled in a secure way, e.g., by opting into data execution prevention, address layout randomization and other features. </description>
+    <summary>A correctness and security checker for Windows portable executables and Linux ELF binaries.</summary>
+    <releaseNotes>Version $version$ of BinSkim</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>    
+    <projectUrl>https://github.com/microsoft/binskim</projectUrl>
+    <tags>binary analysis binskim binscope security portable executable linkable format sdl devops devsecops</tags>
+    <packageTypes><packageType name="DotnetTool" /></packageTypes>	
+  </metadata>
+  <files>
+	<file src="bld\bin\x64_$configuration$\DotNetToolPublish\**\*" target="tools"/>   		  
+    <file src="src\ReleaseHistory.md" target="tools\ReleaseHistory.md" />
+    <file src="src\sarif-sdk\src\ReleaseHistory.md" target="tools\ReleaseHistory-Sarif-Sdk.md" />
+  </files>
+</package>

--- a/src/Nuget/DotnetToolSettings.xml
+++ b/src/Nuget/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DotNetCliTool Version="1">
+  <Commands>
+    <Command Name="BinSkim" EntryPoint="BinSkim.dll" Runner="dotnet" />
+  </Commands>
+</DotNetCliTool>


### PR DESCRIPTION
This is a working prototype for BinSkim dotnet tool. Create this PR for future use.

It doesn't use the traditional way as documented in https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create, as BinSkim need to reference native .dll and etc. 
This solution uses .nuspec and builds a publish folder especially for dotnet tool and then copy it into the inner folder of the package and then pack it into a dotnet tool.

The name has to be different from the normal NuGet package we already built, otherwise error will occur during installation.

Install the BinSkim dotnet tool according to https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-use.

