### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @microsoft/1es-sdl-engineering @AllDwarf @martin-reznik @mkacmar
+*       @microsoft/1es-sdl-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @eddynaka @michaelcfanning @marmegh
+*       @microsoft/1es-sdl-engineering @AllDwarf @martin-reznik @mkacmar


### PR DESCRIPTION
Update CODEOWNERS to include new team 1es-sdl-engineering as a default code owner