### PR TITLE
Telemetry enhancements

### DIFF
--- a/src/BinSkim.Driver/BinSkim.cs
+++ b/src/BinSkim.Driver/BinSkim.cs
@@ -22,13 +22,16 @@ namespace Microsoft.CodeAnalysis.IL
 
             bool richResultCode = rewrittenArgs.RemoveAll(arg => arg.Equals("--rich-return-code")) == 0;
 
+            using var telemetry = new Sdk.Telemetry();
+            telemetry.LogCommandLine(args);
+
             return Parser.Default.ParseArguments<
                 AnalyzeOptions,
                 ExportRulesMetadataOptions,
                 ExportConfigurationOptions,
                 DumpOptions>(args)
               .MapResult(
-                (AnalyzeOptions analyzeOptions) => new MultithreadedAnalyzeCommand().Run(analyzeOptions),
+                (AnalyzeOptions analyzeOptions) => new MultithreadedAnalyzeCommand(telemetry).Run(analyzeOptions),
                 (ExportRulesMetadataOptions exportRulesMetadataOptions) => new ExportRulesMetadataCommand().Run(exportRulesMetadataOptions),
                 (ExportConfigurationOptions exportConfigurationOptions) => new ExportConfigurationCommand().Run(exportConfigurationOptions),
                 (DumpOptions dumpOptions) => new DumpCommand().Run(dumpOptions),

--- a/src/BinSkim.Driver/RuleTelemetryLogger.cs
+++ b/src/BinSkim.Driver/RuleTelemetryLogger.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.CodeAnalysis.Sarif;
+
+namespace Microsoft.CodeAnalysis.IL
+{
+    /// <summary>
+    /// A logger that records rule summary telemetry by aggregating result kinds for each rule.
+    /// </summary>
+    internal sealed class RuleTelemetryLogger : IAnalysisLogger
+    {
+        // Application Insights event names
+        internal const string AnalysisRequestName = "Analysis";
+        internal const string RuleSummaryEventName = "RuleSummary";
+
+        // Application Insights property names
+        internal const string RuleIdPropertyName = "RuleId";
+
+        // Application Insights metric names
+        internal const string PassCountMetricName = "Pass";
+        internal const string FailCountMetricName = "Fail";
+        internal const string OpenCountMetricName = "Open";
+        internal const string RuleCountMetricName = "RuleCount";
+        internal const string ReviewCountMetricName = "Review";
+        internal const string NotApplicableCountMetricName = "NA";
+        internal const string InformationalCountMetricName = "Info";
+
+        /// <summary>
+        /// The Application Insights telemetry client.
+        /// </summary>
+        private readonly TelemetryClient telemetryClient;
+
+        /// <summary>
+        /// Dictionary of aggregated counts of result kinds keyed on the rule ID.
+        /// </summary>
+        private readonly Dictionary<string, ResultKindCounts> metricsMap = new Dictionary<string, ResultKindCounts>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Tracks the analysis operation. Will be non-null if analysis is in progress.
+        /// </summary>
+        private IOperationHolder<RequestTelemetry>? analysisOperationHolder;
+
+        /// <summary>
+        /// Construct a new <see cref="RuleTelemetryLogger"/>.
+        /// </summary>
+        /// <param name="telemetryClient">The Application Insights telemetry client.</param>
+        public RuleTelemetryLogger(TelemetryClient telemetryClient)
+        {
+            this.telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public void AnalysisStarted()
+        {
+            this.analysisOperationHolder ??= this.telemetryClient.StartOperation<RequestTelemetry>(AnalysisRequestName);
+        }
+
+        public void AnalysisStopped(RuntimeConditions runtimeConditions)
+        {
+            foreach (KeyValuePair<string, ResultKindCounts> kv in this.metricsMap)
+            {
+                var eventTelemetry = new EventTelemetry(RuleSummaryEventName);
+                eventTelemetry.Properties[RuleIdPropertyName] = kv.Key;
+
+                // To reduce telemetry volume, record only non-zero values
+                ResultKindCounts counts = kv.Value;
+                IDictionary<string, double> metrics = eventTelemetry.Metrics;
+                AddMetricIfNonZero(metrics, counts.NotApplicableCount, NotApplicableCountMetricName);
+                AddMetricIfNonZero(metrics, counts.PassCount, PassCountMetricName);
+                AddMetricIfNonZero(metrics, counts.FailCount, FailCountMetricName);
+                AddMetricIfNonZero(metrics, counts.ReviewCount, ReviewCountMetricName);
+                AddMetricIfNonZero(metrics, counts.OpenCount, OpenCountMetricName);
+                AddMetricIfNonZero(metrics, counts.InformationalCount, InformationalCountMetricName);
+
+                this.telemetryClient.TrackEvent(eventTelemetry);
+            }
+
+            if (this.analysisOperationHolder != null)
+            {
+                RequestTelemetry request = this.analysisOperationHolder.Telemetry;
+                request.ResponseCode = runtimeConditions.ToString();
+                request.Success = runtimeConditions == RuntimeConditions.None;
+                request.Metrics[RuleCountMetricName] = metricsMap.Count;
+                this.analysisOperationHolder.Dispose();
+                this.analysisOperationHolder = null;
+            }
+
+            this.metricsMap.Clear();
+        }
+
+        public void AnalyzingTarget(IAnalysisContext context)
+        {
+        }
+
+        public void Log(ReportingDescriptor rule, Result result)
+        {
+            if (!this.metricsMap.TryGetValue(rule.Id, out ResultKindCounts? counts))
+            {
+                this.metricsMap[rule.Id] = counts = new ResultKindCounts();
+            }
+
+            switch (result.Kind)
+            {
+                case ResultKind.NotApplicable:
+                    counts.NotApplicableCount++;
+                    break;
+
+                case ResultKind.Pass:
+                    counts.PassCount++;
+                    break;
+
+                case ResultKind.Fail:
+                    counts.FailCount++;
+                    break;
+
+                case ResultKind.Review:
+                    counts.ReviewCount++;
+                    break;
+
+                case ResultKind.Open:
+                    counts.OpenCount++;
+                    break;
+
+                case ResultKind.Informational:
+                    counts.InformationalCount++;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        public void LogConfigurationNotification(Sarif.Notification notification)
+        {
+        }
+
+        public void LogToolNotification(Sarif.Notification notification, ReportingDescriptor? associatedRule)
+        {
+        }
+
+        private static void AddMetricIfNonZero(IDictionary<string, double> metrics, int count, string name)
+        {
+            if (count != 0)
+            {
+                metrics[name] = count;
+            }
+        }
+
+        /// <summary>
+        /// Counts of result kinds recorded for each rule.
+        /// </summary>
+        private sealed class ResultKindCounts
+        {
+            /// <summary>
+            /// Count of binaries that had <see cref="ResultKind.NotApplicable"/> result.
+            /// </summary>
+            public int NotApplicableCount;
+
+            /// <summary>
+            /// Count of binaries that had a <see cref="ResultKind.Pass"/> result.
+            /// </summary>
+            public int PassCount;
+
+            /// <summary>
+            /// Count of binaries that had a <see cref="ResultKind.Fail"/> result.
+            /// </summary>
+            public int FailCount;
+
+            /// <summary>
+            /// Count of binaries that had a <see cref="ResultKind.Review"/> result.
+            /// </summary>
+            public int ReviewCount;
+
+            /// <summary>
+            /// Count of binaries that had a <see cref="ResultKind.Open"/> result.
+            /// </summary>
+            public int OpenCount;
+
+            /// <summary>
+            /// Count of binaries that had a <see cref="ResultKind.Informational"/> result.
+            /// </summary>
+            public int InformationalCount;
+        }
+    }
+}

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Security;
-using System.Threading.Tasks;
 
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Readers;
 using Microsoft.CodeAnalysis.Sarif.VersionOne;
@@ -29,12 +27,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
     /// </summary>
     public class CompilerDataLogger : IDisposable
     {
-        [ThreadStatic]
-        internal static TelemetryClient s_injectedTelemetryClient;
-
-        [ThreadStatic]
-        internal static TelemetryConfiguration s_injectedTelemetryConfiguration;
-
         internal static int s_chunkSize = 8192;
 
         // Constant values sent to AppInsights telemetry stream.
@@ -44,7 +36,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         internal const string AssemblyReferencesEventName = "AssemblyReferencesInformation";
 
         internal const string ToolName = "toolName";
-        internal const string SessionId = "sessionId";
         internal const string ProjectId = "projectId";
         internal const string SymbolPath = "symbolPath";
         internal const string BuildRunId = "buildRunId";
@@ -75,9 +66,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
         // Data for persisting telemetry to AppInsights and/or a CSV file.
         internal StreamWriter writer;
-        private readonly string sessionId;
-        private TelemetryClient telemetryClient;
-        private TelemetryConfiguration telemetryConfiguration;
+        private readonly TelemetryClient telemetryClient;
 
         // We currently generate telemetry (such as exceptions that occurred during
         // analysis) that is extracted from the SARIF log file. We currently therefore
@@ -108,10 +97,9 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 "CompilerTelemetry", nameof(RootPathToElide), defaultValue: () => string.Empty,
                 "A non-deterministic file path root that should be elided from paths in telemetry, e.g., 'c:\\Users\\SomeUser\\'.");
 
-        public CompilerDataLogger(string sarifOutputFilePath, Sarif.SarifVersion sarifVersion, BinaryAnalyzerContext context, IFileSystem fileSystem = null)
+        public CompilerDataLogger(string sarifOutputFilePath, Sarif.SarifVersion sarifVersion, BinaryAnalyzerContext context, IFileSystem fileSystem = null, Telemetry telemetry = null)
         {
             this.syncRoot = new object();
-            this.sessionId = Guid.NewGuid().ToString();
             this.fileSystem = fileSystem ?? new FileSystem();
 
             this.sarifOutputFilePath = sarifOutputFilePath;
@@ -119,14 +107,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             this.RootPathToElide = context.Policy.GetProperty(RootPathToElideProperty);
             this.OwningContextHashCode = context.GetHashCode();
             this.symbolPath = context.SymbolPath;
-
-            this.telemetryClient = s_injectedTelemetryClient ?? telemetryClient;
-            this.telemetryConfiguration = s_injectedTelemetryConfiguration ?? telemetryConfiguration;
-
-            if (this.telemetryClient == null)
-            {
-                InitializeTelemetryClientFromEnvironmentData();
-            }
+            this.telemetryClient = telemetry?.TelemetryClient;
 
             bool forceOverwrite = context.ForceOverwrite;
             string csvFilePath = context.Policy.GetProperty(CsvOutputPath);
@@ -159,6 +140,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 {
                     throw new InvalidOperationException($"Output file exists and force overwrite was not specified: {csvFilePath}");
                 }
+
                 fileSystem.FileDelete(csvFilePath);
             }
 
@@ -171,23 +153,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
             this.writer = new StreamWriter(new FileStream(csvFilePath, FileMode.OpenOrCreate));
             PrintHeader();
-        }
-
-        private void InitializeTelemetryClientFromEnvironmentData()
-        {
-            string appInsightsKey = RetrieveAppInsightsKeyFromEnvironment();
-            if (!string.IsNullOrEmpty(appInsightsKey) && Guid.TryParse(appInsightsKey, out _))
-            {
-                this.telemetryConfiguration = new TelemetryConfiguration();
-                string connectionString = $"InstrumentationKey={appInsightsKey}";
-                this.telemetryConfiguration.ConnectionString = connectionString;
-                this.telemetryClient = new TelemetryClient(this.telemetryConfiguration);
-            }
-        }
-
-        public static string RetrieveAppInsightsKeyFromEnvironment()
-        {
-            return RetrieveEnvironmentVariable("BinskimCompilerDataAppInsightsKey");
         }
 
         public static string RetrieveEnvironmentVariable(string name)
@@ -263,8 +228,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 { "dialect", compilerData.Dialect },
                 { "moduleName", compilerData.ModuleName ?? string.Empty },
                 { "moduleLibrary", (compilerData.ModuleName == compilerData.ModuleLibrary ? string.Empty : compilerData.ModuleLibrary ?? string.Empty) },
-                { "sessionId", this.sessionId },
-                { "hash", context.Hashes?.Sha256 },
+                { "hash", fileHash },
                 { "error", string.Empty }
             };
 
@@ -310,7 +274,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 return;
             }
 
-            this.telemetryClient?.TrackEvent(CompilerEventName, properties: new Dictionary<string, string>
+            this.telemetryClient.TrackEvent(CompilerEventName, properties: new Dictionary<string, string>
             {
                 { "target", filePath },
                 { "compilerName", string.Empty },
@@ -325,7 +289,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 { "dialect", string.Empty },
                 { "moduleName", string.Empty },
                 { "moduleLibrary", string.Empty },
-                { "sessionId", this.sessionId },
                 { "hash", fileHash },
                 { "error", errorMessage },
             });
@@ -341,7 +304,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                 {
                     { "toolName", summary.ToolName },
                     { "toolVersion", summary.ToolVersion },
-                    { "sessionId", this.sessionId },
                 });
             }
         }
@@ -359,7 +321,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             {
                 { "toolName", summary.ToolName },
                 { "toolVersion", summary.ToolVersion },
-                { "sessionId", this.sessionId },
                 { "normalizedPath", summary.NormalizedPath },
                 { "symbolPath", summary.SymbolPath },
                 { "numberOfBinaryAnalyzed", summary.FileAnalyzed.ToString() },
@@ -387,7 +348,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
                 this.telemetryClient.TrackEvent(eventName, properties: new Dictionary<string, string>
                 {
-                    { "sessionId", this.sessionId },
                     { $"{contentName}Id", contentId },
                     { "orderNumber", (i + 1).ToString() },
                     { "totalNumber", size.ToString() },
@@ -431,7 +391,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
                 var serializer = new JsonSerializer() { ContractResolver = SarifContractResolverVersionOne.Instance };
 
-                using (JsonTextReader reader = new JsonTextReader(new StreamReader(fileSystem.FileOpenRead(sarifOutputFilePath))))
+                using (var reader = new JsonTextReader(new StreamReader(fileSystem.FileOpenRead(sarifOutputFilePath))))
                 {
                     actualLog = serializer.Deserialize<SarifLogVersionOne>(reader);
                 }
@@ -457,20 +417,6 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             // Flush and close output to our csv file, if present.
             this.writer?.Dispose();
             this.writer = null;
-
-            // Flush and close AppInsights client.
-            if (telemetryClient != null)
-            {
-                this.telemetryClient.Flush();
-
-                // Flush is not blocking when not using InMemoryChannel so wait a bit.
-                // There is an active issue regarding the need for `Sleep`/`Delay`
-                // which is tracked here:
-                // https://github.com/microsoft/ApplicationInsights-dotnet/issues/407
-                Task.Delay(5000).Wait();
-            }
-            this.telemetryConfiguration?.Dispose();
-            this.telemetryConfiguration = null;
         }
     }
 }

--- a/src/BinSkim.Sdk/Telemetry.cs
+++ b/src/BinSkim.Sdk/Telemetry.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading;
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.CodeAnalysis.IL.Sdk
+{
+    /// <summary>
+    /// Wraps an Application Insights telemetry pipeline.
+    /// If Application Insights is enabled, then the <see cref="TelemetryClient"/>
+    /// property will be non-null.
+    /// </summary>
+    public sealed class Telemetry : IDisposable
+    {
+        /// <summary>
+        /// The name of an environment variable that holds the connection
+        /// string for an Application Insights resource.
+        /// </summary>
+        internal const string AppInsightsConnectionStringEnvVar = "BinskimAppInsightsConnectionString";
+
+        /// <summary>
+        /// The name of an environment variable that holds the instrumentation
+        /// key for an Application Insights resource.
+        /// </summary>
+        internal const string AppInsightsInstrumentationKeyEnvVar = "BinskimCompilerDataAppInsightsKey";
+
+        /// <summary>
+        /// Gets the telemetry configuration. May be null if Application Insights
+        /// telemetry is not enabled.
+        /// </summary>
+        private TelemetryConfiguration? TelemetryConfiguration { get; }
+
+        /// <summary>
+        /// Gets the telemetry client. This may be null if Application Insights
+        /// telemetry is not enabled.
+        /// </summary>
+        public TelemetryClient? TelemetryClient { get; }
+
+        /// <summary>
+        /// Construct a new <see cref="Telemetry"/> instance from environment variables.
+        /// </summary>
+        /// <remarks>
+        /// If environment variables aren't set, then <see cref="TelemetryClient"/> will be null.
+        /// </remarks>
+        public Telemetry() : this(CreateTelemetryConfigurationFromEnvironment())
+        {
+        }
+
+        /// <summary>
+        /// Construct a new <see cref="Telemetry"/> instance using
+        /// the given <see cref="ApplicationInsights.Extensibility.TelemetryConfiguration"/>.
+        /// </summary>
+        /// <param name="telemetryConfiguration">The pipeline to use. May be null, in which case
+        /// Application Insights is disabled.</param>
+        /// <remarks>
+        /// If <paramref name="telemetryConfiguration"/> is non-null, it will be
+        /// disposed when this object is disposed.
+        /// </remarks>
+        internal Telemetry(TelemetryConfiguration? telemetryConfiguration)
+        {
+            if (telemetryConfiguration != null)
+            {
+                var telemetryClient = new TelemetryClient(telemetryConfiguration);
+                ConfigureTelemetryContext(telemetryClient.Context);
+                this.TelemetryClient = telemetryClient;
+                this.TelemetryConfiguration = telemetryConfiguration;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Flush and close AppInsights client.
+            this.TelemetryClient?.FlushAsync(CancellationToken.None).GetAwaiter().GetResult();
+            this.TelemetryConfiguration?.Dispose();
+        }
+
+        private static void ConfigureTelemetryContext(TelemetryContext context)
+        {
+            context.Session.Id = CreateRandomSessionId();
+            context.Component.Version = Assembly.GetCallingAssembly().GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            context.Device.OperatingSystem = RuntimeInformation.OSDescription;
+        }
+
+        private static TelemetryConfiguration? CreateTelemetryConfigurationFromEnvironment()
+        {
+            string? connectionString = GetConnectionStringFromEnvironment();
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                return null;
+            }
+
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = connectionString
+            };
+
+            telemetryConfiguration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
+            return telemetryConfiguration;
+        }
+
+        private static string? GetConnectionStringFromEnvironment()
+        {
+            // Try connection string first.
+            string? appInsightsConnectionString = CompilerDataLogger.RetrieveEnvironmentVariable(AppInsightsConnectionStringEnvVar);
+            if (!string.IsNullOrEmpty(appInsightsConnectionString))
+            {
+                return appInsightsConnectionString;
+            }
+
+            // Fall back to instrumentation key.
+            string? appInsightsKey = CompilerDataLogger.RetrieveEnvironmentVariable(AppInsightsInstrumentationKeyEnvVar);
+            if (!string.IsNullOrEmpty(appInsightsKey) && Guid.TryParse(appInsightsKey, out _))
+            {
+                return "InstrumentationKey=" + appInsightsKey;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Create a cryptographically random string to represent a session ID.
+        /// </summary>
+        /// <returns>A unique session ID.</returns>
+        /// <remarks>
+        /// The session ID is a Base64-encoded sequence of random bytes.
+        /// The length of the encoded string will be 16 characters.
+        /// </remarks>
+        private static string CreateRandomSessionId()
+        {
+            using var rng = RandomNumberGenerator.Create();
+
+            // The length of the random byte array should be a
+            // multiple of 3 to get maximum benefit from Base64
+            // encoding with no unnecessary padding characters.
+            // Base64 encoding uses 4 characters for every 3 bytes,
+            // so this will result in a 16 character string.
+            byte[] sessionId = new byte[12];
+            rng.GetBytes(sessionId);
+            return Convert.ToBase64String(sessionId);
+        }
+
+        /// <summary>
+        /// Log the command line arguments as a custom event.
+        /// </summary>
+        /// <param name="args">The command line arguments.</param>
+        public void LogCommandLine(string[]? args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                return;
+            }
+
+            TelemetryClient? telemetryClient = TelemetryClient;
+            if (telemetryClient == null)
+            {
+                return;
+            }
+
+            var item = new EventTelemetry("CommandLine");
+            item.Metrics.Add("argc", args.Length);
+            for (int i = 0; i < args.Length; i++)
+            {
+                item.Properties.Add($"arg{i}", args[i] ?? "null");
+            }
+
+            telemetryClient.TrackEvent(item);
+        }
+    }
+}

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 
 using FluentAssertions;
 
-using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -34,6 +33,7 @@ namespace Microsoft.CodeAnalysis.IL
     public class BuiltInRuleFunctionalTests
     {
         private readonly ITestOutputHelper testOutputHelper;
+        private TelemetryConfiguration telemetryConfiguration;
 
         public BuiltInRuleFunctionalTests(ITestOutputHelper output)
         {
@@ -58,104 +58,124 @@ namespace Microsoft.CodeAnalysis.IL
                 return;
             }
 
-            try
+            List<ITelemetry> sendItems = CompilerTelemetryTestSetup();
+            var sb = new StringBuilder();
+            string testDirectory = PEBinaryTests.BaselineTestDataDirectory + Path.DirectorySeparatorChar;
+            string testFile = Path.Combine(testDirectory, "DotNetCore_win-x86_VS2019_Default.dll");
+
+            SarifLog sarifResult = RunRules(sb, testFile);
+
+            List<CompilerData> records = CollectCompilerDetails(binaryPath: testFile,
+                                                                out int expectedSummaryEventCount,
+                                                                out int expectedCompilerEventCount,
+                                                                out int expectedAssemblyReferencesEventCount,
+                                                                out int expectedCommandLineEventCount);
+
+            var compilerEvents = new List<EventTelemetry>();
+            var assemblyReferencesEvents = new List<EventTelemetry>();
+            var commandLineEvents = new List<EventTelemetry>();
+            var summaryEvents = new List<EventTelemetry>();
+            var ruleSummaryEvents = new List<EventTelemetry>();
+            var analysisRequests = new List<RequestTelemetry>();
+
+            foreach (ITelemetry telemetryItem in sendItems)
             {
-                List<ITelemetry> sendItems = CompilerTelemetryTestSetup();
-                var sb = new StringBuilder();
-                string testDirectory = PEBinaryTests.BaselineTestDataDirectory + Path.DirectorySeparatorChar;
-                string testFile = Path.Combine(testDirectory, "DotNetCore_win-x86_VS2019_Default.dll");
-
-                SarifLog sarifResult = RunRules(sb, testFile);
-
-                string testEnvironmentVar = Environment.GetEnvironmentVariable(nameof(AnalysisSummaryExtractor.ProjectIdVariableName), EnvironmentVariableTarget.Process);
-
-                sendItems.All<ITelemetry>(item => item.GetType() == typeof(EventTelemetry));
-
-                List<CompilerData> records = CollectCompilerDetails(binaryPath: testFile,
-                                                                    out int expectedSummaryEventCount,
-                                                                    out int expectedCompilerEventCount,
-                                                                    out int expectedAssemblyReferencesEventCount,
-                                                                    out int expectedCommandLineEventCount);
-
-                var compilerEvents = new List<EventTelemetry>();
-                var assemblyReferencesEvents = new List<EventTelemetry>();
-                var commandLineEvents = new List<EventTelemetry>();
-                var summaryEvents = new List<EventTelemetry>();
-
-                foreach (EventTelemetry telemetryEvent in sendItems)
+                switch (telemetryItem)
                 {
-                    switch (telemetryEvent.Name)
-                    {
-                        case CompilerDataLogger.CompilerEventName: compilerEvents.Add(telemetryEvent); break;
-                        case CompilerDataLogger.AssemblyReferencesEventName: assemblyReferencesEvents.Add(telemetryEvent); break;
-                        case CompilerDataLogger.CommandLineEventName: commandLineEvents.Add(telemetryEvent); break;
-                        case CompilerDataLogger.SummaryEventName: summaryEvents.Add(telemetryEvent); break;
-                    }
+                    case EventTelemetry telemetryEvent:
+                        switch (telemetryEvent.Name)
+                        {
+                            case CompilerDataLogger.CompilerEventName: compilerEvents.Add(telemetryEvent); break;
+                            case CompilerDataLogger.AssemblyReferencesEventName: assemblyReferencesEvents.Add(telemetryEvent); break;
+                            case CompilerDataLogger.CommandLineEventName: commandLineEvents.Add(telemetryEvent); break;
+                            case CompilerDataLogger.SummaryEventName: summaryEvents.Add(telemetryEvent); break;
+                            case RuleTelemetryLogger.RuleSummaryEventName: ruleSummaryEvents.Add(telemetryEvent); break;
+                        }
+
+                        break;
+
+                    case RequestTelemetry request:
+                        switch (request.Name)
+                        {
+                            case RuleTelemetryLogger.AnalysisRequestName: analysisRequests.Add(request); break;
+                        }
+
+                        break;
+
+                    default:
+                        break;
                 }
-
-                summaryEvents.Should().NotBeNull();
-                if (summaryEvents.Count != expectedSummaryEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} summary event per binary, but found {1}.",
-                                                expectedSummaryEventCount,
-                                                summaryEvents.Count));
-                }
-
-                assemblyReferencesEvents.Should().NotBeNull();
-                if (assemblyReferencesEvents.Count != expectedAssemblyReferencesEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} AssemblyReferencesEvent, but found {1}",
-                                                expectedAssemblyReferencesEventCount,
-                                                assemblyReferencesEvents.Count));
-                }
-
-                // Managed code will not result in any Command Line Events.
-                commandLineEvents.Should().NotBeNull();
-                if (commandLineEvents.Count != expectedCommandLineEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} CommandLineEvents, but found {1}",
-                                                expectedCommandLineEventCount,
-                                                commandLineEvents.Count));
-                }
-
-                compilerEvents.Should().NotBeNull();
-                if (compilerEvents.Count != expectedCompilerEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} CompilerEvent, but found {1}",
-                                                expectedCompilerEventCount,
-                                                compilerEvents.Count));
-                }
-
-                string summaryEventSessionId = summaryEvents.First().Properties["sessionId"];
-                string assemblyReferencesEventSessionId = assemblyReferencesEvents.First().Properties["sessionId"];
-                string compilerEventSessionId = compilerEvents.First().Properties["sessionId"];
-
-                if (summaryEventSessionId != assemblyReferencesEventSessionId)
-                {
-                    sb.AppendLine(
-                        string.Format("SessionIds did not match. `SummaryEvent.SessionId` was {0} and `AssemblyReferencesEvent.SessionId` was {1}",
-                        summaryEventSessionId,
-                        assemblyReferencesEventSessionId));
-                }
-
-                if (summaryEventSessionId != compilerEventSessionId)
-                {
-                    sb.AppendLine(
-                        string.Format("SessionIds did not match. `SummaryEvent.SessionId` was {0} and `CompilerEvent.SessionId` was {1}",
-                        summaryEventSessionId,
-                        compilerEventSessionId));
-                }
-
-                AnalysisSummary summary = AnalysisSummaryExtractor.ExtractAnalysisSummary(sarifResult, string.Empty, null);
-
-                ValidateSummaryEvent(summary, summaryEvents.First(), sb);
             }
-            finally
+
+            summaryEvents.Should().NotBeNull();
+            if (summaryEvents.Count != expectedSummaryEventCount)
             {
-                // Clean mocks from CompilerDataLogger.
-                CompilerDataLogger.s_injectedTelemetryClient = null;
-                CompilerDataLogger.s_injectedTelemetryConfiguration = null;
+                sb.AppendLine(string.Format("Expected {0} summary event per binary, but found {1}.",
+                                            expectedSummaryEventCount,
+                                            summaryEvents.Count));
             }
+
+            assemblyReferencesEvents.Should().NotBeNull();
+            if (assemblyReferencesEvents.Count != expectedAssemblyReferencesEventCount)
+            {
+                sb.AppendLine(string.Format("Expected {0} AssemblyReferencesEvent, but found {1}",
+                                            expectedAssemblyReferencesEventCount,
+                                            assemblyReferencesEvents.Count));
+            }
+
+            // Managed code will not result in any Command Line Events.
+            commandLineEvents.Should().NotBeNull();
+            if (commandLineEvents.Count != expectedCommandLineEventCount)
+            {
+                sb.AppendLine(string.Format("Expected {0} CommandLineEvents, but found {1}",
+                                            expectedCommandLineEventCount,
+                                            commandLineEvents.Count));
+            }
+
+            compilerEvents.Should().NotBeNull();
+            if (compilerEvents.Count != expectedCompilerEventCount)
+            {
+                sb.AppendFormat("Expected {0} CompilerEvent, but found {1}",
+                                            expectedCompilerEventCount,
+                                            compilerEvents.Count);
+            }
+
+            string summaryEventSessionId = summaryEvents.First().Context.Session.Id;
+            string assemblyReferencesEventSessionId = assemblyReferencesEvents.First().Context.Session.Id;
+            string compilerEventSessionId = compilerEvents.First().Context.Session.Id;
+
+            if (summaryEventSessionId != assemblyReferencesEventSessionId)
+            {
+                sb.AppendFormat(
+                    "SessionIds did not match. `SummaryEvent.SessionId` was {0} and `AssemblyReferencesEvent.SessionId` was {1}",
+                    summaryEventSessionId,
+                    assemblyReferencesEventSessionId);
+            }
+
+            if (summaryEventSessionId != compilerEventSessionId)
+            {
+                sb.AppendFormat(
+                    "SessionIds did not match. `SummaryEvent.SessionId` was {0} and `CompilerEvent.SessionId` was {1}",
+                    summaryEventSessionId,
+                    compilerEventSessionId);
+            }
+
+            analysisRequests.Count.Should().Be(1);
+            string expectedRuntimeConditions = (RuntimeConditions.RuleNotApplicableToTarget | RuntimeConditions.OneOrMoreWarningsFired).ToString();
+            string actualRuntimeConditions = analysisRequests.Single().ResponseCode;
+            if (actualRuntimeConditions != expectedRuntimeConditions)
+            {
+                sb.AppendFormat(
+                    "Expected {0}, runtime conditions in AnalysisStopped event but found {1}",
+                    expectedRuntimeConditions,
+                    actualRuntimeConditions);
+            }
+
+            ValidateRuleSummaryEvents(sarifResult, ruleSummaryEvents);
+
+            AnalysisSummary summary = AnalysisSummaryExtractor.ExtractAnalysisSummary(sarifResult, string.Empty, null);
+
+            ValidateSummaryEvent(summary, summaryEvents.First(), sb);
         }
 
         [Fact]
@@ -167,93 +187,112 @@ namespace Microsoft.CodeAnalysis.IL
                 return;
             }
 
-            try
+            List<ITelemetry> sendItems = CompilerTelemetryTestSetup();
+            var sb = new StringBuilder();
+            string testDirectory = PEBinaryTests.BaselineTestDataDirectory + Path.DirectorySeparatorChar;
+            string testFile = Path.Combine(testDirectory, "Native_x64_VS2015_Default.dll");
+
+            SarifLog sarifResult = RunRules(sb, testFile);
+
+            List<CompilerData> records = CollectCompilerDetails(binaryPath: testFile,
+                                                                out int expectedSummaryEventCount,
+                                                                out int expectedCompilerEventCount,
+                                                                out int expectedAssemblyReferencesEventCount,
+                                                                out int expectedCommandLineEventCount);
+
+            var compilerEvents = new List<EventTelemetry>();
+            var assemblyReferencesEvents = new List<EventTelemetry>();
+            var commandLineEvents = new List<EventTelemetry>();
+            var summaryEvents = new List<EventTelemetry>();
+            var ruleSummaryEvents = new List<EventTelemetry>();
+            var analysisRequests = new List<RequestTelemetry>();
+
+            foreach (ITelemetry telemetryItem in sendItems)
             {
-                List<ITelemetry> sendItems = CompilerTelemetryTestSetup();
-                var sb = new StringBuilder();
-                string testDirectory = PEBinaryTests.BaselineTestDataDirectory + Path.DirectorySeparatorChar;
-                string testFile = Path.Combine(testDirectory, "Native_x64_VS2015_Default.dll");
-
-                SarifLog sarifResult = RunRules(sb, testFile);
-
-                sendItems.All<ITelemetry>(item => item.GetType() == typeof(EventTelemetry));
-
-                List<CompilerData> records = CollectCompilerDetails(binaryPath: testFile,
-                                                                    out int expectedSummaryEventCount,
-                                                                    out int expectedCompilerEventCount,
-                                                                    out int expectedAssemblyReferencesEventCount,
-                                                                    out int expectedCommandLineEventCount);
-
-                var compilerEvents = new List<EventTelemetry>();
-                var assemblyReferencesEvents = new List<EventTelemetry>();
-                var commandLineEvents = new List<EventTelemetry>();
-                var summaryEvents = new List<EventTelemetry>();
-
-                foreach (EventTelemetry telemetryEvent in sendItems)
+                switch (telemetryItem)
                 {
-                    switch (telemetryEvent.Name)
-                    {
-                        case CompilerDataLogger.CompilerEventName: compilerEvents.Add(telemetryEvent); break;
-                        case CompilerDataLogger.AssemblyReferencesEventName: assemblyReferencesEvents.Add(telemetryEvent); break;
-                        case CompilerDataLogger.CommandLineEventName: commandLineEvents.Add(telemetryEvent); break;
-                        case CompilerDataLogger.SummaryEventName: summaryEvents.Add(telemetryEvent); break;
-                    }
+                    case EventTelemetry telemetryEvent:
+                        switch (telemetryEvent.Name)
+                        {
+                            case CompilerDataLogger.CompilerEventName: compilerEvents.Add(telemetryEvent); break;
+                            case CompilerDataLogger.AssemblyReferencesEventName: assemblyReferencesEvents.Add(telemetryEvent); break;
+                            case CompilerDataLogger.CommandLineEventName: commandLineEvents.Add(telemetryEvent); break;
+                            case CompilerDataLogger.SummaryEventName: summaryEvents.Add(telemetryEvent); break;
+                            case RuleTelemetryLogger.RuleSummaryEventName: ruleSummaryEvents.Add(telemetryEvent); break;
+                        }
+
+                        break;
+
+                    case RequestTelemetry request:
+                        switch (request.Name)
+                        {
+                            case RuleTelemetryLogger.AnalysisRequestName: analysisRequests.Add(request); break;
+                        }
+
+                        break;
+
+                    default:
+                        break;
                 }
-
-                summaryEvents.Should().NotBeNull();
-                if (summaryEvents.Count != expectedSummaryEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} summary event per binary, but found {1}.",
-                                                expectedSummaryEventCount,
-                                                summaryEvents.Count));
-                }
-
-                assemblyReferencesEvents.Should().NotBeNull();
-                if (assemblyReferencesEvents.Count != expectedAssemblyReferencesEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} AssemblyReferencesEvent, but found {1}",
-                                                expectedAssemblyReferencesEventCount,
-                                                assemblyReferencesEvents.Count));
-                }
-
-                // Managed code will not result in any Command Line Events.
-                commandLineEvents.Should().NotBeNull();
-                if (commandLineEvents.Count != expectedCommandLineEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} CommandLineEvents, but found {1}",
-                                                expectedCommandLineEventCount,
-                                                commandLineEvents.Count));
-                }
-
-                compilerEvents.Should().NotBeNull();
-                if (compilerEvents.Count != expectedCompilerEventCount)
-                {
-                    sb.AppendLine(string.Format("Expected {0} CompilerEvent, but found {1}",
-                                                expectedCompilerEventCount,
-                                                compilerEvents.Count));
-                }
-
-                summaryEvents.Count.Should().Be(1);
-                assemblyReferencesEvents.Count.Should().Be(0);
-                commandLineEvents.Count.Should().Be(25);
-                compilerEvents.Count.Should().Be(35);
-
-                summaryEvents.First().Properties["sessionId"]
-                    .Should().Be(commandLineEvents.First().Properties["sessionId"]);
-
-                summaryEvents.First().Properties["sessionId"]
-                    .Should().Be(compilerEvents.First().Properties["sessionId"]);
-
-                AnalysisSummary summary = AnalysisSummaryExtractor.ExtractAnalysisSummary(sarifResult, string.Empty, null);
-
-                ValidateSummaryEvent(summary, summaryEvents.First(), sb);
             }
-            finally
+
+            summaryEvents.Should().NotBeNull();
+            if (summaryEvents.Count != expectedSummaryEventCount)
             {
-                // Clean mocks from CompilerDataLogger.
-                CompilerDataLogger.s_injectedTelemetryClient = null;
-                CompilerDataLogger.s_injectedTelemetryConfiguration = null;
+                sb.AppendLine(string.Format("Expected {0} summary event per binary, but found {1}.",
+                                            expectedSummaryEventCount,
+                                            summaryEvents.Count));
             }
+
+            assemblyReferencesEvents.Should().NotBeNull();
+            if (assemblyReferencesEvents.Count != expectedAssemblyReferencesEventCount)
+            {
+                sb.AppendLine(string.Format("Expected {0} AssemblyReferencesEvent, but found {1}",
+                                            expectedAssemblyReferencesEventCount,
+                                            assemblyReferencesEvents.Count));
+            }
+
+            // Managed code will not result in any Command Line Events.
+            commandLineEvents.Should().NotBeNull();
+            if (commandLineEvents.Count != expectedCommandLineEventCount)
+            {
+                sb.AppendLine(string.Format("Expected {0} CommandLineEvents, but found {1}",
+                                            expectedCommandLineEventCount,
+                                            commandLineEvents.Count));
+            }
+
+            compilerEvents.Should().NotBeNull();
+            if (compilerEvents.Count != expectedCompilerEventCount)
+            {
+                sb.AppendLine(string.Format("Expected {0} CompilerEvent, but found {1}",
+                                            expectedCompilerEventCount,
+                                            compilerEvents.Count));
+            }
+
+            summaryEvents.Count.Should().Be(1);
+            assemblyReferencesEvents.Count.Should().Be(0);
+            commandLineEvents.Count.Should().Be(25);
+            compilerEvents.Count.Should().Be(35);
+
+            summaryEvents.First().Context.Session.Id
+                .Should().Be(commandLineEvents.First().Context.Session.Id);
+
+            summaryEvents.First().Context.Session.Id
+                .Should().Be(compilerEvents.First().Context.Session.Id);
+
+            analysisRequests.Count.Should().Be(1);
+            RuntimeConditions expectedRuntimeConditions =
+                RuntimeConditions.RuleNotApplicableToTarget |
+                RuntimeConditions.OneOrMoreWarningsFired |
+                RuntimeConditions.OneOrMoreErrorsFired;
+
+            analysisRequests.First().ResponseCode.Should().Be(expectedRuntimeConditions.ToString());
+
+            ValidateRuleSummaryEvents(sarifResult, ruleSummaryEvents);
+
+            AnalysisSummary summary = AnalysisSummaryExtractor.ExtractAnalysisSummary(sarifResult, string.Empty, null);
+
+            ValidateSummaryEvent(summary, summaryEvents.First(), sb);
         }
 
         private List<CompilerData> CollectCompilerDetails(string binaryPath,
@@ -378,6 +417,7 @@ namespace Microsoft.CodeAnalysis.IL
             {
                 expectedDirectory = Path.Combine(Path.GetDirectoryName(inputFileName), "NonWindowsExpected");
             }
+
             if (!Directory.Exists(actualDirectory))
             {
                 Directory.CreateDirectory(actualDirectory);
@@ -386,7 +426,8 @@ namespace Microsoft.CodeAnalysis.IL
             string expectedFileName = Path.Combine(expectedDirectory, fileName + ".sarif");
             string actualFileName = Path.Combine(actualDirectory, fileName + ".sarif");
 
-            var command = new MultithreadedAnalyzeCommand();
+            using var telemetry = new Sdk.Telemetry(this.telemetryConfiguration);
+            var command = new MultithreadedAnalyzeCommand(telemetry);
             var options = new AnalyzeOptions
             {
                 Force = true,
@@ -468,20 +509,57 @@ namespace Microsoft.CodeAnalysis.IL
 
         private List<ITelemetry> CompilerTelemetryTestSetup()
         {
-            List<ITelemetry> sendItems = null;
-            sendItems = new List<ITelemetry>();
-            TelemetryClient telemetryClient;
-            TelemetryConfiguration telemetryConfiguration;
-            telemetryConfiguration = new TelemetryConfiguration();
-            string connectionString = $"InstrumentationKey={Guid.NewGuid()}";
-            telemetryConfiguration.ConnectionString = connectionString;
-            telemetryConfiguration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => sendItems.Add(item) };
-            telemetryConfiguration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
-            telemetryClient = new TelemetryClient(telemetryConfiguration);
-            CompilerDataLogger.s_injectedTelemetryClient = telemetryClient;
-            CompilerDataLogger.s_injectedTelemetryConfiguration = telemetryConfiguration;
+            List<ITelemetry> sendItems = new List<ITelemetry>();
+            this.telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
+                TelemetryChannel = new StubTelemetryChannel { OnSend = sendItems.Add }
+            };
 
+            this.telemetryConfiguration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
             return sendItems;
+        }
+
+        /// <summary>
+        /// Check the rule summary metrics against the actual result.
+        /// </summary>
+        /// <param name="sarifResult">The actual SARIF results.</param>
+        /// <param name="ruleSummaryEvents">Rule summary events from telemetry.</param>
+        private static void ValidateRuleSummaryEvents(SarifLog sarifResult, List<EventTelemetry> ruleSummaryEvents)
+        {
+            ruleSummaryEvents.Count.Should().Be(sarifResult.Runs[0].Tool.Driver.Rules.Count);
+            foreach (EventTelemetry ruleSummaryEvent in ruleSummaryEvents)
+            {
+                string ruleId = ruleSummaryEvent.Properties[RuleTelemetryLogger.RuleIdPropertyName];
+
+                // Note that there may be more than one result for a rule (e.g. BA2004), so
+                // we need to count.
+                int expectedPassCount = 0, expectedFailCount = 0;
+                foreach (Result result in sarifResult.Runs[0].Results.Where(r => r.RuleId == ruleId))
+                {
+                    if (result.Kind == ResultKind.Pass)
+                    {
+                        expectedPassCount++;
+                    }
+                    else
+                    {
+                        expectedFailCount++;
+                    }
+                }
+
+                if (!ruleSummaryEvent.Metrics.TryGetValue(RuleTelemetryLogger.PassCountMetricName, out double actualPassCount))
+                {
+                    actualPassCount = 0;
+                }
+
+                if (!ruleSummaryEvent.Metrics.TryGetValue(RuleTelemetryLogger.FailCountMetricName, out double actualFailCount))
+                {
+                    actualFailCount = 0;
+                }
+
+                actualPassCount.Should().Be(expectedPassCount);
+                actualFailCount.Should().Be(expectedFailCount);
+            }
         }
 
         private StringBuilder ValidateSummaryEvent(AnalysisSummary summary,
@@ -593,6 +671,7 @@ namespace Microsoft.CodeAnalysis.IL
                                         organizationNameVariable,
                                         eventTelemetry.Properties[CompilerDataLogger.OrganizationName]));
             }
+
             if (eventTelemetry.Properties[CompilerDataLogger.ProjectId] != projectIdVariable)
             {
                 sb.Append(string.Format("Unexpected {0} in `SummaryEvent`. Expected {1}, found {2}.",

--- a/src/Test.UnitTests.BinSkim.Driver/TelemetryTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/TelemetryTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using FluentAssertions;
+
+using Microsoft.ApplicationInsights.Extensibility;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BinSkim.Rules
+{
+    public class TelemetryTests
+    {
+        [Fact]
+        public void Telemetry_TelemetryClientShouldBeNullIfEnvironmentVariablesNotSet()
+        {
+            using var telemetry = new IL.Sdk.Telemetry();
+            telemetry.TelemetryClient.Should().BeNull();
+        }
+
+        [Fact]
+        public void Telemetry_ShouldInitializeFromIKeyEnvironmentVariable()
+        {
+            try
+            {
+                string iKey = Guid.NewGuid().ToString();
+                Environment.SetEnvironmentVariable(IL.Sdk.Telemetry.AppInsightsInstrumentationKeyEnvVar, iKey);
+
+                using var telemetry = new IL.Sdk.Telemetry();
+                telemetry.TelemetryClient.Should().NotBeNull();
+            }
+            finally
+            {
+                // Clear environment variable set for this test.
+                Environment.SetEnvironmentVariable(IL.Sdk.Telemetry.AppInsightsInstrumentationKeyEnvVar, null);
+            }
+        }
+
+        [Fact]
+        public void Telemetry_ShouldInitializeFromConnectionStringEnvironmentVariable()
+        {
+            try
+            {
+                string connectionString = "InstrumentationKey=" + Guid.NewGuid().ToString();
+                Environment.SetEnvironmentVariable(IL.Sdk.Telemetry.AppInsightsConnectionStringEnvVar, connectionString);
+
+                using var telemetry = new IL.Sdk.Telemetry();
+                telemetry.TelemetryClient.Should().NotBeNull();
+            }
+            finally
+            {
+                // Clear environment variable set for this test.
+                Environment.SetEnvironmentVariable(IL.Sdk.Telemetry.AppInsightsConnectionStringEnvVar, null);
+            }
+        }
+
+        [Fact]
+        public void Telemetry_ShouldDisposeTelemetryConfigurationInDispose()
+        {
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = "InstrumentationKey=" + Guid.NewGuid().ToString()
+            };
+
+            using (var telemetry = new IL.Sdk.Telemetry(telemetryConfiguration))
+            {
+                telemetryConfiguration.TelemetryChannel.Should().NotBeNull();
+            }
+
+            telemetryConfiguration.TelemetryChannel.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Addresses #785

Move App Insights telemetry out of CompilerDataLogger into its own Telemetry class Add support for connection string via BinskimAppInsightsConnectionString environment variable. Put the session ID in the global context instead of individual events. Use a more compact session ID format.
Log OS and tool version.
Log rule summary data.