### PR TITLE
Adding Coyote testing support

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -12,6 +12,8 @@ if "%Configuration%" EQU "" (
 set Configuration=Release
 )
 
+set NightlyTest=%2
+
 @REM Remove existing build data
 if exist bld (rd /s /q bld)
 
@@ -46,6 +48,13 @@ dotnet restore %~dp0src\BinSkim.sln /p:Configuration=%Configuration% --packages 
 :: Build the solution 
 echo Building solution...
 dotnet build --no-restore /verbosity:minimal %~dp0src\BinSkim.sln /p:Configuration=%Configuration% /filelogger /fileloggerparameters:Verbosity=detailed || goto :ExitFailed
+
+:nightly
+if "%NightlyTest%" EQU "nightly" (
+    echo Running nightly Tests
+    dotnet test %~dp0src\BinSkim.sln --no-build --filter TestCategory=NightlyTest
+    goto :Exit
+)
 
 ::Run unit tests 
 echo Run all multitargeting xunit tests

--- a/src/BinSkim.sln
+++ b/src/BinSkim.sln
@@ -58,6 +58,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarif.Converters", "sarif-s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif.Converters", "sarif-sdk\src\Test.UnitTests.Sarif.Converters\Test.UnitTests.Sarif.Converters.csproj", "{E29D948B-BF8D-41D3-9924-01E994602D8A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.ConcurrencyTests", "Test.ConcurrencyTests\Test.ConcurrencyTests.csproj", "{27A04162-2037-41FB-AD76-E179451BB627}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -194,6 +196,14 @@ Global
 		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|x64.ActiveCfg = Release|Any CPU
 		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|x64.Build.0 = Release|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|x64.Build.0 = Debug|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Release|x64.ActiveCfg = Release|Any CPU
+		{27A04162-2037-41FB-AD76-E179451BB627}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Test.ConcurrencyTests/BasicCoyoteTests.cs
+++ b/src/Test.ConcurrencyTests/BasicCoyoteTests.cs
@@ -79,6 +79,7 @@ namespace Test.CoyoteTests
             finally
             {
                 testingEngine.Stop();
+                testingEngine.Dispose();
             }
         }
 

--- a/src/Test.ConcurrencyTests/BasicCoyoteTests.cs
+++ b/src/Test.ConcurrencyTests/BasicCoyoteTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+
+using Microsoft.Coyote;
+using Microsoft.Coyote.Specifications;
+using Microsoft.Coyote.SystematicTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Test.CoyoteTests
+{
+    [TestClass]
+    public class BasicCoyoteTests
+    {
+        /// <summary>
+        /// This is a very simple concurrency unit test, where the bug is hard to manifest
+        /// using traditional test infrastructure. This test serves as a template for using
+        /// Coyote testing (which is able to rapidly reveal the assertion failure).
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task TestTaskAsync()
+        {
+            int value = 0;
+            Task task = Task.Run(() =>
+            {
+                value = 1;
+            });
+
+            Specification.Assert(value == 0, "value is 1");
+            await task;
+        }
+
+        [TestMethod, TestCategory("NightlyTest")]
+        public void SystematicTestScenario()
+        {
+            RunSystematicTest(TestTaskAsync);
+        }
+
+
+        private static void RunSystematicTest(Func<Task> test)
+        {
+            // Configuration for how to run a concurrency unit test with Coyote.
+            Configuration config = Configuration
+                .Create()
+                .WithMaxSchedulingSteps(5000)
+                .WithTestingIterations(1000);
+
+            async Task TestActionAsync()
+            {
+                await test();
+            };
+
+            var testingEngine = TestingEngine.Create(config, TestActionAsync);
+
+            try
+            {
+                testingEngine.Run();
+
+                string assertionText = testingEngine.TestReport.GetText(config);
+                assertionText +=
+                    $"{Environment.NewLine} Random Generator Seed: " +
+                    $"{testingEngine.TestReport.Configuration.RandomGeneratorSeed}{Environment.NewLine}";
+                foreach (string bugReport in testingEngine.TestReport.BugReports)
+                {
+                    assertionText +=
+                    $"{Environment.NewLine}" +
+                    "Bug Report: " + bugReport.ToString(CultureInfo.InvariantCulture);
+                }
+
+                Assert.IsTrue(testingEngine.TestReport.NumOfFoundBugs == 0, assertionText);
+
+                Console.WriteLine(testingEngine.TestReport.GetText(config));
+            }
+            finally
+            {
+                testingEngine.Stop();
+            }
+        }
+
+    }
+}

--- a/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
+++ b/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
@@ -25,6 +25,9 @@
 		<None Update="rewrite.coyote.Windows.Debug.json">
 			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</None>
+		<None Update="rewrite.coyote.Windows.Release.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</None>
 	  <None Update="rewriteUnitTests.ps1">
 	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
 	  </None>

--- a/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
+++ b/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	 <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(Platform)_$(Configuration)\</OutputPath>
     <TargetFramework>netcoreapp3.1</TargetFramework>
 	 <CoyoteVersion>1.7.8</CoyoteVersion>
 	 <PowershellExecutable Condition="'$(OS)'=='Windows_NT'">powershell</PowershellExecutable>

--- a/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
+++ b/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
@@ -33,8 +33,8 @@
 	  </None>
 	</ItemGroup>
 
-	<Target Name="CoyoteRewriting" AfterTargets="AfterBuild">
+	<Target Name="CoyoteRewriting" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)'=='netcoreapp3.1' ">
 		<Exec Command="$(ExecCommand)" />
-	</Target>
+	</Target>		
 
 </Project>

--- a/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
+++ b/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+	 <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(Platform)_$(Configuration)\</OutputPath>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+	 <CoyoteVersion>1.7.8</CoyoteVersion>
+	 <PowershellExecutable Condition="'$(OS)'=='Windows_NT'">powershell</PowershellExecutable>
+	 <PowershellExecutable Condition="'$(PowershellExecutable)'==''">pwsh</PowershellExecutable>
+	 <PathSeparator Condition="'$(OS)'=='Windows_NT'">\</PathSeparator>
+	 <PathSeparator Condition="'$(OS)'!='Windows_NT'">/</PathSeparator>
+  </PropertyGroup>
+
+	<PropertyGroup>
+		<ExecCommand>$(PowershellExecutable) -executionpolicy bypass -command ".$(PathSeparator)rewriteUnitTests.ps1 -Configuration $(Configuration) -CoyoteVersion $(CoyoteVersion) -TargetFramework $(TargetFramework)"</ExecCommand>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Coyote" Version="$(CoyoteVersion)" />
+		<PackageReference Include="Microsoft.Coyote.Test" Version="$(CoyoteVersion)" />
+		<PackageReference Include="Microsoft.Coyote.Tool" Version="$(CoyoteVersion)" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="rewrite.coyote.Windows.Debug.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</None>
+	  <None Update="rewriteUnitTests.ps1">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+
+	<Target Name="CoyoteRewriting" AfterTargets="AfterBuild">
+		<Exec Command="$(ExecCommand)" />
+	</Target>
+
+</Project>

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Debug.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Debug.json
@@ -1,0 +1,4 @@
+{
+  "AssembliesPath": "..\\bld\\bin\\AnyCPU_Debug\\netcoreapp3.1",
+  "Assemblies": [ "Test.ConcurrencyTests.dll" ]
+}

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Debug.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Debug.json
@@ -1,4 +1,4 @@
 {
-  "AssembliesPath": "..\\bld\\bin\\AnyCPU_Debug\\netcoreapp3.1",
+  "AssembliesPath": ".\\bin\\Debug\\netcoreapp3.1",
   "Assemblies": [ "Test.ConcurrencyTests.dll" ]
 }

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
@@ -1,0 +1,4 @@
+{
+  "AssembliesPath": "..\\bld\\bin\\x64_Release\\netcoreapp3.1",
+  "Assemblies": [ "Test.ConcurrencyTests.dll" ]
+}

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
@@ -1,4 +1,4 @@
 {
-  "AssembliesPath": "..\\bld\\bin\\x64_Release\\netcoreapp3.1",
+  "AssembliesPath": "..\\bin\\Release\\netcoreapp3.1",
   "Assemblies": [ "Test.ConcurrencyTests.dll" ]
 }

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
@@ -1,4 +1,4 @@
 {
-  "AssembliesPath": "..\\bin\\Release\\netcoreapp3.1",
+  "AssembliesPath": ".\\bin\\Release\\netcoreapp3.1",
   "Assemblies": [ "Test.ConcurrencyTests.dll" ]
 }

--- a/src/Test.ConcurrencyTests/rewriteUnitTests.ps1
+++ b/src/Test.ConcurrencyTests/rewriteUnitTests.ps1
@@ -1,0 +1,12 @@
+param(
+  [Parameter(Mandatory=$true)][string]$CoyoteVersion="",
+  [Parameter(Mandatory=$true)][string]$Configuration,
+  [Parameter(Mandatory=$true)][string]$TargetFramework
+)
+
+Write-Output "Rewrite Unit Tests with Coyote"
+if ($ENV:OS) {
+    dotnet ../packages/microsoft.coyote.tool/$CoyoteVersion/tools/$TargetFramework/coyote.dll rewrite rewrite.coyote.Windows.$Configuration.json
+} else {
+    dotnet ../packages/microsoft.coyote.tool/$CoyoteVersion/tools/$TargetFramework/coyote.dll rewrite rewrite.coyote.nonWindows.$Configuration.json
+}


### PR DESCRIPTION
This PR makes the following changes:

1. Adds a new project with [Coyote testing](https://microsoft.github.io/coyote/#) enabled. The project uses the standard `MSTest` framework to wrap the Coyote tests.

_Note 1_: Coyote_ is a sophisticated controlled concurrency testing framework from Microsoft Research, which can uncover deep concurrency bugs.
_Note 2_: The output path for this new project is kept separate from the general build output folder (`bld\bin`). Coyote requires instrumenting the binaries, and we do not want to instrument production binaries.

2. The PR adds a post-build task to the new project, which performs a dll instrumentation step after the build. The instrumentation is required for controlling the concurrency.

3. The PR adds a simple concurrency unit test where the bug is very hard to expose. The test is then wrapped inside a Coyote test, to show how quickly Coyote can expose the bug. This also serves as a template for using Coyote.

4. Coyote tests have a new attribute called `NightlyTest`, which will be selectively run in a nightly pipeline.

5. The `BuildAndTest.cmd` has been extended to selectively run tests with the `NightlyTest` attribute.