### PR TITLE
* NEW: BinSkim will now log warning `OneOrMoreSymbolServersProvidedInaccessible` if can not connect to the http symbol servers provided by `--sympath`

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,7 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
-* NEW: BinSkim will now log warning `OneOrMoreSymbolServersProvidedInaccessible` if can not connect to the http symbol servers provided by `--sympath`. [#907](https://github.com/microsoft/binskim/pull/907)
+* NEW: BinSkim will now log warning `OneOrMoreSymbolServersProvidedInaccessible` if can not connect to the http symbol servers provided by `--sympath`. [#908](https://github.com/microsoft/binskim/pull/908)
 * DEP: Update `Microsoft.CodeAnalysis.NetAnalyzers` package from 7.0.0 to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,6 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
+* NEW: BinSkim will now log warning `OneOrMoreSymbolServersProvidedInaccessible` if can not connect to the http symbol servers provided by `--sympath`. [#907](https://github.com/microsoft/binskim/pull/907)
 * DEP: Update `Microsoft.CodeAnalysis.NetAnalyzers` package from 7.0.0 to 7.0.1 to resolve build warnings. [#903](https://github.com/microsoft/binskim/pull/903)
 
 ## **v4.1.0**

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -69,6 +69,24 @@ namespace Microsoft.CodeAnalysis.IL
 
             // Update context object based on command-line parameters.
             context.SymbolPath = options.SymbolsPath;
+
+            IList<string> inaccessibleSymbolPaths = DriverUtilities.GetInaccessibleSymbolPaths(context.SymbolPath);
+
+            if (inaccessibleSymbolPaths.Count > 0)
+            {
+                // These symbol servers provided are inaccessible: {0}.
+                context.Logger.LogConfigurationNotification(
+                    Errors.CreateNotification(
+                        context.CurrentTarget?.Uri,
+                        "OneOrMoreSymbolServersProvidedInaccessible",
+                        ruleId: null,
+                        FailureLevel.Warning,
+                        exception: null,
+                        persistExceptionStack: false,
+                        messageFormat: RuleResources.OneOrMoreSymbolServersProvidedInaccessible,
+                        string.Join(";", inaccessibleSymbolPaths)));
+            }
+
             context.IgnorePdbLoadError = options.IgnorePdbLoadError;
             context.LocalSymbolDirectories = options.LocalSymbolDirectories;
             context.TracePdbLoads = options.Traces.Contains(nameof(Traces.PdbLoad));

--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -1583,6 +1583,15 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to These symbol servers provided are inaccessible: {0}..
+        /// </summary>
+        internal static string OneOrMoreSymbolServersProvidedInaccessible {
+            get {
+                return ResourceManager.GetString("OneOrMoreSymbolServersProvidedInaccessible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not locate the PDB for &apos;{0}&apos;. Probing details:
         ///{1}.
         /// </summary>

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -642,4 +642,7 @@ Modules did not meet the criteria: {1}</value>
   <data name="BA6006_Warning" xml:space="preserve">
     <value>'{0}' was compiled without Link Time Code Generation (/LTCG). Enabling LTCG can improve optimizations and performance.</value>
   </data>
+  <data name="OneOrMoreSymbolServersProvidedInaccessible" xml:space="preserve">
+    <value>These symbol servers provided are inaccessible: {0}.</value>
+  </data>
 </root>

--- a/src/Test.UnitTests.BinSkim.Driver/DriverUtilitiesTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/DriverUtilitiesTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.IL;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BinSkim.Rules
+{
+    public class DriverUtilitiesTests
+    {
+        [Fact]
+        public void GetInaccessibleSymbolPathsTests()
+        {
+            DriverUtilities.GetInaccessibleSymbolPaths(null)
+                .Should().BeEquivalentTo(Array.Empty<string>());
+            DriverUtilities.GetInaccessibleSymbolPaths("")
+                .Should().BeEquivalentTo(Array.Empty<string>());
+            DriverUtilities.GetInaccessibleSymbolPaths("SRV*http://msdl.microsoft.com/download/symbols")
+                .Should().BeEquivalentTo(Array.Empty<string>());
+            DriverUtilities.GetInaccessibleSymbolPaths("SRV*c:\\symbols*http://msdl.microsoft.com/download/symbols")
+                .Should().BeEquivalentTo(Array.Empty<string>());
+            DriverUtilities.GetInaccessibleSymbolPaths("CACHE*c:\\symbols;SRV*http://notexists/SymStore*http://notexists2/SymStore")
+                .Should().BeEquivalentTo(new[] { "http://notexists/SymStore", "http://notexists2/SymStore" });
+        }
+    }
+}


### PR DESCRIPTION
### Issue:

User provided:
`--sympath srv*https://username:password@artifacts.dev.azure.com/Org/_apis/Symbol/symsrv`
It does not work for some reason. It is running on server which is less easy to verify if issues unrelated to BinSkim itself:
1. network restrictions the url can not be reached
2. user name and password wrong

### Change:
Add the probe and when the user provided http symbol server can not be reached, we log a warning message.
