### PR TITLE
Hotfix `PdbLoad` not working for `--trace`

### DIFF
--- a/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
+++ b/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.Sarif;
@@ -86,7 +87,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
         public override bool AnalysisComplete { get; set; }
 
-        public override DefaultTraces Traces { get; set; }
+        public override IEnumerable<string> Traces { get; set; }
 
         public CompilerDataLogger CompilerDataLogger
         {

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -13,7 +13,9 @@
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
 
-## **v4.0.0-rc5** UNRELEASED
+## **v4.0.0** UNRELEASED
+* DEP: Update Sarif.Sdk submodule from [120fae35 to ef63e9e](https://github.com/microsoft/sarif-sdk/compare/120fae35...ef63e9e). Full [SARIF SDK Release History](https://github.com/microsoft/sarif-sdk/blob/ef63e9e/src/ReleaseHistory.md).
+* BUG: Fix `PdbLoad` not working for `--trace`. [819](https://github.com/microsoft/binskim/pull/819)
 
 ## **v4.0.0-rc4**
 * DEP: Update Sarif.Sdk submodule from [235394a to 120fae35](https://github.com/microsoft/sarif-sdk/compare/235394a...120fae35). Full [SARIF SDK Release History](https://github.com/microsoft/sarif-sdk/blob/120fae35/src/ReleaseHistory.md).

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -14,7 +14,7 @@
 - UEE => eliminate unhandled exceptions in engine
 
 ## **v4.0.0** UNRELEASED
-* DEP: Update Sarif.Sdk submodule from [120fae35 to ef63e9e](https://github.com/microsoft/sarif-sdk/compare/120fae35...ef63e9e). Full [SARIF SDK Release History](https://github.com/microsoft/sarif-sdk/blob/ef63e9e/src/ReleaseHistory.md).
+* DEP: Update Sarif.Sdk submodule from [120fae35 to f6c3bd8](https://github.com/microsoft/sarif-sdk/compare/120fae35...f6c3bd8). Full [SARIF SDK Release History](https://github.com/microsoft/sarif-sdk/blob/f6c3bd8/src/ReleaseHistory.md).
 * BUG: Fix `PdbLoad` not working for `--trace`. [819](https://github.com/microsoft/binskim/pull/819)
 
 ## **v4.0.0-rc4**


### PR DESCRIPTION
This is a Hotfix on top of the current version of the SDK submodule, not the latest sdk.
The issue is currently `PdbLoad` is broken with exception:
![image](https://user-images.githubusercontent.com/81775155/221729229-2e554ff9-8e0c-45ea-b53c-56ac943ac572.png)

