### PR TITLE
Using consoleLogger in Telemetry client within MultithreadedAnlyzeCom…

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,6 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
+* BUG: Fork telemetry to log always to Console and AppInsights in the same time when Error occur. [1002](https://github.com/microsoft/binskim/pull/1002)
 
 ## **v4.3.0**
 * DEP: Update `msdia140.dll` from 14.36.32532.0 to 14.40.33810.0. This update fixes the `System.AccessViolationException: Attempted to read or write protected memory` exception that occurs when reading certain PDB files. [996](https://github.com/microsoft/binskim/pull/996)

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
+using CommandLine;
+
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.IL.Rules;
 using Microsoft.CodeAnalysis.IL.Sdk;
@@ -52,13 +54,21 @@ namespace Microsoft.CodeAnalysis.IL
 
             if (this.Telemetry?.TelemetryClient != null)
             {
+                // Create an aggregating logger that will combine all loggers into a single logger.
                 var aggregatingLogger = new AggregatingLogger();
+                if (context.Logger is AggregatingLogger)
+                {
+                    aggregatingLogger = context.Logger as AggregatingLogger;
+                }
+                else
+                {
+                    aggregatingLogger.Loggers.Add(context.Logger);
+                }
 
                 var ruleTelemetryLogger = new RuleTelemetryLogger(this.Telemetry.TelemetryClient);
                 ruleTelemetryLogger.AnalysisStarted();
 
                 // Combine rule telemetry with any other loggers that may be present.
-                aggregatingLogger.Loggers.Add(context.Logger);
                 aggregatingLogger.Loggers.Add(ruleTelemetryLogger);
                 context.Logger = aggregatingLogger;
             }

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -57,6 +57,7 @@ namespace Microsoft.CodeAnalysis.IL
                 var ruleTelemetryLogger = new RuleTelemetryLogger(this.Telemetry.TelemetryClient);
                 ruleTelemetryLogger.AnalysisStarted();
 
+                // Combine rule telemetry with any other loggers that may be present.
                 aggregatingLogger.Loggers.Add(context.Logger);
                 aggregatingLogger.Loggers.Add(ruleTelemetryLogger);
                 context.Logger = aggregatingLogger;

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -48,6 +48,8 @@ namespace Microsoft.CodeAnalysis.IL
 
         public override BinaryAnalyzerContext InitializeGlobalContextFromOptions(AnalyzeOptions options, ref BinaryAnalyzerContext context)
         {
+            base.InitializeGlobalContextFromOptions(options, ref context);
+
             if (this.Telemetry?.TelemetryClient != null)
             {
                 var aggregatingLogger = new AggregatingLogger();
@@ -55,6 +57,7 @@ namespace Microsoft.CodeAnalysis.IL
                 var ruleTelemetryLogger = new RuleTelemetryLogger(this.Telemetry.TelemetryClient);
                 ruleTelemetryLogger.AnalysisStarted();
 
+                aggregatingLogger.Loggers.Add(context.Logger);
                 aggregatingLogger.Loggers.Add(ruleTelemetryLogger);
                 context.Logger = aggregatingLogger;
             }
@@ -65,7 +68,7 @@ namespace Microsoft.CodeAnalysis.IL
                 ? options.MaxFileSizeInKilobytes.Value
                 : long.MaxValue;
 
-            base.InitializeGlobalContextFromOptions(options, ref context);
+
 
             // Update context object based on command-line parameters.
             context.SymbolPath = options.SymbolsPath ?? context.SymbolPath;


### PR DESCRIPTION
This pull request includes changes to the `MultithreadedAnalyzeCommand` class in `src/BinSkim.Driver` to enhance logging capabilities by adding a new console logger and ensuring proper namespaces are included.

Enhancements to logging:

* [`src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs`](diffhunk://#diff-d24327e39f7ce09f6e1bcd7cf14bffbe07c6341a35c9dc6c0647b0f6262900efR54-R64): Added a `ConsoleLogger` to the `AggregatingLogger` to enable console logging during analysis.

Namespace inclusion:

* [`src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs`](diffhunk://#diff-d24327e39f7ce09f6e1bcd7cf14bffbe07c6341a35c9dc6c0647b0f6262900efR16): Included the `Microsoft.CodeAnalysis.Sarif.Writers` namespace to support the new logging functionality.