### PR TITLE
Adding VC project properties info to 'how to resolve' suggestions.

### DIFF
--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -61,7 +61,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a 64-bit image with a preferred base address below the 4GB boundary. Having a preferred base address below this boundary triggers a compatibility mode in Address Space Layout Randomization (ASLR) on recent versions of Windows that reduces the number of locations to which ASLR may relocate the binary. This reduces the effectiveness of ASLR at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from co [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a 64-bit image with a preferred base address below the 4GB boundary. 
+        ///Having a preferred base address below this boundary triggers a compatibility mode in Address Space Layout Randomization (ASLR) on recent versions of Windows that reduces the number of locations to which ASLR may relocate the binary. This reduces the effectiveness of ASLR at mitigating memory corruption vulnerabilities.
+        ///To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2001_Error {
             get {
@@ -70,7 +72,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to 64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities.
+        ///To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2001_LoadImageAboveFourGigabyteAddress_Description {
             get {
@@ -115,7 +118,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code.
+        ///This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs.
+        ///This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm use [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2004_EnableSecureSourceCodeHashing_Description {
             get {
@@ -133,7 +138,11 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a native binary that directly compiles and links one or more object files which were hashed using an insecure checksum algorithm. Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity. Pass &apos;/ZH:SHA_256&apos; on the cl.exe command-line to enable secure source code hashing. The following modules are out of policy:
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a native binary that directly compiles and links one or more object files which were hashed using an insecure checksum algorithm.
+        ///Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity.
+        ///Use MSVC 17.0 (14.30.*) or later if possible.
+        ///When using older MSVC versions, pass &apos;/ZH:SHA_256&apos; on the cl.exe command-line to enable secure source code hashing.
+        ///The following modules are out of policy:
         ///{1}.
         /// </summary>
         internal static string BA2004_Error_NativeWithInsecureDirectCompilands {
@@ -152,7 +161,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a native binary that links one or more static libraries that include object files which were hashed using an insecure checksum algorithm. Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity. Pass &apos;/ZH:SHA_256&apos; on the cl.exe command-line to enable secure source code hashing. The following modules are out of policy:
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a native binary that links one or more static libraries that include object files which were hashed using an insecure checksum algorithm.
+        ///Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity.
+        ///To resolve this issue, use newer versions of libraries that are compiled with /ZH:SHA_256. MSVC: 17.0 (14.30.*) or later. Windows SDK: 10.0.18362.0 or later.
+        ///The following modules are out of policy:
         ///{1}.
         /// </summary>
         internal static string BA2004_Warning_NativeWithInsecureStaticLibraryCompilands {
@@ -171,7 +183,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning..
+        ///   Looks up a localized string similar to &apos;{0}&apos; appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. 
+        ///To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning..
         /// </summary>
         internal static string BA2005_Error {
             get {
@@ -207,7 +220,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks..
+        ///   Looks up a localized string similar to Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. 
+        ///Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks..
         /// </summary>
         internal static string BA2006_BuildWithSecureTools_Description {
             get {
@@ -216,7 +230,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with one or more modules which were not built using minimum required tool versions (compiler version {1}). More recent toolchains contain mitigations that make it more difficult for an attacker to exploit vulnerabilities in programs they produce. To resolve this issue, compile and/or link your binary with more recent tools. If you are servicing a product where the tool chain cannot be modified (e.g. producing a hotfix for an already shipped version) ignore this warning. Modules built outs [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with one or more modules which were not built using minimum required tool versions (compiler version {1}). More recent toolchains contain mitigations that make it more difficult for an attacker to exploit vulnerabilities in programs they produce.
+        ///To resolve this issue, compile and/or link your binary with more recent tools. If you are servicing a product where the tool chain cannot be modified (e.g. producing a hotfix for an already shipped version) ignore this warning. Modules built out [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2006_Error {
             get {
@@ -261,7 +276,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted..
+        ///   Looks up a localized string similar to Binaries should be compiled with a warning level that enables all critical security-relevant checks.
+        ///Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities.
+        ///To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted.
+        ///For VC projects use %(ClCompile.WarningLevel) ItemDefin [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2007_EnableCriticalCompilerWarnings_Description {
             get {
@@ -270,8 +288,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled at too low a warning level (effective warning level {1} for one or more modules). Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted. An example compiler command line triggering this check: {2}
-        ///Modules triggering this check: {3}.
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled at too low a warning level (effective warning level {1} for one or more modules).
+        ///Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities.
+        ///To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted.
+        ///For VC projects use ItemDefinitionGroup - ClCompile - WarningLevel property with &apos;Level3&apos;, &apos;Le [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2007_Error_InsufficientWarningLevel {
             get {
@@ -289,8 +309,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation. An example compiler command line triggering this check was: {1}
-        ///Modules tr [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities.
+        ///To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation.
+        ///For VC projects check ItemDefinitionGroup - ClCompile - DisableSpecificWa [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2007_Error_WarningsDisabled {
             get {
@@ -317,7 +338,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not enable the control flow guard (CFG) mitigation. To resolve this issue, pass /guard:cf on both the compiler and linker command lines. Binaries also require the /DYNAMICBASE linker option in order to enable CFG..
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not enable the control flow guard (CFG) mitigation.
+        ///To resolve this issue, pass /guard:cf on both the compiler and linker command lines. Binaries also require the /DYNAMICBASE linker option in order to enable CFG.
+        ///For VC projects use ItemDefinitionGroup - ClCompile - ControlFlowGuard property with &apos;Guard&apos; value, link CFG property will be set automatically..
         /// </summary>
         internal static string BA2008_Error {
             get {
@@ -353,7 +376,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. To resolve this issue, configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later..
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities.
+        ///To resolve this issue, configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line.
+        ///For VC projects use ItemDefinitionGroup - Link - RandomizedBaseAddress property with &apos;true&apos; value [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2009_Error_NotDynamicBase {
             get {
@@ -389,7 +414,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable.
+        ///To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2010_DoNotMarkImportsSectionAsExecutable_Description {
             get {
@@ -398,7 +424,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; has the imports section marked executable. Because the loader will always mark the imports section as writable, it is important to mark this section as non-executable, so that an attacker cannot place shellcode here. To resolve this issue, ensure that your program does not mark the imports section as executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the &quot;.rdata&quot; segment into a [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; has the imports section marked executable. Because the loader will always mark the imports section as writable, it is important to mark this section as non-executable, so that an attacker cannot place shellcode here.
+        ///To resolve this issue, ensure that your program does not mark the imports section as executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the &quot;.rdata&quot; segment into  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2010_Error {
             get {
@@ -416,7 +443,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line..
+        ///   Looks up a localized string similar to Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities.
+        ///To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the cl.exe command line.
+        ///For VC projects use ItemDefinitionGroup - ClCompile - BufferSecurityCheck property with &apos;true&apos; value..
         /// </summary>
         internal static string BA2011_EnableStackProtection_Description {
             get {
@@ -425,7 +454,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary built with the stack protector buffer security feature disabled in one or more modules. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that your code is compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line. The affected modules were: {1}.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary built with the stack protector buffer security feature disabled in one or more modules. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+        ///To resolve this issue, ensure that your code is compiled with the stack protector enabled by supplying /GS on cl.exe command line.
+        ///For VC projects use ItemDefinitionGroup - ClCompile - BufferSecurityCheck property with &apos;true&apos; value.        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2011_Error {
             get {
@@ -452,7 +483,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the &quot;security cookie&quot;, to detect these buffer overflows. This &apos;cookie&apos; is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. 
+        ///The stack protector relies on a random number, called the &quot;security cookie&quot;, to detect these buffer overflows. This &apos;cookie&apos; is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie.
+        ///On recent Windows versions, the loader looks for  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2012_DoNotModifyStackProtectionCookie_Description {
             get {
@@ -461,7 +494,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary that interferes with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the &quot;security cookie&quot;, to detect these buffer overflows. This &apos;cookie&apos; is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks fo [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary that interferes with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+        ///The stack protector relies on a random number, called the &quot;security cookie&quot;, to detect these buffer overflows. This &apos;cookie&apos; is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie.
+        ///On recent Windows versions, the loader looks  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2012_Error {
             get {
@@ -515,7 +550,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary that does not initialize the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary&apos;s entry point as possible. Failing to do so will result in spurious bu [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary that does not initialize the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+        ///The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary&apos;s entry point as possible. Failing to do so will result in spurious b [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2013_Error {
             get {
@@ -524,7 +560,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary&apos;s entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To re [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities.
+        ///The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary&apos;s entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector.
+        ///To  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2013_InitializeStackProtection_Description {
             get {
@@ -560,7 +598,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been s [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+        ///Disabling the stack protector, even on a function-by-function basis, can compromise the security of code.
+        ///To resolve this issue, remove occurrences of __declspec(safebuffers) from your code.
+        ///If the additional code inserted by the stack protector has bee [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2014_DoNotDisableStackProtectionForFunctions_Description {
             get {
@@ -569,7 +610,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary built with function(s) ({1}) that disable the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, is disallowed by SDL policy. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in prof [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a C or C++ binary built with function(s) ({1}) that disable the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+        ///Disabling the stack protector, even on a function-by-function basis, is disallowed by SDL policy.
+        ///To resolve this issue, remove occurrences of __declspec(safebuffers) from your code.
+        ///If the additional code inserted by the stack protector has been shown in p [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2014_Error {
             get {
@@ -587,7 +631,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR..
+        ///   Looks up a localized string similar to Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities.
+        ///To resolve this issue, don&apos;t set /HIGHENTROPYV:NO on link.exe command line and allow it to be enabled by default. .
         /// </summary>
         internal static string BA2015_EnableHighEntropyVirtualAddresses_Description {
             get {
@@ -596,7 +641,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tools to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA as well as /LARGEADDRESSAWARE to the C or C++ linker command line..
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
+        ///To resolve this issue, don&apos;t set /HIGHENTROPYVA:NO and /LARGEADDRESSAWARE:NO on link.exe command line and allow then to be enabled by default..
         /// </summary>
         internal static string BA2015_Error_NeitherHighEntropyVANorLargeAddressAware {
             get {
@@ -605,7 +651,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tools to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. (This image was determined to have been properly compiled as /LARGEADDRESSAWARE.).
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
+        ///To resolve this issue, don&apos;t set /HIGHENTROPYVA:NO on link.exe command line and allow it to be enabled by default. (This image was determined to have been properly compiled as /LARGEADDRESSAWARE.).
         /// </summary>
         internal static string BA2015_Error_NoHighEntropyVA {
             get {
@@ -614,7 +661,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tools to mark the program high entropy compatible by supplying /LARGEADDRESSAWARE to the C or C++ linker command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.).
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
+        ///To resolve this issue, don&apos;t set /LARGEADDRESSAWARE:NO on link.exe command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.).
         /// </summary>
         internal static string BA2015_Error_NoLargeAddressAware {
             get {
@@ -632,7 +680,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not marked NX compatible. The NXCompat bit, also known as &quot;Data Execution Prevention&quot; (DEP) or &quot;Execute Disable&quot; (XD), is a processor feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit, because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment. To resolve this issue, en [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not marked NX compatible. The NXCompat bit, also known as &quot;Data Execution Prevention&quot; (DEP) or &quot;Execute Disable&quot; (XD), is a processor feature that allows a program to mark a piece of memory as non-executable.
+        ///This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit, because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment.
+        ///To resolve this issue,  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2016_Error {
             get {
@@ -641,7 +691,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as &quot;Data Execution Prevention&quot; (DEP) or &quot;Execute Disable&quot; (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data s [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as &quot;Data Execution Prevention&quot; (DEP) or &quot;Execute Disable&quot; (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable.
+        ///This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2016_MarkImageAsNXCompatible_Description {
             get {
@@ -659,7 +710,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to sup [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode).
+        ///To resolve this issue, supply the /SafeSEH flag on link.exe command line.
+        ///For VC projects use ItemDefinitionGroup - Link = ImageHasSafe [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2018_EnableSafeSEH_Description {
             get {
@@ -668,7 +721,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is an x86 binary which {1}, indicating that it does not enable the SafeSEH mitigation. SafeSEH makes it more difficult to exploit memory corruption vulnerabilities that can overwrite SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is an x86 binary which {1}, indicating that it does not enable the SafeSEH mitigation. SafeSEH makes it more difficult to exploit memory corruption vulnerabilities that can overwrite SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode).
+        ///To resolve this issue, supply the /SafeSEH flag on link.exe command line.
+        ///For VC projects use ItemDefinitionGroup - Link = ImageH [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2018_Error {
             get {
@@ -731,7 +786,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IP [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process.
+        ///If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.).
+        ///If you must share common data across processes (for inter-process communication ( [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2019_DoNotMarkWritableSectionsAsShared_Description {
             get {
@@ -740,7 +797,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for in [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process.
+        ///If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.).
+        ///If you must share common data across processes (for  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2019_Error {
             get {
@@ -758,7 +817,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attribu [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode.
+        ///To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attrib [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2021_DoNotMarkWritableSectionsAsExecutable_Description {
             get {
@@ -767,7 +827,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, w [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode.
+        ///To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code,  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2021_Error {
             get {
@@ -839,7 +900,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application code should be compiled with the Spectre mitigations switch (/Qspectre cl.exe command-line argument or &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; build property). Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve this issue, provide the /Qspectre switch on the compiler command-line (or specify &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; in build properties), or pass /d2guardspecload  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Application code which stores sensitive data in memory should be compiled with the Spectre mitigations switch (/Qspectre cl.exe command-line argument or &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; build property).
+        ///Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache.
+        ///To resolve this issue, ensure that all modules compiled into the binary are compiled with /Qspectre switch on cl.exe command-line.
+        ///You may need to [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2024_EnableSpectreMitigations_Description {
             get {
@@ -866,7 +930,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or specify &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; in build properties), or pass /d2guardspecload in cases where y [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities.
+        ///Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache.
+        ///To resolve this issue, ensure that all modules compiled into the binary are compiled with /Qspectre switch on cl.exe command-line.
+        ///You may need to install the &apos;C++ spectre-mitigated libs&apos; component f [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2024_Warning {
             get {
@@ -924,7 +991,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following modules were compiled with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified. The likely cause is that the code was linked to a static library with no debug information: {0}.
+        ///   Looks up a localized string similar to The following modules were compiled with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified.
+        ///The likely cause is that the code was linked to a static library with no debug information: {0}.
         /// </summary>
         internal static string BA2024_Warning_SpectreMitigationUnknownNoCommandLine {
             get {
@@ -933,7 +1001,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}&apos; was compiled with one or more modules with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified. The likely cause is that the code was linked to a static library with no debug information.  It is not known whether code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities was enabled. Spectre attacks can compromise hardware-based isolation, allowing non-pri [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to {0}&apos; was compiled with one or more modules with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified.
+        ///The likely cause is that the code was linked to a static library with no debug information.  It is not known whether code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities was enabled.
+        ///Spectre attacks can compromise hardware-based isolation, allowing non-p [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2024_WarningMissingCommandLine {
             get {
@@ -960,7 +1030,10 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not enable the Control-flow Enforcement Technology (CET) Shadow Stack mitigation. To resolve this issue, pass /CETCOMPAT on the linker command lines. Note: older versions of .NET are not compatible with CET/shadow stack technology. If your native process loads older managed assemblies (.NET 6 or earlier), unhandled exceptions in those components may not be handled properly and may cause your process to crash..
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not enable the Control-flow Enforcement Technology (CET) Shadow Stack mitigation.
+        ///To resolve this issue, pass /CETCOMPAT on the linker command lines.
+        ///For VC projects use ItemDefinitionGroup - Link - CETCompat property with &apos;true&apos; value.
+        ///Note: older .NET versions are not compatible with CET/shadow stack technology. If your native process loads older managed assemblies (.NET 6 or earlier), unhandled exceptions in those components may not be handled properly and may cause your process to crash..
         /// </summary>
         internal static string BA2025_Warning {
             get {
@@ -996,7 +1069,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a Windows PE that wasn&apos;t compiled with recommended Security Development Lifecycle (SDL) checks. As a result some critical compile-time and runtime checks may be disabled, increasing the possibility of an exploitable runtime issue. To resolve this problem, pass &apos;/sdl&apos; on the cl.exe command-line, set the &apos;SDL checks&apos; property in the &apos;C/C++ -&gt; General&apos; Configuration property page, or explicitly set the &apos;SDLCheck&apos; property in the project file (nested within a &apos;CLCompile&apos; element) to &apos;true&apos;..
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a Windows PE that wasn&apos;t compiled with recommended Security Development Lifecycle (SDL) checks. As a result some critical compile-time and runtime checks may be disabled, increasing the possibility of an exploitable runtime issue.
+        ///To resolve this problem, pass &apos;/sdl&apos; on the cl.exe command-line.
+        ///For VC projects use ItemDefinitionGroup - ClCompile - SDLCheck property with &apos;true&apos; value..
         /// </summary>
         internal static string BA2026_Warning {
             get {
@@ -1005,7 +1080,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SourceLink information should be present in the PDB. This applies to binaries built with the C# and MSVC compilers. When enabled, SourceLink information is added to the PDB. That information includes the repository URLs and commit IDs for all source files fed to the compiler. The PDB should also be uploaded to a symbol server so that it can be discovered by a debugger such as Visual Studio. Developers can then step into the matching source code. Frictionless source-driven debugging provides a good user expe [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to SourceLink information should be present in the PDB. This applies to binaries built with the C# and MSVC compilers. When enabled, SourceLink information is added to the PDB. That information includes the repository URLs and commit IDs for all source files fed to the compiler.
+        ///The PDB should also be uploaded to a symbol server so that it can be discovered by a debugger such as Visual Studio. Developers can then step into the matching source code. Frictionless source-driven debugging provides a good user exp [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2027_EnableSourceLink_Description {
             get {
@@ -1023,7 +1099,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The PDB for &apos;{0}&apos; does not contain SourceLink information, compromising frictionless source-driven debugging and increasing latency of security response. Enable SourceLink by configuring necessary project properties and adding a package reference for your source control provider. See https://aka.ms/sourcelink for more information..
+        ///   Looks up a localized string similar to The PDB for &apos;{0}&apos; does not contain SourceLink information, compromising frictionless source-driven debugging and increasing latency of security response.
+        ///Enable SourceLink by configuring necessary project properties and adding a package reference for your source control provider.
+        ///See https://aka.ms/sourcelink for more information..
         /// </summary>
         internal static string BA2027_Warning {
             get {
@@ -1032,7 +1110,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Binaries that are loaded by certain Windows features must (and device drivers should) opt into Windows validation of their digital signatures by setting the /INTEGRITYCHECK linker flag. This option sets the IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY attribute in the PE header of binaries which tells the memory manager to validate a binary&apos;s digital signature when loaded. Any user mode code that is interfacing with Early Launch Antimalware (ELAM) drivers, integrates with device firmware execution or is trying  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Binaries that are loaded by certain Windows features must (and device drivers should) opt into Windows validation of their digital signatures by setting the /INTEGRITYCHECK linker flag.
+        ///This option sets the IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY attribute in the PE header of binaries which tells the memory manager to validate a binary&apos;s digital signature when loaded.
+        ///Any user mode code that is interfacing with Early Launch Antimalware (ELAM) drivers, integrates with device firmware execution or is tryin [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BA2029_EnableIntegrityCheck_Description {
             get {
@@ -1041,7 +1121,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was not compiled with /INTEGRITYCHECK and therefore will not have its digital signature validated at load time. Failing to validate binary signatures increases the risk of loading malicious code in low-level, high-privilege execution environments, including subsystems that provide critical security malware protections. To resolve this problem, pass &apos;/INTEGRITYCHECK&apos; on the linker command line and sign your files using the Microsoft Azure Code Signing program..
+        ///   Looks up a localized string similar to &apos;{0}&apos; was not compiled with /INTEGRITYCHECK and therefore will not have its digital signature validated at load time.
+        ///Failing to validate binary signatures increases the risk of loading malicious code in low-level, high-privilege execution environments, including subsystems that provide critical security malware protections.
+        ///To resolve this problem, pass &apos;/INTEGRITYCHECK&apos; on link.exe command line and sign your files using the Microsoft Azure Code Signing program..
         /// </summary>
         internal static string BA2029_Error {
             get {
@@ -1448,7 +1530,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incremental linking support increases binary size and can reduce runtime performance. The support for incremental linking adds padding and other overhead to support the ability to modify a binary without a full link.  The use of incrementally linked binaries may reduce the level of determinism because previous compilations will have lingering effects on subsequent compilations.  Fully optimized release builds should not specify incremental linking..
+        ///   Looks up a localized string similar to Incremental linking support increases binary size and can reduce runtime performance. The support for incremental linking adds padding and other overhead to support the ability to modify a binary without a full link.
+        ///The use of incrementally linked binaries may reduce the level of determinism because previous compilations will have lingering effects on subsequent compilations.  Fully optimized release builds should not specify incremental linking..
         /// </summary>
         internal static string BA6001_DisableIncrementalLinkingInReleaseBuilds_Description {
             get {
@@ -1493,7 +1576,9 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled without Eliminate Duplicate Strings (/GF) enabled, increasing binary size.  The following modules do not specify that policy: {1}..
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled without Eliminate Duplicate Strings (/GF) enabled, increasing binary size.
+        ///For VC projects use ItemDefinitionGroup - ClCompile - StringPooling property with &apos;true&apos; value.
+        ///The following modules do not specify that policy: {1}..
         /// </summary>
         internal static string BA6002_Warning {
             get {
@@ -1520,7 +1605,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with COMDAT folding (/OPT:ICF) disabled, increasing binary size..
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with COMDAT folding (/OPT:ICF) disabled, increasing binary size.
+        ///For VC projects use ItemDefinitionGroup - Link - EnableCOMDATFolding property with &apos;true&apos; value..
         /// </summary>
         internal static string BA6004_Warning_DisabledForRelease {
             get {
@@ -1529,7 +1615,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; appears to be a Debug build which was compiled with COMDAT folding (/OPT:ICF) enabled. That may make debugging more difficult..
+        ///   Looks up a localized string similar to &apos;{0}&apos; appears to be a Debug build which was compiled with COMDAT folding (/OPT:ICF) enabled.
+        ///For VC projects check ItemDefinitionGroup - Link - EnableCOMDATFolding property. That may make debugging more difficult..
         /// </summary>
         internal static string BA6004_Warning_EnabledForDebug {
             get {
@@ -1556,7 +1643,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with Optimize References (/OPT:REF) disabled, increasing binary size..
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled with Optimize References (/OPT:REF) disabled, increasing binary size.
+        ///For VC projects use ItemDefinitionGroup - Link - OptimizeReferences property with &apos;true&apos; value..
         /// </summary>
         internal static string BA6005_Warning {
             get {
@@ -1583,7 +1671,8 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled without Link Time Code Generation (/LTCG). Enabling LTCG can improve optimizations and performance..
+        ///   Looks up a localized string similar to &apos;{0}&apos; was compiled without Link Time Code Generation (/LTCG). Enabling LTCG can improve optimizations and performance.
+        ///For VC projects use WholeProgramOptimization property with &apos;true&apos; value..
         /// </summary>
         internal static string BA6006_Warning {
             get {

--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
-        ///To resolve this issue, don&apos;t set /LARGEADDRESSAWARE:NO on link.exe command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.).
+        ///To resolve this issue, don&apos;t set /LARGEADDRESSAWARE:NO on link.exe command line and allow it to be enabled by default. (This image was determined to have been properly compiled as /HIGHENTROPYVA.).
         /// </summary>
         internal static string BA2015_Error_NoLargeAddressAware {
             get {

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -338,7 +338,7 @@ To resolve this issue, don't set /HIGHENTROPYVA:NO on link.exe command line and 
   </data>
   <data name="BA2015_Error_NoLargeAddressAware" xml:space="preserve">
     <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
-To resolve this issue, don't set /LARGEADDRESSAWARE:NO on link.exe command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.)</value>
+To resolve this issue, don't set /LARGEADDRESSAWARE:NO on link.exe command line and allow it to be enabled by default. (This image was determined to have been properly compiled as /HIGHENTROPYVA.)</value>
   </data>
   <data name="BA2015_Pass" xml:space="preserve">
     <value>'{0}' is high entropy ASLR compatible, reducing an attacker's ability to exploit code in well-known locations.</value>

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -118,10 +118,17 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="BA2001_Error" xml:space="preserve">
-    <value>'{0}' is a 64-bit image with a preferred base address below the 4GB boundary. Having a preferred base address below this boundary triggers a compatibility mode in Address Space Layout Randomization (ASLR) on recent versions of Windows that reduces the number of locations to which ASLR may relocate the binary. This reduces the effectiveness of ASLR at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries.</value>
+    <value>'{0}' is a 64-bit image with a preferred base address below the 4GB boundary. 
+Having a preferred base address below this boundary triggers a compatibility mode in Address Space Layout Randomization (ASLR) on recent versions of Windows that reduces the number of locations to which ASLR may relocate the binary. This reduces the effectiveness of ASLR at mitigating memory corruption vulnerabilities.
+To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE).
+Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries.
+For VC projects make sure that ItemDefinitionGroup - Link - BaseAddress property is not set.</value>
   </data>
   <data name="BA2001_LoadImageAboveFourGigabyteAddress_Description" xml:space="preserve">
-    <value>64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities. To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE). Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries.</value>
+    <value>64-bit images should have a preferred base address above the 4GB boundary to prevent triggering an Address Space Layout Randomization (ASLR) compatibility mode that decreases security. ASLR compatibility mode reduces the number of locations to which ASLR may relocate the binary, reducing its effectiveness at mitigating memory corruption vulnerabilities.
+To resolve this issue, either use the default preferred base address by removing any uses of /baseaddress from compiler command lines, or /BASE from linker command lines (recommended), or configure your program to start at a base address above 4GB when compiled for 64 bit platforms (by changing the constant passed to /baseaddress or /BASE).
+Note that if you choose to continue using a custom preferred base address, you will need to make this modification only for 64-bit builds, as base addresses above 4GB are not valid for 32-bit binaries.
+For VC projects make sure that ItemDefinitionGroup - Link - BaseAddress property is not set.</value>
   </data>
   <data name="BA2001_Pass" xml:space="preserve">
     <value>'{0}' is a 64-bit image with a base address that is &gt;= 4 gigabytes, increasing the effectiveness of Address Space Layout Randomization (which helps prevent attackers from executing security-sensitive code in well-known locations).</value>
@@ -139,7 +146,8 @@
     <value>Do not ship obsolete libraries for which there are known security vulnerabilities.</value>
   </data>
   <data name="BA2005_Error" xml:space="preserve">
-    <value>'{0}' appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning.</value>
+    <value>'{0}' appears to be an obsolete library (version {1}) for which there are known security vulnerabilities. 
+To resolve this issue, obtain a version of {0} that is newer than version {2}. If this binary is not in fact {0}, ignore this warning.</value>
   </data>
   <data name="BA2005_Error_CouldNotParseVersion" xml:space="preserve">
     <value>Version information for '{0}' could not be parsed. The binary therefore could not be verified not to be an obsolete binary that is known to be vulnerable to one or more security problems.</value>
@@ -151,10 +159,12 @@
     <value>'{0}' is not known to be an obsolete binary that is vulnerable to one or more security problems.</value>
   </data>
   <data name="BA2006_BuildWithSecureTools_Description" xml:space="preserve">
-    <value>Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks.</value>
+    <value>Application code should be compiled with the most up-to-date tool sets possible to take advantage of the most current compile-time security features. 
+Among other things, these features provide address space layout randomization, help prevent arbitrary code execution, and enable code generation that can help prevent speculative execution side-channel attacks.</value>
   </data>
   <data name="BA2006_Error" xml:space="preserve">
-    <value>'{0}' was compiled with one or more modules which were not built using minimum required tool versions (compiler version {1}). More recent toolchains contain mitigations that make it more difficult for an attacker to exploit vulnerabilities in programs they produce. To resolve this issue, compile and/or link your binary with more recent tools. If you are servicing a product where the tool chain cannot be modified (e.g. producing a hotfix for an already shipped version) ignore this warning. Modules built outside of policy: 
+    <value>'{0}' was compiled with one or more modules which were not built using minimum required tool versions (compiler version {1}). More recent toolchains contain mitigations that make it more difficult for an attacker to exploit vulnerabilities in programs they produce.
+To resolve this issue, compile and/or link your binary with more recent tools. If you are servicing a product where the tool chain cannot be modified (e.g. producing a hotfix for an already shipped version) ignore this warning. Modules built outside of policy: 
 {2}</value>
   </data>
   <data name="BA2006_Error_BadModule" xml:space="preserve">
@@ -164,17 +174,26 @@
     <value>All linked modules of '{0}' satisfy configured policy (observed compilers: {1}).</value>
   </data>
   <data name="BA2007_EnableCriticalCompilerWarnings_Description" xml:space="preserve">
-    <value>Binaries should be compiled with a warning level that enables all critical security-relevant checks. Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted.</value>
+    <value>Binaries should be compiled with a warning level that enables all critical security-relevant checks.
+Enabling at least warning level 3 enables important static analysis in the compiler that can identify bugs with a potential to provoke memory corruption, information disclosure, or double-free vulnerabilities.
+To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted.
+For VC projects use %(ClCompile.WarningLevel) ItemDefinitionGroup property with 'Level3', 'Level4' or 'EnableAllWarnings' values.</value>
   </data>
   <data name="BA2007_Error_InsufficientWarningLevel" xml:space="preserve">
-    <value>'{0}' was compiled at too low a warning level (effective warning level {1} for one or more modules). Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted. An example compiler command line triggering this check: {2}
+    <value>'{0}' was compiled at too low a warning level (effective warning level {1} for one or more modules).
+Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities.
+To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted.
+For VC projects use ItemDefinitionGroup - ClCompile - WarningLevel property with 'Level3', 'Level4' or 'EnableAllWarnings' values. An example compiler command line triggering this check: {2}
 Modules triggering this check: {3}</value>
   </data>
   <data name="BA2007_Error_UnknownModuleLanguage" xml:space="preserve">
     <value>'{0}' contains code from an unknown language, preventing a comprehensive analysis of the compiler warning settings. The language could not be identified for the following modules: {1}</value>
   </data>
   <data name="BA2007_Error_WarningsDisabled" xml:space="preserve">
-    <value>'{0}' disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation. An example compiler command line triggering this check was: {1}
+    <value>'{0}' disables compiler warning(s) which are required by policy. A compiler warning is typically required if it has a high likelihood of flagging memory corruption, information disclosure, or double-free vulnerabilities.
+To resolve this issue, enable the indicated warning(s) by removing /Wxxxx switches (where xxxx is a warning id indicated here) from your command line, and resolve any warnings subsequently raised during compilation.
+For VC projects check ItemDefinitionGroup - ClCompile - DisableSpecificWarnings property.
+An example compiler command line triggering this check was: {1}
 Modules triggering this check were:
 {2}</value>
   </data>
@@ -185,7 +204,9 @@ Modules triggering this check were:
     <value>Binaries should enable the compiler control guard feature (CFG) at build time to prevent attackers from redirecting execution to unexpected, unsafe locations. CFG analyzes and discovers all indirect-call instructions at compilation and link time. It also injects a check that precedes every indirect call in code that ensures the target is an expected, safe location.  If that check fails at runtime, the operating system will close the program.</value>
   </data>
   <data name="BA2008_Error" xml:space="preserve">
-    <value>'{0}' does not enable the control flow guard (CFG) mitigation. To resolve this issue, pass /guard:cf on both the compiler and linker command lines. Binaries also require the /DYNAMICBASE linker option in order to enable CFG.</value>
+    <value>'{0}' does not enable the control flow guard (CFG) mitigation.
+To resolve this issue, pass /guard:cf on both the compiler and linker command lines. Binaries also require the /DYNAMICBASE linker option in order to enable CFG.
+For VC projects use ItemDefinitionGroup - ClCompile - ControlFlowGuard property with 'Guard' value, link CFG property will be set automatically.</value>
   </data>
   <data name="BA2008_NotApplicable_UnsupportedKernelModeVersion" xml:space="preserve">
     <value>'{0}' is a kernel mode portable executable compiled for a version of Windows that does not support the control flow guard feature for kernel mode binaries.</value>
@@ -197,7 +218,10 @@ Modules triggering this check were:
     <value>Binaries should linked as DYNAMICBASE to be eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. Configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later.</value>
   </data>
   <data name="BA2009_Error_NotDynamicBase" xml:space="preserve">
-    <value>'{0}' is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities. To resolve this issue, configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line. For .NET applications, use a compiler shipping with Visual Studio 2008 or later.</value>
+    <value>'{0}' is not marked as DYNAMICBASE. This means that the binary is not eligible for relocation by Address Space Layout Randomization (ASLR). ASLR is an important mitigation that makes it more difficult for an attacker to exploit memory corruption vulnerabilities.
+To resolve this issue, configure your tools to build with this feature enabled. For C and C++ binaries, add /DYNAMICBASE to your linker command line.
+For VC projects use ItemDefinitionGroup - Link - RandomizedBaseAddress property with 'true' value.
+For .NET applications, use a compiler shipping with Visual Studio 2008 or later.</value>
   </data>
   <data name="BA2009_Error_RelocsStripped" xml:space="preserve">
     <value>'{0}' is marked as DYNAMICBASE but relocation data has been stripped from the image, preventing address space layout randomization. </value>
@@ -209,19 +233,26 @@ Modules triggering this check were:
     <value>'{0}' is properly compiled to enable Address Space Layout Randomization, reducing an attacker's ability to exploit code in well-known locations.</value>
   </data>
   <data name="BA2010_DoNotMarkImportsSectionAsExecutable_Description" xml:space="preserve">
-    <value>PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable. To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the ".rdata" segment into an executable section.</value>
+    <value>PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. Because the loader will always mark the imports section as writable, it is therefore important to mark this section as non-executable.
+To resolve this issue, ensure that your program does not mark the imports section executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the ".rdata" segment into an executable section.</value>
   </data>
   <data name="BA2010_Error" xml:space="preserve">
-    <value>'{0}' has the imports section marked executable. Because the loader will always mark the imports section as writable, it is important to mark this section as non-executable, so that an attacker cannot place shellcode here. To resolve this issue, ensure that your program does not mark the imports section as executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the ".rdata" segment into an executable section.</value>
+    <value>'{0}' has the imports section marked executable. Because the loader will always mark the imports section as writable, it is important to mark this section as non-executable, so that an attacker cannot place shellcode here.
+To resolve this issue, ensure that your program does not mark the imports section as executable. Look for uses of /SECTION or /MERGE on the linker command line, or #pragma segment in source code, which change the imports section to be executable, or which merge the ".rdata" segment into an executable section.</value>
   </data>
   <data name="BA2010_Pass" xml:space="preserve">
     <value>'{0}' does not have an imports section that is marked as executable, helping to prevent the exploitation of code vulnerabilities.</value>
   </data>
   <data name="BA2011_EnableStackProtection_Description" xml:space="preserve">
-    <value>Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line.</value>
+    <value>Binaries should be built with the stack protector buffer security feature (/GS) enabled to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities.
+To resolve this issue, ensure that all modules compiled into the binary are compiled with the stack protector enabled by supplying /GS on the cl.exe command line.
+For VC projects use ItemDefinitionGroup - ClCompile - BufferSecurityCheck property with 'true' value.</value>
   </data>
   <data name="BA2011_Error" xml:space="preserve">
-    <value>'{0}' is a C or C++ binary built with the stack protector buffer security feature disabled in one or more modules. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. To resolve this issue, ensure that your code is compiled with the stack protector enabled by supplying /GS on the Visual C++ compiler command line. The affected modules were: {1}</value>
+    <value>'{0}' is a C or C++ binary built with the stack protector buffer security feature disabled in one or more modules. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+To resolve this issue, ensure that your code is compiled with the stack protector enabled by supplying /GS on cl.exe command line.
+For VC projects use ItemDefinitionGroup - ClCompile - BufferSecurityCheck property with 'true' value.
+The affected modules were: {1}</value>
   </data>
   <data name="BA2011_Error_UnknownModuleLanguage" xml:space="preserve">
     <value>'{0}' contains code from an unknown language, preventing a comprehensive analysis of the stack protector buffer security features. The language could not be identified for the following modules: {1}.</value>
@@ -230,10 +261,19 @@ Modules triggering this check were:
     <value>'{0}' is a C or C++ binary built with the stack protector buffer security feature enabled for all modules, making it more difficult for an attacker to exploit stack buffer overflow memory corruption vulnerabilities. </value>
   </data>
   <data name="BA2012_DoNotModifyStackProtectionCookie_Description" xml:space="preserve">
-    <value>Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the "security cookie", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement.</value>
+    <value>Application code should not interfere with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. 
+The stack protector relies on a random number, called the "security cookie", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie.
+On recent Windows versions, the loader looks for the statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code.
+When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector.
+To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement.</value>
   </data>
   <data name="BA2012_Error" xml:space="preserve">
-    <value>'{0}' is a C or C++ binary that interferes with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector relies on a random number, called the "security cookie", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie. On recent Windows versions, the loader looks for the magic statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code. When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector. To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement. NOTE: the modified cookie value detected was: {1}</value>
+    <value>'{0}' is a C or C++ binary that interferes with the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+The stack protector relies on a random number, called the "security cookie", to detect these buffer overflows. This 'cookie' is statically linked with your binary from a Visual C++ library in the form of the symbol __security_cookie.
+On recent Windows versions, the loader looks for the magic statically linked value of this cookie, and initializes the cookie with a far better source of entropy -- the system's secure random number generator -- rather than the limited random number generator available early in the C runtime startup code.
+When this symbol is not the default value, the additional entropy is not injected by the operating system, reducing the effectiveness of the stack protector.
+To resolve this issue, ensure that your code does not reference or create a symbol named __security_cookie or __security_cookie_complement.
+NOTE: the modified cookie value detected was: {1}</value>
   </data>
   <data name="BA2012_Error_CouldNotLocateCookie" xml:space="preserve">
     <value>'{0}' is a C or C++binary that enables the stack protection feature but the security cookie could not be located. The binary may be corrupted.</value>
@@ -251,10 +291,14 @@ Modules triggering this check were:
     <value>'{0}' appears to be a packed C or C++ binary that reports a security cookie offset that exceeds the size of the packed file. Use of the stack protector (/GS) feature therefore could not be verified. The file was possibly packed by: {1}.</value>
   </data>
   <data name="BA2013_Error" xml:space="preserve">
-    <value>'{0}' is a C or C++ binary that does not initialize the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point.</value>
+    <value>'{0}' is a C or C++ binary that does not initialize the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector.
+To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point.</value>
   </data>
   <data name="BA2013_InitializeStackProtection_Description" xml:space="preserve">
-    <value>Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities. The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector. To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point.</value>
+    <value>Binaries should properly initialize the stack protector (/GS) in order to increase the difficulty of exploiting stack buffer overflow memory corruption vulnerabilities.
+The stack protector requires access to entropy in order to be effective, which means a binary must initialize a random number generator at startup, by calling __security_init_cookie() as close to the binary's entry point as possible. Failing to do so will result in spurious buffer overflow detections on the part of the stack protector.
+To resolve this issue, use the default entry point provided by the C runtime, which will make this call for you, or call __security_init_cookie() manually in your custom entry point.</value>
   </data>
   <data name="BA2013_NotApplicable_FeatureNotEnabled" xml:space="preserve">
     <value>'{0}' is a C or C++ binary that does not enable the stack protection buffer security feature. It is therefore not required to initialize the stack protector.</value>
@@ -266,43 +310,63 @@ Modules triggering this check were:
     <value>'{0}' is a C or C++ binary that is not required to initialize the stack protection, as it does not contain executable code.</value>
   </data>
   <data name="BA2014_DoNotDisableStackProtectionForFunctions_Description" xml:space="preserve">
-    <value>Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, can compromise the security of code. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether.</value>
+    <value>Application code should not disable stack protection for individual functions. The stack protector (/GS) is a security feature of the Windows native compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+Disabling the stack protector, even on a function-by-function basis, can compromise the security of code.
+To resolve this issue, remove occurrences of __declspec(safebuffers) from your code.
+If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether.</value>
   </data>
   <data name="BA2014_Error" xml:space="preserve">
-    <value>'{0}' is a C or C++ binary built with function(s) ({1}) that disable the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities. Disabling the stack protector, even on a function-by-function basis, is disallowed by SDL policy. To resolve this issue, remove occurrences of __declspec(safebuffers) from your code. If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether.</value>
+    <value>'{0}' is a C or C++ binary built with function(s) ({1}) that disable the stack protector. The stack protector (/GS) is a security feature of the compiler which makes it more difficult to exploit stack buffer overflow memory corruption vulnerabilities.
+Disabling the stack protector, even on a function-by-function basis, is disallowed by SDL policy.
+To resolve this issue, remove occurrences of __declspec(safebuffers) from your code.
+If the additional code inserted by the stack protector has been shown in profiling to cause a significant performance problem for your application, attempt to move stack buffer modifications out of the hot path of execution to allow the compiler to avoid inserting stack protector checks in these locations rather than disabling the stack protector altogether.</value>
   </data>
   <data name="BA2014_Pass" xml:space="preserve">
     <value>'{0}' is a C or C++ binary built with the stack protector buffer security feature enabled which does not disable protection for any individual functions (via __declspec(safebuffers), making it more difficult for an attacker to exploit stack buffer overflow memory corruption vulnerabilities.</value>
   </data>
   <data name="BA2015_EnableHighEntropyVirtualAddresses_Description" xml:space="preserve">
-    <value>Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tool chain to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. Binaries must also be compiled as /LARGEADDRESSAWARE in order to enable high entropy ASLR.</value>
+    <value>Binaries should be marked as high entropy Address Space Layout Randomization (ASLR) compatible. High entropy allows ASLR to be more effective in mitigating memory corruption vulnerabilities.
+To resolve this issue, don't set /HIGHENTROPYV:NO on link.exe command line and allow it to be enabled by default. </value>
   </data>
   <data name="BA2015_Error_NeitherHighEntropyVANorLargeAddressAware" xml:space="preserve">
-    <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tools to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA as well as /LARGEADDRESSAWARE to the C or C++ linker command line.</value>
+    <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
+To resolve this issue, don't set /HIGHENTROPYVA:NO and /LARGEADDRESSAWARE:NO on link.exe command line and allow then to be enabled by default.</value>
   </data>
   <data name="BA2015_Error_NoHighEntropyVA" xml:space="preserve">
-    <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tools to mark the program high entropy compatible; e.g. by supplying /HIGHENTROPYVA to the C or C++ linker command line. (This image was determined to have been properly compiled as /LARGEADDRESSAWARE.)</value>
+    <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
+To resolve this issue, don't set /HIGHENTROPYVA:NO on link.exe command line and allow it to be enabled by default. (This image was determined to have been properly compiled as /LARGEADDRESSAWARE.)</value>
   </data>
   <data name="BA2015_Error_NoLargeAddressAware" xml:space="preserve">
-    <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities. To resolve this issue, configure your tools to mark the program high entropy compatible by supplying /LARGEADDRESSAWARE to the C or C++ linker command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.)</value>
+    <value>'{0}' does not declare itself as high entropy ASLR compatible. High entropy makes Address Space Layout Randomization more effective in mitigating memory corruption vulnerabilities.
+To resolve this issue, don't set /LARGEADDRESSAWARE:NO on link.exe command line. (This image was determined to have been properly compiled as /HIGHENTROPYVA.)</value>
   </data>
   <data name="BA2015_Pass" xml:space="preserve">
     <value>'{0}' is high entropy ASLR compatible, reducing an attacker's ability to exploit code in well-known locations.</value>
   </data>
   <data name="BA2016_Error" xml:space="preserve">
-    <value>'{0}' is not marked NX compatible. The NXCompat bit, also known as "Data Execution Prevention" (DEP) or "Execute Disable" (XD), is a processor feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit, because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment. To resolve this issue, ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker.</value>
+    <value>'{0}' is not marked NX compatible. The NXCompat bit, also known as "Data Execution Prevention" (DEP) or "Execute Disable" (XD), is a processor feature that allows a program to mark a piece of memory as non-executable.
+This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit, because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment.
+To resolve this issue, don't set /NXCOMPAT:NO on link.exe command line and allow it to be enabled by default.</value>
   </data>
   <data name="BA2016_MarkImageAsNXCompatible_Description" xml:space="preserve">
-    <value>Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as "Data Execution Prevention" (DEP) or "Execute Disable" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable. This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment). Ensure that your tools are configured to mark your binaries as NX compatible, e.g. by passing /NXCOMPAT to the C/C++ linker.</value>
+    <value>Binaries should be marked as NX compatible to help prevent execution of untrusted data as code. The NXCompat bit, also known as "Data Execution Prevention" (DEP) or "Execute Disable" (XD), triggers a processor security feature that allows a program to mark a piece of memory as non-executable.
+This helps mitigate memory corruption vulnerabilities by preventing an attacker from supplying direct shellcode in their exploit (because the exploit comes in the form of input data to the exploited program on a data segment, rather than on an executable code segment).
+To resolve this issue, don't set /NXCOMPAT:NO on link.exe command line and allow it to be enabled by default.</value>
   </data>
   <data name="BA2016_Pass" xml:space="preserve">
     <value>'{0}' is marked as NX compatible, helping to prevent attackers from executing code that is injected into data segments.</value>
   </data>
   <data name="BA2018_EnableSafeSEH_Description" xml:space="preserve">
-    <value>X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64.</value>
+    <value>X86 binaries should enable the SafeSEH mitigation to minimize exploitable memory corruption issues. SafeSEH makes it more difficult to exploit vulnerabilities that permit overwriting SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode).
+To resolve this issue, supply the /SafeSEH flag on link.exe command line.
+For VC projects use ItemDefinitionGroup - Link = ImageHasSafeExceptionHandlers property with 'true' value.
+Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64.</value>
   </data>
   <data name="BA2018_Error" xml:space="preserve">
-    <value>'{0}' is an x86 binary which {1}, indicating that it does not enable the SafeSEH mitigation. SafeSEH makes it more difficult to exploit memory corruption vulnerabilities that can overwrite SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode). To resolve this issue, supply the /SafeSEH flag on the linker command line. Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64.</value>
+    <value>'{0}' is an x86 binary which {1}, indicating that it does not enable the SafeSEH mitigation. SafeSEH makes it more difficult to exploit memory corruption vulnerabilities that can overwrite SEH control blocks on the stack, by verifying that the location to which a thrown SEH exception would jump is indeed defined as an exception handler in the source program (and not shellcode).
+To resolve this issue, supply the /SafeSEH flag on link.exe command line.
+For VC projects use ItemDefinitionGroup - Link = ImageHasSafeExceptionHandlers property with 'true' value.
+Note that you will need to configure your build system to supply this flag for x86 builds only, as the /SafeSEH flag is invalid when linking for ARM and x64.</value>
   </data>
   <data name="BA2018_Error_EmptySEHandlerTable" xml:space="preserve">
     <value>has an empty SE handler table in the load configuration table</value>
@@ -323,19 +387,28 @@ Modules triggering this check were:
     <value>'{0}' is an x86 binary that does not use SEH, making it an invalid target for exploits that attempt to replace SEH jump targets with attacker-controlled shellcode.</value>
   </data>
   <data name="BA2019_DoNotMarkWritableSectionsAsShared_Description" xml:space="preserve">
-    <value>Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.).</value>
+    <value>Code or data sections should not be marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process.
+If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.).
+If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.).</value>
   </data>
   <data name="BA2019_Error" xml:space="preserve">
-    <value>'{0}' contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process. If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.). If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.).</value>
+    <value>'{0}' contains one or more code or data sections ({1}) which are marked as both shared and writable. Because these sections are shared across processes, this condition might permit a process with low privilege to alter memory in a higher privilege process.
+If you do not actually require that a section be both writable and shared, remove one or both of these attributes (by modifying your .DEF file, the appropriate linker /section switch arguments, etc.).
+If you must share common data across processes (for inter-process communication (IPC) or other purposes) use CreateFileMapping with proper security attributes or an actual IPC mechanism instead (COM, named pipes, LPC, etc.).</value>
   </data>
   <data name="BA2019_Pass" xml:space="preserve">
     <value>'{0}' contains no data or code sections marked as both shared and writable, helping to prevent the exploitation of code vulnerabilities.</value>
   </data>
   <data name="BA2021_DoNotMarkWritableSectionsAsExecutable_Description" xml:space="preserve">
-    <value>PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function.</value>
+    <value>PE sections should not be marked as both writable and executable. This condition makes it easier for an attacker to exploit memory corruption vulnerabilities, as it may provide an attacker executable location(s) to inject shellcode.
+To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes.
+Be sure to disable incremental linking in release builds, as this feature creates a writable and executable section named '.textbss' in order to function.</value>
   </data>
   <data name="BA2021_Error" xml:space="preserve">
-    <value>'{0}' contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode. To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes. Enabling incremental linking via the /INCREMENTAL argument (the default for Microsoft Visual Studio debug build) can also result in a writable and executable section named 'textbss'. For this case, disable incremental linking (or analyze an alternate build configuration that disables this feature) to resolve the problem.</value>
+    <value>'{0}' contains PE section(s) ({1}) that are both writable and executable. Writable and executable memory segments make it easier for an attacker to exploit memory corruption vulnerabilities, because it may provide an attacker executable location(s) to inject shellcode.
+To resolve this issue, configure your tools to not emit memory sections that are writable and executable. For example, look for uses of /SECTION on the linker command line for C and C++ programs, or #pragma section in C and C++ source code, which mark a section with both attributes.
+Enabling incremental linking via the /INCREMENTAL argument (the default for Microsoft Visual Studio debug build) can also result in a writable and executable section named 'textbss'. For this case, disable incremental linking (or analyze an alternate build configuration that disables this feature) to resolve the problem.
+For VC projects use ItemDefinitionGroup - Link - LinkIncremental property with 'false' value.</value>
   </data>
   <data name="BA2021_Error_UnexpectedSectionAligment" xml:space="preserve">
     <value>'{0}' has a section alignment ({1}) that is smaller than its page size ({2}).</value>
@@ -359,11 +432,26 @@ Modules triggering this check were:
     <value>Images should be correctly signed by trusted publishers using cryptographically secure signature algorithms. This rule invokes WinTrustVerify to validate that binary hash, signing and public key algorithms are secure and, where configurable, that key sizes meet acceptable size thresholds.</value>
   </data>
   <data name="BA2024_EnableSpectreMitigations_Description" xml:space="preserve">
-    <value>Application code should be compiled with the Spectre mitigations switch (/Qspectre cl.exe command-line argument or &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; build property). Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve this issue, provide the /Qspectre switch on the compiler command-line (or specify &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; in build properties), or pass /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre. This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request. You may need to install the 'C++ spectre-mitigated libs' component from the Visual Studio installer if you observe violations against C runtime libraries such as libcmt.lib, libvcruntime.lib, etc.</value>
+    <value>Application code which stores sensitive data in memory should be compiled with the Spectre mitigations switch (/Qspectre cl.exe command-line argument or &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; build property).
+Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache.
+To resolve this issue, ensure that all modules compiled into the binary are compiled with /Qspectre switch on cl.exe command-line.
+You may need to install the 'C++ spectre-mitigated libs' component from the Visual Studio installer if you observe violations against C runtime libraries such as libcmt.lib, libvcruntime.lib, etc.
+For VC projects use SpectreMitigation property with 'Spectre' value.
+When using older MSVC versions pass /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre.
+This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request.
+For mitigation to be effective, all dlls and libs that are part of an exe, should be compiled with /QSpectre, so decision should be made for the whole process.
+Can cause some perf degradations, so should not be used when not needed.</value>
   </data>
   <data name="BA2024_Warning" xml:space="preserve">
-    <value>'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, provide the /Qspectre switch on the compiler command-line (or specify &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; in build properties), or pass /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre. This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request.
-{1}</value>
+    <value>'{0}' was compiled with one or more modules that do not enable code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities.
+Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache.
+To resolve this issue, ensure that all modules compiled into the binary are compiled with /Qspectre switch on cl.exe command-line.
+You may need to install the 'C++ spectre-mitigated libs' component from the Visual Studio installer if you observe violations against C runtime libraries such as libcmt.lib, libvcruntime.lib, etc.
+For VC projects use SpectreMitigation property with 'Spectre' value.
+When using older MSVC versions pass /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre.
+This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request.
+For mitigation to be effective, all dlls and libs that are part of an exe, should be compiled with /QSpectre, so decision should be made for the whole process.
+Can cause some perf degradations, so should not be used when not needed.</value>
   </data>
   <data name="BA2024_Warning_MasmModulesDetected" xml:space="preserve">
     <value>The following MASM modules were detected. The MASM compiler does not currently mitigate against speculative execution attacks:
@@ -481,14 +569,28 @@ Modules did not meet the criteria: {1}</value>
     <value>'{0}' is a {1} binary which was compiled with a secure (SHA-256) source code hashing algorithm.</value>
   </data>
   <data name="BA2004_Warning_NativeWithInsecureStaticLibraryCompilands" xml:space="preserve">
-    <value>'{0}' is a native binary that links one or more static libraries that include object files which were hashed using an insecure checksum algorithm. Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity. Pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing. The following modules are out of policy:
+    <value>'{0}' is a native binary that links one or more static libraries that include object files which were hashed using an insecure checksum algorithm.
+Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity.
+To resolve this issue, use newer versions of libraries that are compiled with /ZH:SHA_256. MSVC: 17.0 (14.30.*) or later. Windows SDK: 10.0.18362.0 or later.
+The following modules are out of policy:
 {1}</value>
   </data>
   <data name="BA2004_EnableSecureSourceCodeHashing_Description" xml:space="preserve">
-    <value>Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code. This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs. This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure. Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files). Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler. For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '&lt;ChecksumAlgorithm&gt;' project property with 'SHA256' to enable secure source code hashing. For native binaries, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing.</value>
+    <value>Compilers can generate and store checksums of source files in order to provide linkage between binaries, their PDBs, and associated source code.
+This information is typically used to resolve source file when debugging but it can also be used to verify that a specific body of source code is, in fact, the code that was used to produce a specific set of binaries and PDBs.
+This validation is helpful in verifying supply chain integrity. Due to this security focus, it is important that the hashing algorithm used to produce checksums is secure.
+Legacy hashing algorithms, such as MD5 and SHA-1, have been demonstrated to be broken by modern hardware (that is, it is computationally feasible to force hash collisions, in which a common hash is generated from distinct files).
+Using a secure hashing algorithm, such as SHA-256, prevents the possibility of collision attacks, in which the checksum of a malicious file is used to produce a hash that satisfies the system that it is, in fact, the original file processed by the compiler.
+For managed binaries, pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the '&lt;ChecksumAlgorithm&gt;' project property with 'SHA256' to enable secure source code hashing.
+For native code - use to MSVC 17.0 (14.30.*) or later if possible. For VC projects use PlatformToolset property with 'v143' or later value.
+When using older MSVC versions add /ZH:SHA_256 on cl.exe command line.</value>
   </data>
   <data name="BA2004_Error_NativeWithInsecureDirectCompilands" xml:space="preserve">
-    <value>'{0}' is a native binary that directly compiles and links one or more object files which were hashed using an insecure checksum algorithm. Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity. Pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing. The following modules are out of policy:
+    <value>'{0}' is a native binary that directly compiles and links one or more object files which were hashed using an insecure checksum algorithm.
+Insecure checksum algorithms are subject to collision attacks and its use can compromise supply chain integrity.
+Use MSVC 17.0 (14.30.*) or later if possible.
+When using older MSVC versions, pass '/ZH:SHA_256' on the cl.exe command-line to enable secure source code hashing.
+The following modules are out of policy:
 {1}</value>
   </data>
   <data name="BA2006_Error_OutdatedCsc" xml:space="preserve">
@@ -504,7 +606,10 @@ Modules did not meet the criteria: {1}</value>
     <value>Control-flow Enforcement Technology (CET) Shadow Stack is a computer processor feature that provides capabilities to defend against return-oriented programming (ROP) based malware attacks. Note: older versions of .NET are not compatible with CET/shadow stack technology. If your native process loads older managed assemblies (.NET 6 or earlier), unhandled exceptions in those components may not be handled properly and may cause your process to crash.</value>
   </data>
   <data name="BA2025_Warning" xml:space="preserve">
-    <value>'{0}' does not enable the Control-flow Enforcement Technology (CET) Shadow Stack mitigation. To resolve this issue, pass /CETCOMPAT on the linker command lines. Note: older versions of .NET are not compatible with CET/shadow stack technology. If your native process loads older managed assemblies (.NET 6 or earlier), unhandled exceptions in those components may not be handled properly and may cause your process to crash.</value>
+    <value>'{0}' does not enable the Control-flow Enforcement Technology (CET) Shadow Stack mitigation.
+To resolve this issue, pass /CETCOMPAT on the linker command lines.
+For VC projects use ItemDefinitionGroup - Link - CETCompat property with 'true' value.
+Note: older .NET versions are not compatible with CET/shadow stack technology. If your native process loads older managed assemblies (.NET 6 or earlier), unhandled exceptions in those components may not be handled properly and may cause your process to crash.</value>
   </data>
   <data name="BA2025_Pass" xml:space="preserve">
     <value>'{0}' enables the Control-flow Enforcement Technology (CET) Shadow Stack mitigation.</value>
@@ -544,7 +649,9 @@ Modules did not meet the criteria: {1}</value>
     <value>/sdl enables a superset of the baseline security checks provided by /GS and overrides /GS-. By default, /sdl is off. /sdl- disables the additional security checks.</value>
   </data>
   <data name="BA2026_Warning" xml:space="preserve">
-    <value>'{0}' is a Windows PE that wasn't compiled with recommended Security Development Lifecycle (SDL) checks. As a result some critical compile-time and runtime checks may be disabled, increasing the possibility of an exploitable runtime issue. To resolve this problem, pass '/sdl' on the cl.exe command-line, set the 'SDL checks' property in the 'C/C++ -&gt; General' Configuration property page, or explicitly set the 'SDLCheck' property in the project file (nested within a 'CLCompile' element) to 'true'.</value>
+    <value>'{0}' is a Windows PE that wasn't compiled with recommended Security Development Lifecycle (SDL) checks. As a result some critical compile-time and runtime checks may be disabled, increasing the possibility of an exploitable runtime issue.
+To resolve this problem, pass '/sdl' on the cl.exe command-line.
+For VC projects use ItemDefinitionGroup - ClCompile - SDLCheck property with 'true' value.</value>
   </data>
   <data name="BA2026_Pass" xml:space="preserve">
     <value>'{0}' is a Windows PE that was compiled with recommended Security Development Lifecycle (SDL) checks. These checks change security-relevant warnings into errors, and set additional secure code-generation features.</value>
@@ -586,16 +693,21 @@ Modules did not meet the criteria: {1}</value>
     <value>'{0}' was compiled using Clang but without the SafeStack instrumentation pass, which should be used to mitigate the risk of stack-based buffer overflows. To enable SafeStack, pass '-fsanitize=safe-stack' flag to both compile and link command lines. You might need to update your version of Clang to enable it.</value>
   </data>
   <data name="BA2027_EnableSourceLink_Description" xml:space="preserve">
-    <value>SourceLink information should be present in the PDB. This applies to binaries built with the C# and MSVC compilers. When enabled, SourceLink information is added to the PDB. That information includes the repository URLs and commit IDs for all source files fed to the compiler. The PDB should also be uploaded to a symbol server so that it can be discovered by a debugger such as Visual Studio. Developers can then step into the matching source code. Frictionless source-driven debugging provides a good user experience for consumers and also accelerates security response in the event of supply-chain compromise. See https://aka.ms/sourcelink for more information.</value>
+    <value>SourceLink information should be present in the PDB. This applies to binaries built with the C# and MSVC compilers. When enabled, SourceLink information is added to the PDB. That information includes the repository URLs and commit IDs for all source files fed to the compiler.
+The PDB should also be uploaded to a symbol server so that it can be discovered by a debugger such as Visual Studio. Developers can then step into the matching source code. Frictionless source-driven debugging provides a good user experience for consumers and also accelerates security response in the event of supply-chain compromise.
+See https://aka.ms/sourcelink for more information.</value>
   </data>
   <data name="BA2027_Warning" xml:space="preserve">
-    <value>The PDB for '{0}' does not contain SourceLink information, compromising frictionless source-driven debugging and increasing latency of security response. Enable SourceLink by configuring necessary project properties and adding a package reference for your source control provider. See https://aka.ms/sourcelink for more information.</value>
+    <value>The PDB for '{0}' does not contain SourceLink information, compromising frictionless source-driven debugging and increasing latency of security response.
+Enable SourceLink by configuring necessary project properties and adding a package reference for your source control provider.
+See https://aka.ms/sourcelink for more information.</value>
   </data>
   <data name="BA2027_Pass" xml:space="preserve">
     <value>The PDB for '{0}' contains SourceLink information, maximizing engineering and security response efficiency when source code is required for debugging and other critical analysis.</value>
   </data>
   <data name="BA6001_DisableIncrementalLinkingInReleaseBuilds_Description" xml:space="preserve">
-    <value>Incremental linking support increases binary size and can reduce runtime performance. The support for incremental linking adds padding and other overhead to support the ability to modify a binary without a full link.  The use of incrementally linked binaries may reduce the level of determinism because previous compilations will have lingering effects on subsequent compilations.  Fully optimized release builds should not specify incremental linking.</value>
+    <value>Incremental linking support increases binary size and can reduce runtime performance. The support for incremental linking adds padding and other overhead to support the ability to modify a binary without a full link.
+The use of incrementally linked binaries may reduce the level of determinism because previous compilations will have lingering effects on subsequent compilations.  Fully optimized release builds should not specify incremental linking.</value>
   </data>
   <data name="BA6001_Pass" xml:space="preserve">
     <value>'{0}' was compiled with incremental linking disabled.</value>
@@ -610,7 +722,9 @@ Modules did not meet the criteria: {1}</value>
     <value>'{0}' was compiled with Eliminate Duplicate Strings (/GF) enabled.</value>
   </data>
   <data name="BA6002_Warning" xml:space="preserve">
-    <value>'{0}' was compiled without Eliminate Duplicate Strings (/GF) enabled, increasing binary size.  The following modules do not specify that policy: {1}.</value>
+    <value>'{0}' was compiled without Eliminate Duplicate Strings (/GF) enabled, increasing binary size.
+For VC projects use ItemDefinitionGroup - ClCompile - StringPooling property with 'true' value.
+The following modules do not specify that policy: {1}.</value>
   </data>
   <data name="BA6004_EnableCOMDATFolding_Description" xml:space="preserve">
     <value>COMDAT folding can significantly reduce binary size by combining functions which generate identical machine code into a single copy in the final binary.</value>
@@ -619,10 +733,12 @@ Modules did not meet the criteria: {1}</value>
     <value>'{0}' was compiled with COMDAT folding (/OPT:ICF) enabled</value>
   </data>
   <data name="BA6004_Warning_DisabledForRelease" xml:space="preserve">
-    <value>'{0}' was compiled with COMDAT folding (/OPT:ICF) disabled, increasing binary size.</value>
+    <value>'{0}' was compiled with COMDAT folding (/OPT:ICF) disabled, increasing binary size.
+For VC projects use ItemDefinitionGroup - Link - EnableCOMDATFolding property with 'true' value.</value>
   </data>
   <data name="BA6004_Warning_EnabledForDebug" xml:space="preserve">
-    <value>'{0}' appears to be a Debug build which was compiled with COMDAT folding (/OPT:ICF) enabled. That may make debugging more difficult.</value>
+    <value>'{0}' appears to be a Debug build which was compiled with COMDAT folding (/OPT:ICF) enabled.
+For VC projects check ItemDefinitionGroup - Link - EnableCOMDATFolding property. That may make debugging more difficult.</value>
   </data>
   <data name="BA6005_EnableOptimizeReferences_Description" xml:space="preserve">
     <value>Optimize References can significantly reduce binary size because it instructs the linker to remove unreferenced functions and data from the final binary.</value>
@@ -631,7 +747,8 @@ Modules did not meet the criteria: {1}</value>
     <value>'{0}' was compiled with Optimize References (/OPT:REF) enabled</value>
   </data>
   <data name="BA6005_Warning" xml:space="preserve">
-    <value>'{0}' was compiled with Optimize References (/OPT:REF) disabled, increasing binary size.</value>
+    <value>'{0}' was compiled with Optimize References (/OPT:REF) disabled, increasing binary size.
+For VC projects use ItemDefinitionGroup - Link - OptimizeReferences property with 'true' value.</value>
   </data>
   <data name="BA6006_EnableLinkTimeCodeGeneration_Description" xml:space="preserve">
     <value>Enabling Link Time Code Generation (LTCG) performs whole-program optimization, which is able to better optimize code across translation units. LTCG is also a prerequisite for Profile-Guided Optimization (PGO) which can further improve performance.</value>
@@ -640,21 +757,32 @@ Modules did not meet the criteria: {1}</value>
     <value>'{0}' was compiled with LinkTimeCodeGeneration (/LTCG) enabled.</value>
   </data>
   <data name="BA6006_Warning" xml:space="preserve">
-    <value>'{0}' was compiled without Link Time Code Generation (/LTCG). Enabling LTCG can improve optimizations and performance.</value>
+    <value>'{0}' was compiled without Link Time Code Generation (/LTCG). Enabling LTCG can improve optimizations and performance.
+For VC projects use WholeProgramOptimization property with 'true' value.</value>
   </data>
   <data name="BA2029_EnableIntegrityCheck_Description" xml:space="preserve">
-    <value>Binaries that are loaded by certain Windows features must (and device drivers should) opt into Windows validation of their digital signatures by setting the /INTEGRITYCHECK linker flag. This option sets the IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY attribute in the PE header of binaries which tells the memory manager to validate a binary's digital signature when loaded. Any user mode code that is interfacing with Early Launch Antimalware (ELAM) drivers, integrates with device firmware execution or is trying to load into protected process lite space must enable /INTEGRITYCHECK. This feature applies to both 32-but and 64-bit files. Binaries that opt into /INTEGRITYCHECK must be signed using the Microsoft Azure Code Signing program.</value>
+    <value>Binaries that are loaded by certain Windows features must (and device drivers should) opt into Windows validation of their digital signatures by setting the /INTEGRITYCHECK linker flag.
+This option sets the IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY attribute in the PE header of binaries which tells the memory manager to validate a binary's digital signature when loaded.
+Any user mode code that is interfacing with Early Launch Antimalware (ELAM) drivers, integrates with device firmware execution or is trying to load into protected process lite space must enable /INTEGRITYCHECK.
+This feature applies to both 32-but and 64-bit files. Binaries that opt into /INTEGRITYCHECK must be signed using the Microsoft Azure Code Signing program.</value>
   </data>
   <data name="BA2029_Error" xml:space="preserve">
-    <value>'{0}' was not compiled with /INTEGRITYCHECK and therefore will not have its digital signature validated at load time. Failing to validate binary signatures increases the risk of loading malicious code in low-level, high-privilege execution environments, including subsystems that provide critical security malware protections. To resolve this problem, pass '/INTEGRITYCHECK' on the linker command line and sign your files using the Microsoft Azure Code Signing program.</value>
+    <value>'{0}' was not compiled with /INTEGRITYCHECK and therefore will not have its digital signature validated at load time.
+Failing to validate binary signatures increases the risk of loading malicious code in low-level, high-privilege execution environments, including subsystems that provide critical security malware protections.
+To resolve this problem, pass '/INTEGRITYCHECK' on link.exe command line and sign your files using the Microsoft Azure Code Signing program.</value>
   </data>
   <data name="BA2029_Pass" xml:space="preserve">
     <value>'{0}' was compiled with /INTEGRITYCHECK and will therefore have its digital signature validated at load time when executing in sensitive Windows runtime environments.</value>
   </data>
   <data name="BA2024_WarningMissingCommandLine" xml:space="preserve">
-    <value>{0}' was compiled with one or more modules with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified. The likely cause is that the code was linked to a static library with no debug information.  It is not known whether code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities was enabled. Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache. To resolve the issue, ensure that the compiler command line is present (provide the /Z7 switch) and provide the /Qspectre switch on the compiler command-line (or specify &lt;SpectreMitigation&gt;Spectre&lt;/SpectreMitigation&gt; in build properties), or pass /d2guardspecload in cases where your compiler supports this switch and it is not possible to update to a toolset that supports /Qspectre. This warning should be addressed for code that operates on data that crosses a trust boundary and that can affect execution, such as parsing untrusted file inputs or processing query strings of a web request.</value>
+    <value>{0}' was compiled with one or more modules with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified.
+The likely cause is that the code was linked to a static library with no debug information.  It is not known whether code generation mitigations for speculative execution side-channel attack (Spectre) vulnerabilities was enabled.
+Spectre attacks can compromise hardware-based isolation, allowing non-privileged users to retrieve potentially sensitive data from the CPU cache.
+To resolve the issue, ensure that the static library pdb is availble or compile static library code with /Z7 switch which makes symbols to be included in .obj.
+For VC projects use ItemDefinitionGroup - ClCompile - DebugInformationFormat property with 'ProgramDatabase' (/Zi) or 'OldStyle' (/Z7) value.</value>
   </data>
   <data name="BA2024_Warning_SpectreMitigationUnknownNoCommandLine" xml:space="preserve">
-    <value>The following modules were compiled with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified. The likely cause is that the code was linked to a static library with no debug information: {0}</value>
+    <value>The following modules were compiled with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified.
+The likely cause is that the code was linked to a static library with no debug information: {0}</value>
   </data>
 </root>


### PR DESCRIPTION
Adding VC project properties info to suggestions
Making long strings multiline for easier reading.
Adding more info for BA2004 and clarifying some suggestions for compiler defaults.