### PR TITLE
Add explicit permissions to github action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,6 @@
 name: CodeQL Analysis
+permissions:
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Adds the `security-events: write` permisson to CodeQL Analysis, allowing TSA Upload (Satif upload of results) to successfully complete, unblocking the codeQL analysis github action.