### PR TITLE
Fix `sympath` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you only want to run the Binskim tool without installing anything, then you c
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
 | **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary. |
-| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) |
+| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) See https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/advanced-symsrv-use for syntax information. |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |
 | **`-r, --recurse [true\|false]`** | If true, recurse into subdirectories when evaluating file specifier arguments |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you only want to run the Binskim tool without installing anything, then you c
 
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
-| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
+| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary. |
 | **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you only want to run the Binskim tool without installing anything, then you c
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
 | **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
-| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols or Cache*d:\symbols;Srv*http://symweb`) |
+| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |
 | **`-r, --recurse [true\|false]`** | If true, recurse into subdirectories when evaluating file specifier arguments |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you only want to run the Binskim tool without installing anything, then you c
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
 | **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
-| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV http://msdl.microsoft.com/download/symbols or Cache d:\symbols;Srv http://symweb`) |
+| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols or Cache*d:\symbols;Srv*http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |
 | **`-r, --recurse [true\|false]`** | If true, recurse into subdirectories when evaluating file specifier arguments |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -41,7 +41,7 @@ The **`analyze`** command supports the following additional arguments:
 
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
-| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
+| **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary. |
 | **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,7 +42,7 @@ The **`analyze`** command supports the following additional arguments:
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
 | **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
-| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV http://msdl.microsoft.com/download/symbols or Cache d:\symbols;Srv http://symweb`) |
+| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols or Cache*d:\symbols;Srv*http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |
 | **`-r, --recurse [true\|false]`** | If true, recurse into subdirectories when evaluating file specifier arguments |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,7 +42,7 @@ The **`analyze`** command supports the following additional arguments:
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
 | **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad, ScanTime, RuleScanTime, PeakWorkingSet, TargetsScanned, ResultsSummary. |
-| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) |
+| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) See https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/advanced-symsrv-use for syntax information. |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |
 | **`-r, --recurse [true\|false]`** | If true, recurse into subdirectories when evaluating file specifier arguments |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,7 +42,7 @@ The **`analyze`** command supports the following additional arguments:
 | Argument (short form, long form) | Meaning |
 | -------------------------------- | ------- |
 | **`--trace`** | Execution traces, expressed as a semicolon-delimited list enclosed in double quotes, that should be emitted to the console and log file (if appropriate). Valid values: PdbLoad. |
-| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols or Cache*d:\symbols;Srv*http://symweb`) |
+| **`--sympath`** | Symbol paths, expressed as a semicolon-delimited list enclosed in double quotes. (e.g. `SRV*http://msdl.microsoft.com/download/symbols` or `Cache*d:\symbols;Srv*http://symweb`) |
 | **`--local-symbol-directories`** | Local directory paths, expressed as a semicolon-delimited list enclosed in double quotes, that will be examined when attempting to locate PDBs. |
 | **`-o, --output`** | File path used to write and output analysis using [SARIF](https://github.com/Microsoft/sarif-sdk) |
 | **`-r, --recurse [true\|false]`** | If true, recurse into subdirectories when evaluating file specifier arguments |


### PR DESCRIPTION
Providing the right examples for user.
See https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/advanced-symsrv-use for syntax information.