### PR TITLE
Fix BA2004 bug creating error with empty list

### DIFF
--- a/src/BinSkim.Rules/PERules/BA2004.EnableSecureSourceCodeHashing.cs
+++ b/src/BinSkim.Rules/PERules/BA2004.EnableSecureSourceCodeHashing.cs
@@ -252,17 +252,20 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 compilandsWithOneOrMoreInsecureFileHashes.Remove(HashType.None);
             }
 
-            string[] messages = new string[compilandsWithOneOrMoreInsecureFileHashes.Count];
-
-            int hashTypeCount = 0;
-            foreach (HashType hashType in compilandsWithOneOrMoreInsecureFileHashes.Keys)
+            if (compilandsWithOneOrMoreInsecureFileHashes.Count > 0)
             {
-                objectModuleDetails = compilandsWithOneOrMoreInsecureFileHashes[hashType];
-                messages[hashTypeCount++] = objectModuleDetails.CreateOutputCoalescedByCompiler(hashType.ToString());
-            }
+                string[] messages = new string[compilandsWithOneOrMoreInsecureFileHashes.Count];
 
-            message = string.Join(Environment.NewLine, messages);
-            GenerateCompilandsAndLog(context, message, failureLevel);
+                int hashTypeCount = 0;
+                foreach (HashType hashType in compilandsWithOneOrMoreInsecureFileHashes.Keys)
+                {
+                    objectModuleDetails = compilandsWithOneOrMoreInsecureFileHashes[hashType];
+                    messages[hashTypeCount++] = objectModuleDetails.CreateOutputCoalescedByCompiler(hashType.ToString());
+                }
+
+                message = string.Join(Environment.NewLine, messages);
+                GenerateCompilandsAndLog(context, message, failureLevel);
+            }
         }
 
         private void GenerateCompilandsAndLog(BinaryAnalyzerContext context, string message, FailureLevel failureLevel)


### PR DESCRIPTION
when all error are caused by no hash, the current code will also generate an error with no item in the list.
generate an error will cause pipeline to fail, so we should fix it.