### PR TITLE
* BUG: Fix `PdbLoad` not working for `--trace`.

### DIFF
--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -16,11 +16,11 @@ namespace Microsoft.CodeAnalysis.IL
         [Option(
             "trace",
             Separator = ';',
-            Default = null,
+            Default = new string[] { },
             HelpText = "Execution traces, expressed as a semicolon-delimited list, that " +
                        "should be emitted to the console and log file (if appropriate). " +
                        "Valid values: PdbLoad.")]
-        public override IEnumerable<string> Traces { get; set; }
+        public new IEnumerable<string> Traces { get; set; } = Array.Empty<string>();
 
         [Option(
             "sympath",

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -13,7 +13,8 @@
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
 
-## **v4.0.0-rc5** UNRELEASED
+## **v4.0.0** UNRELEASED
+* BUG: Fix `PdbLoad` not working for `--trace`. [821](https://github.com/microsoft/binskim/pull/821)
 
 ## **v4.0.0-rc4**
 * DEP: Update Sarif.Sdk submodule from [235394a to 120fae35](https://github.com/microsoft/sarif-sdk/compare/235394a...120fae35). Full [SARIF SDK Release History](https://github.com/microsoft/sarif-sdk/blob/120fae35/src/ReleaseHistory.md).

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
@@ -74,6 +74,25 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         }
 
         [Fact]
+        public void AnalyzeCommand_ShouldNotThrowWithPdbLoadTrace()
+        {
+            var options = new AnalyzeOptions
+            {
+                TargetFileSpecifiers = new string[] { GetThisTestAssemblyFilePath() },
+                Traces = new[] { "PdbLoad" },
+            };
+
+            var command = new MultithreadedAnalyzeCommand
+            {
+                UnitTestOutputVersion = Sarif.SarifVersion.Current
+            };
+
+            int result = command.Run(options);
+            result.Should().Be(0);
+            command.ExecutionException.Should().Be(null);
+        }
+
+        [Fact]
         [Obsolete]
         public void AnalyzeCommand_Hashes_ShouldUpdateDataToInsert()
         {
@@ -114,5 +133,10 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
             return sarifLog;
         }
 
+        private static string GetThisTestAssemblyFilePath()
+        {
+            string filePath = typeof(AnalyzeCommandTests).Assembly.Location;
+            return filePath;
+        }
     }
 }


### PR DESCRIPTION
This is a Hotfix without the need to change sdk code.
The issue is currently `PdbLoad` is broken with exception:
![image](https://user-images.githubusercontent.com/81775155/221729229-2e554ff9-8e0c-45ea-b53c-56ac943ac572.png)

In sdk it is trying to convert `PdbLoad` into `DefaultTraces` enum and it will throw exception because that enum will not have that value, that value is for Binskim only.

The fix is to "hide" the property and so that in sdk it will get an empty list so no error will be throw.
The way we hide the property, in Binskim we will still be able to get the values passed from the command line so this line will still work:
`binaryAnalyzerContext.TracePdbLoads = options.Traces.Contains(nameof(Traces.PdbLoad));`
in path:
`\src\BinSkim.Driver\MultithreadedAnalyzeCommand.cs`

