### PR TITLE
Fix Spacing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This repository contains the source code for BinSkim, a Portable Executable (PE)
 3. Find out more about the Static Analysis Results Interchange Format **([SARIF](https://github.com/sarif-standard/sarif-spec/))** used to output Binskim results
 
 ### How to extract the exe file from the nuget package
+
 If you only want to run the Binskim tool without installing anything, then you can 
+
 1. Download BinSkim from **[NuGet](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/)**
 2. Rename the file extension from .nupkg to .zip (ie. via commandline: `rename microsoft.codeanalysis.binskim.x.y.z.nupkg microsoft.codeanalysis.binskim.x.y.z.zip`)
 3. Unzip


### PR DESCRIPTION
This is only fixing the format missing 2 blank lines per linter, safe to test merge in. 
Not visible change in the rendering of the md file.