### PR TITLE
Fix for BuildAndTest.sh for public BinSkim

### DIFF
--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -6,6 +6,11 @@ if [[  "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]; then
   sed 's#\\#/#g' src/BinSkim.sln > src/BinSkimUnix.sln
 fi
 
+if [ ! -f src/sarif-sdk/src/Sarif.Sdk.sln ]; then
+  echo "Get submodule..."
+  git submodule update --init --recursive
+fi
+
 dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
 dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll


### PR DESCRIPTION
This is for the public BinSkim, where the existing Linux script does not check out the submodules.

PS. There are already similar scripts in BuildAndTest.cmd to check out submodules. The logic is same.