### PR TITLE
Fix 4.1.0 issue: `System.InvalidOperationException`: `Sequence contains more than one matching element` when `--trace` is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you only want to run the Binskim tool without installing anything, then you c
 
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
-| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
+| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary. |
 | **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV http://msdl.microsoft.com/download/symbols or Cache d:\symbols;Srv http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -14,7 +14,8 @@
 - UEE => eliminate unhandled exceptions in engine
 - NEW => new feature 
 
-## UNRELEASED
+## **v4.1.1** UNRELEASED
+* BUG: Fix `System.InvalidOperationException`: `Sequence contains more than one matching element` when `--trace` is provided. [896](https://github.com/microsoft/binskim/pull/896)
 
 ## **v4.1.0**
 * NEW: `CompilerInformation` telemetry now emits the last modified date of the scan target. [#873](https://github.com/microsoft/binskim/pull/873)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -17,6 +17,7 @@
 
 ## UNRELEASED
 * BUG: Fix `System.InvalidOperationException`: `Sequence contains more than one matching element` when `--trace` is provided. [896](https://github.com/microsoft/binskim/pull/896)
+* BUG: Fix `--trace` missing supported values from SARIF SDK (`ScanTime`, `RuleScanTime`, `PeakWorkingSet`, `TargetsScanned`, `ResultsSummary`). [896](https://github.com/microsoft/binskim/pull/896)
 * DEP: Update `Microsoft.CodeAnalysis.NetAnalyzers` package from 7.0.0 to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -41,7 +41,7 @@ The **`analyze`** command supports the following additional arguments:
 
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
-| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
+| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary. |
 | **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV http://msdl.microsoft.com/download/symbols or Cache d:\symbols;Srv http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |

--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.IL
     [Verb("analyze", HelpText = "Analyze one or more binary files for security and correctness issues.")]
     public class AnalyzeOptions : AnalyzeOptionsBase
     {
-        private IEnumerable<string> trace;
+        private IEnumerable<string> trace = Array.Empty<string>();
         [Option(
             "trace",
             Separator = ';',

--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using CommandLine;
 
@@ -13,14 +13,23 @@ namespace Microsoft.CodeAnalysis.IL
     [Verb("analyze", HelpText = "Analyze one or more binary files for security and correctness issues.")]
     public class AnalyzeOptions : AnalyzeOptionsBase
     {
+        private IEnumerable<string> trace;
         [Option(
             "trace",
             Separator = ';',
             Default = new string[] { },
             HelpText = "Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, " +
                        "that should be emitted to the console and log file (if appropriate). " +
-                       "Valid values: PdbLoad.")]
-        public new IEnumerable<string> Trace { get; set; } = Array.Empty<string>();
+                       "Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary.")]
+        public new IEnumerable<string> Trace
+        {
+            get => this.trace;
+            set
+            {
+                this.trace = value;
+                base.Trace = value?.Where(s => s != nameof(IL.Traces.PdbLoad));
+            }
+        }
 
         [Option(
             "sympath",

--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.IL
                        "(escape semicolon with backslash in Unix-like OS), that " +
                        "should be emitted to the console and log file (if appropriate). " +
                        "Valid values: PdbLoad.")]
-        public new IEnumerable<string> Traces { get; set; } = Array.Empty<string>();
+        public new IEnumerable<string> Trace { get; set; } = Array.Empty<string>();
 
         [Option(
             "sympath",

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.IL
             context.SymbolPath = options.SymbolsPath;
             context.IgnorePdbLoadError = options.IgnorePdbLoadError;
             context.LocalSymbolDirectories = options.LocalSymbolDirectories;
-            context.TracePdbLoads = options.Traces.Contains(nameof(Traces.PdbLoad));
+            context.TracePdbLoads = options.Trace.Contains(nameof(Traces.PdbLoad));
 
             context.CompilerDataLogger =
                 new CompilerDataLogger(context.OutputFilePath,
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.IL
         {
             Stopwatch stopwatch = null;
 
-            if (analyzeOptions.Traces.Where(s => s == "ScanTime").Any())
+            if (analyzeOptions.Trace.Where(s => s == "ScanTime").Any())
             {
                 stopwatch = Stopwatch.StartNew();
             }

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.IL
         {
             Stopwatch stopwatch = null;
 
-            if (analyzeOptions.Trace.Where(s => s == "ScanTime").Any())
+            if (analyzeOptions.Trace.Where(s => s == nameof(DefaultTraces.ScanTime)).Any())
             {
                 stopwatch = Stopwatch.StartNew();
             }

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
             var options = new AnalyzeOptions
             {
                 TargetFileSpecifiers = new string[] { GetThisTestAssemblyFilePath() },
-                Traces = new[] { "PdbLoad" },
+                Trace = new[] { "PdbLoad" },
             };
 
             var command = new MultithreadedAnalyzeCommand
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
 
             BinaryAnalyzerContext context = null;
             int result = command.Run(options, ref context);
+            context.TracePdbLoads.Should().BeTrue();
             context.RuntimeExceptions.Should().BeNull();
             result.Should().Be(0);
         }

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
@@ -438,7 +438,6 @@ namespace Microsoft.CodeAnalysis.IL
                 ConfigurationFilePath = "default",
                 SarifOutputVersion = Sarif.SarifVersion.Current,
                 TargetFileSpecifiers = new string[] { inputFileName },
-                Trace = Array.Empty<string>(),
                 Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note },
                 Kind = new List<ResultKind> { ResultKind.Fail, ResultKind.Pass },
             };

--- a/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/BaselineTests.cs
@@ -438,7 +438,7 @@ namespace Microsoft.CodeAnalysis.IL
                 ConfigurationFilePath = "default",
                 SarifOutputVersion = Sarif.SarifVersion.Current,
                 TargetFileSpecifiers = new string[] { inputFileName },
-                Traces = Array.Empty<string>(),
+                Trace = Array.Empty<string>(),
                 Level = new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note },
                 Kind = new List<ResultKind> { ResultKind.Fail, ResultKind.Pass },
             };


### PR DESCRIPTION
## Update: this PR now not just fix the unhandled exception but also fix:
### Fix `--trace` missing supported values from SARIF SDK (`ScanTime`, `RuleScanTime`, `PeakWorkingSet`, `TargetsScanned`, `ResultsSummary`)

## Issue:
Found a bug In 4.1.0 , if `--trace` is provided will have unhandled exception.
The reason is new new pipeline change has SDK traces changed to trace, because we overwrite in BinSkim, we need to change the name ass well.

This is the full error:
![image](https://github.com/microsoft/binskim/assets/81775155/7be58ca0-d0bb-463b-8040-3e630a2f1b3f)
