### PR TITLE
Update Microsoft.CodeAnalysis.NetAnalyzers 7.0.0 --> 7.0.1

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,7 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
-* DEP: Update 'Microsoft.CodeAnalysis.NetAnalyzers' package from 7.0.0 to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
+* DEP: Update `Microsoft.CodeAnalysis.NetAnalyzers` package from 7.0.0 to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**
 * NEW: `CompilerInformation` telemetry now emits the last modified date of the scan target. [#873](https://github.com/microsoft/binskim/pull/873)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,7 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
-* DEP: Update 'Microsoft.CodeAnalysis.NetAnalyzers' package to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
+* DEP: Update 'Microsoft.CodeAnalysis.NetAnalyzers' package from 7.0.0 to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**
 * NEW: `CompilerInformation` telemetry now emits the last modified date of the scan target. [#873](https://github.com/microsoft/binskim/pull/873)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,7 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
-* DEP: Eliminate build warning - The .NET SDK has newer analyzers with version '7.0.1' than what version of '7.0.0' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference. [#903](https://github.com/microsoft/binskim/pull/903)
+* DEP: Update 'Microsoft.CodeAnalysis.NetAnalyzers' package to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**
 * NEW: `CompilerInformation` telemetry now emits the last modified date of the scan target. [#873](https://github.com/microsoft/binskim/pull/873)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -12,9 +12,11 @@
 - FND => False negative reduction in dynamic phase
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
+- DEP => upgrade dependency versions
 - NEW => new feature 
 
 ## UNRELEASED
+* BUG: Eliminate build warning - The .NET SDK has newer analyzers with version '7.0.1' than what version of '7.0.0' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**
 * NEW: `CompilerInformation` telemetry now emits the last modified date of the scan target. [#873](https://github.com/microsoft/binskim/pull/873)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,7 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
-* BUG: Eliminate build warning - The .NET SDK has newer analyzers with version '7.0.1' than what version of '7.0.0' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference. [#903](https://github.com/microsoft/binskim/pull/903)
+* DEP: Eliminate build warning - The .NET SDK has newer analyzers with version '7.0.1' than what version of '7.0.0' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**
 * NEW: `CompilerInformation` telemetry now emits the last modified date of the scan target. [#873](https://github.com/microsoft/binskim/pull/873)

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -75,13 +75,6 @@
     <MsRuntime Include="..\..\refs\runtime\*" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <Target Name="CopyMsDiaLibs" AfterTargets="build">
     <Copy SourceFiles="@(MsDiaLibs)" DestinationFolder="$(OutputPath)\" />
     <Copy SourceFiles="@(MsRuntime)" DestinationFolder="$(OutputPath)\" />

--- a/src/BinSkim.Rules/BinSkim.Rules.csproj
+++ b/src/BinSkim.Rules/BinSkim.Rules.csproj
@@ -43,10 +43,4 @@
     </EmbeddedResource>
   </ItemGroup>
   
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/BinSkim.Rules/BinSkim.Rules.csproj
+++ b/src/BinSkim.Rules/BinSkim.Rules.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/BinSkim.Sdk/BinSkim.Sdk.csproj
+++ b/src/BinSkim.Sdk/BinSkim.Sdk.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/BinSkim.Sdk/BinSkim.Sdk.csproj
+++ b/src/BinSkim.Sdk/BinSkim.Sdk.csproj
@@ -35,10 +35,4 @@
     </EmbeddedResource>
   </ItemGroup>
   
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/BinaryParsers/BinaryParsers.csproj
+++ b/src/BinaryParsers/BinaryParsers.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/BinaryParsers/BinaryParsers.csproj
+++ b/src/BinaryParsers/BinaryParsers.csproj
@@ -43,10 +43,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
@@ -55,10 +55,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj
@@ -41,10 +41,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj
+++ b/src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj
@@ -31,7 +31,7 @@
     <Folder Include="Samples\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj
+++ b/src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj
@@ -30,10 +30,4 @@
   <ItemGroup>
     <Folder Include="Samples\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj
+++ b/src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj
@@ -25,10 +25,4 @@
     <ProjectReference Include="..\BinSkim.Rules\BinSkim.Rules.csproj" />
     <ProjectReference Include="..\BinSkim.Sdk\BinSkim.Sdk.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj
+++ b/src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\BinSkim.Sdk\BinSkim.Sdk.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj
+++ b/src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj
+++ b/src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj
@@ -32,10 +32,4 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/build.common.props
+++ b/src/build.common.props
@@ -60,7 +60,7 @@
   </ItemGroup>
   
   <ItemGroup Label="Common Packages">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
There is a new version of the Microsoft.CodeAnalysis.NetAnalyzers package available (7.0.1)

Warnings were being generated that a new version of the NetAnalyzers were availble.
This PR will update all of the package references to the new version 7.0.1