### PR TITLE
Replace sarif-sdk submodule with Nuget package

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,11 +5,11 @@ permissions:
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
+      - "dependabot/**"
   pull_request:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -24,8 +24,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
@@ -60,5 +58,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-
 # Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -16,4 +16,4 @@ jobs:
       run: dotnet tool install -g dotnet-format
 
     - name: dotnet format
-      run: dotnet-format --folder --check  --exclude .\src\sarif-sdk\
+      run: dotnet-format --folder --check

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/sarif-sdk"]
-	path = src/sarif-sdk
-	url = https://github.com/microsoft/sarif-sdk

--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -38,8 +38,6 @@ echo         public const string Version = AssemblyVersion + Prerelease;        
 echo     }                                                                           >> %VERSION_CONSTANTS%
 echo  }                                                                              >> %VERSION_CONSTANTS%
 
-::Download Submodules
-if not exist %~dp0src\sarif-sdk\src\Sarif.Sdk.sln (git submodule update --init --recursive)
 
 ::Restore packages
 echo Restoring packages...
@@ -78,7 +76,6 @@ call BuildPackages.cmd || goto :ExitFailed
 
 echo dotnet-format
 dotnet tool update --global dotnet-format --version 4.1.131201
-dotnet-format --folder --exclude .\src\sarif-sdk\
 
 ::Update BinSkimRules.md to cover any xml changes
 echo Exporting any BinSkim rules

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -6,10 +6,6 @@ if [[  "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]; then
   sed 's#\\#/#g' src/BinSkim.sln > src/BinSkimUnix.sln
 fi
 
-if [ ! -f src/sarif-sdk/src/Sarif.Sdk.sln ]; then
-  echo "Get submodule..."
-  git submodule update --init --recursive
-fi
 
 dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,6 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
+* NEW: Remove sarif-sdk submodule and use nuget package instead
 
 ## **v4.3.1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.3.1)
 * DEP: Update `msdia140.dll` from 14.40.33810.0 to 14.40.33812. [1000](https://github.com/microsoft/binskim/pull/1002)

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -52,8 +52,6 @@ jobs:
           script: "BuildAndTest.cmd"
 
       - task: ComponentGovernanceComponentDetection@0
-        inputs:
-          ignoreDirectories: 'src\sarif-sdk'
 
   - job: mac
     pool:

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -19,7 +19,6 @@ jobs:
           packageType: sdk
 
       - checkout: self
-        submodules: true
 
       - task: Bash@3
         displayName: "Build and Test"
@@ -44,7 +43,6 @@ jobs:
           packageType: sdk
 
       - checkout: self
-        submodules: true
 
       - task: CmdLine@2
         displayName: "Build and Test"
@@ -70,7 +68,6 @@ jobs:
           packageType: sdk
 
       - checkout: self
-        submodules: true
 
       - task: Bash@3
         displayName: "Build and Test"

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -20,6 +20,12 @@ jobs:
 
       - checkout: self
 
+      - task: UseDotNet@2
+        displayName: .NET Core 8 sdk
+        inputs:
+          version: "8.0.x"
+          packageType: sdk
+
       - task: Bash@3
         displayName: "Build and Test"
         inputs:
@@ -40,6 +46,12 @@ jobs:
         displayName: .NET Core 6.0 sdk
         inputs:
           version: "6.0.x"
+          packageType: sdk
+
+      - task: UseDotNet@2
+        displayName: .NET Core 8 sdk
+        inputs:
+          version: "8.0.x"
           packageType: sdk
 
       - checkout: self
@@ -65,6 +77,12 @@ jobs:
         displayName: .NET Core 6.0 sdk
         inputs:
           version: "6.0.x"
+          packageType: sdk
+
+      - task: UseDotNet@2
+        displayName: .NET Core 8 sdk
+        inputs:
+          version: "8.0.x"
           packageType: sdk
 
       - checkout: self

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.111",
+    "version": "8.0.404",
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "8.0.111",
+    "rollForward": "latestPatch"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.Traversal": "2.0.48"
+  }
+}

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.netcore.props))\build.netcore.props" />
-
   <PropertyGroup>
     <AssemblyName>BinSkim</AssemblyName>
     <!--  Condition="'$(OS)'=='Windows_NT'" -->
@@ -10,7 +9,6 @@
     <OutputType>Exe</OutputType>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -19,35 +17,30 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Microsoft/binskim</RepositoryUrl>
   </PropertyGroup>
-
   <ItemGroup>
     <Content Include="README.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Private.Uri" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Dia2Lib">
       <HintPath>..\..\refs\Dia2Lib.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />
     <ProjectReference Include="..\BinSkim.Rules\BinSkim.Rules.csproj" />
     <ProjectReference Include="..\BinSkim.Sdk\BinSkim.Sdk.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="DriverResources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -55,7 +48,6 @@
       <DependentUpon>DriverResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="DriverResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -63,17 +55,14 @@
       <CustomToolNamespace>Microsoft.CodeAnalysis.IL</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
-
-  <ItemGroup>   
+  <ItemGroup>
     <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(RuntimeIdentifier)'==''" />
-	<!-- Note: Official Release builds on Windows should specify a RID. Build using the BuildAndTest.cmd script. -->
+    <!-- Note: Official Release builds on Windows should specify a RID. Build using the BuildAndTest.cmd script. -->
     <MsDiaLibs Include="..\..\refs\x64\*" Condition="'$(RuntimeIdentifier)'=='win-x64'" />
     <MsDiaLibs Include="..\..\refs\msdia140.dll.manifest" />
-
     <!-- Required DLLs for Microsoft Visual C++ runtime. -->
     <MsRuntime Include="..\..\refs\runtime\*" />
   </ItemGroup>
-
   <Target Name="CopyMsDiaLibs" AfterTargets="build">
     <Copy SourceFiles="@(MsDiaLibs)" DestinationFolder="$(OutputPath)\" />
     <Copy SourceFiles="@(MsRuntime)" DestinationFolder="$(OutputPath)\" />

--- a/src/BinSkim.Rules/BinSkim.Rules.csproj
+++ b/src/BinSkim.Rules/BinSkim.Rules.csproj
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.netcore.props))\build.netcore.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.IL.Rules</RootNamespace>
     <TargetFramework>$(NetStandardVersion)</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
     <Reference Include="Dia2Lib">
       <HintPath>..\..\refs\Dia2Lib.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
-  
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="System.Composition" Version="7.0.0" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
-  
   <ItemGroup>
-    <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />
     <ProjectReference Include="..\BinSkim.Sdk\BinSkim.Sdk.csproj" />
   </ItemGroup>
-  
   <ItemGroup>
     <Compile Update="RuleResources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -34,7 +29,6 @@
       <DependentUpon>RuleResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-  
   <ItemGroup>
     <EmbeddedResource Update="RuleResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -42,5 +36,4 @@
       <CustomToolNamespace>Microsoft.CodeAnalysis.IL.Rules</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
-  
 </Project>

--- a/src/BinSkim.Sdk/BinSkim.Sdk.csproj
+++ b/src/BinSkim.Sdk/BinSkim.Sdk.csproj
@@ -1,24 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.netcore.props))\build.netcore.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.netcore.props))\build.netcore.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.IL.Sdk</RootNamespace>
     <TargetFramework>$(NetStandardVersion)</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />
-    <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
   </ItemGroup>
-    
   <ItemGroup>
     <Compile Update="EnvironmentResources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -31,7 +27,6 @@
       <DependentUpon>SdkResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-  
   <ItemGroup>
     <EmbeddedResource Update="EnvironmentResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -43,5 +38,4 @@
       <CustomToolNamespace>Microsoft.CodeAnalysis.IL.Sdk</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
-  
 </Project>

--- a/src/BinSkim.Sdk/Telemetry.cs
+++ b/src/BinSkim.Sdk/Telemetry.cs
@@ -87,7 +87,8 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         private static void ConfigureTelemetryContext(TelemetryContext context)
         {
             context.Session.Id = CreateRandomSessionId();
-            context.Component.Version = Assembly.GetCallingAssembly().GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            AssemblyFileVersionAttribute? versionAttribute = Assembly.GetCallingAssembly().GetCustomAttribute<AssemblyFileVersionAttribute>();
+            context.Component.Version = versionAttribute?.Version ?? "Unknown";
             context.Device.OperatingSystem = RuntimeInformation.OSDescription;
         }
 

--- a/src/BinSkim.sln
+++ b/src/BinSkim.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -41,24 +41,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.BinSkim.Rules", "Test.UnitTests.BinSkim.Rules\Test.UnitTests.BinSkim.Rules.csproj", "{BDB5E58E-7B62-4BCB-B032-D86E18193E78}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.BinSkim.Driver", "Test.UnitTests.BinSkim.Driver\Test.UnitTests.BinSkim.Driver.csproj", "{B64DBE60-C7E6-48C1-BB7F-B12129DF98B2}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarif.Driver", "sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj", "{27C37565-AA27-4452-BABF-75DAF151A8F2}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sarif-sdk", "sarif-sdk", "{E69E2009-ECED-4750-AA40-BFDD4FD13DAB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarif", "sarif-sdk\src\Sarif\Sarif.csproj", "{C0DA9150-1651-457E-A700-A5CC389571A6}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif", "sarif-sdk\src\Test.UnitTests.Sarif\Test.UnitTests.Sarif.csproj", "{D976E333-3E50-41DD-B324-603B92237FC6}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif.Driver", "sarif-sdk\src\Test.UnitTests.Sarif.Driver\Test.UnitTests.Sarif.Driver.csproj", "{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.Utilities.Sarif", "sarif-sdk\src\Test.Utilities.Sarif\Test.Utilities.Sarif.csproj", "{33EE1C90-2A26-428C-8006-B585E07AB620}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarif.Converters", "sarif-sdk\src\Sarif.Converters\Sarif.Converters.csproj", "{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif.Converters", "sarif-sdk\src\Test.UnitTests.Sarif.Converters\Test.UnitTests.Sarif.Converters.csproj", "{E29D948B-BF8D-41D3-9924-01E994602D8A}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.ConcurrencyTests", "Test.ConcurrencyTests\Test.ConcurrencyTests.csproj", "{27A04162-2037-41FB-AD76-E179451BB627}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -140,78 +122,9 @@ Global
 		{B64DBE60-C7E6-48C1-BB7F-B12129DF98B2}.Release|Any CPU.Build.0 = Release|x64
 		{B64DBE60-C7E6-48C1-BB7F-B12129DF98B2}.Release|x64.ActiveCfg = Release|x64
 		{B64DBE60-C7E6-48C1-BB7F-B12129DF98B2}.Release|x64.Build.0 = Release|x64
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Debug|x64.Build.0 = Debug|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Release|x64.ActiveCfg = Release|Any CPU
-		{27C37565-AA27-4452-BABF-75DAF151A8F2}.Release|x64.Build.0 = Release|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Debug|x64.Build.0 = Debug|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Release|x64.ActiveCfg = Release|Any CPU
-		{C0DA9150-1651-457E-A700-A5CC389571A6}.Release|x64.Build.0 = Release|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Debug|x64.Build.0 = Debug|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Release|x64.ActiveCfg = Release|Any CPU
-		{D976E333-3E50-41DD-B324-603B92237FC6}.Release|x64.Build.0 = Release|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Debug|x64.Build.0 = Debug|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Release|x64.ActiveCfg = Release|Any CPU
-		{F8B27B8D-9DEE-4950-9257-83B8CD3714FE}.Release|x64.Build.0 = Release|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Debug|x64.Build.0 = Debug|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Release|Any CPU.Build.0 = Release|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Release|x64.ActiveCfg = Release|Any CPU
-		{33EE1C90-2A26-428C-8006-B585E07AB620}.Release|x64.Build.0 = Release|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Debug|x64.Build.0 = Debug|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Release|x64.ActiveCfg = Release|Any CPU
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB}.Release|x64.Build.0 = Release|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Debug|x64.Build.0 = Debug|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|x64.ActiveCfg = Release|Any CPU
-		{E29D948B-BF8D-41D3-9924-01E994602D8A}.Release|x64.Build.0 = Release|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Debug|x64.Build.0 = Debug|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Release|Any CPU.Build.0 = Release|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Release|x64.ActiveCfg = Release|Any CPU
-		{27A04162-2037-41FB-AD76-E179451BB627}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{27C37565-AA27-4452-BABF-75DAF151A8F2} = {E69E2009-ECED-4750-AA40-BFDD4FD13DAB}
-		{C0DA9150-1651-457E-A700-A5CC389571A6} = {E69E2009-ECED-4750-AA40-BFDD4FD13DAB}
-		{0C7A9CC9-991F-4971-8C82-9C8DDE66C3EB} = {E69E2009-ECED-4750-AA40-BFDD4FD13DAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AD3DFD92-76F5-471C-AAAB-9762C40A363E}

--- a/src/BinaryParsers/BinaryParsers.csproj
+++ b/src/BinaryParsers/BinaryParsers.csproj
@@ -7,26 +7,20 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="ELFSharp" Version="2.17.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+    <PackageReference Include="ELFSharp" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" />
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Dia2Lib">
       <HintPath>..\..\refs\Dia2Lib.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="BinaryParsersResources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -34,7 +28,6 @@
       <DependentUpon>BinaryParsersResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="BinaryParsersResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -42,7 +35,6 @@
       <CustomToolNamespace>Microsoft.CodeAnalysis.BinaryParsers</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
-
   <PropertyGroup>
     <PreBuildEvent Condition="$(OS) == 'Windows_NT'">
       echo Copying file from "$(MSBuildProjectDirectory)\..\..\refs\Dia2Lib.dll" to "$(MSBuildProjectDirectory)\..\..\src\packages\microsoft.diagnostics.tracing.traceevent\3.1.3\lib\netstandard2.0\"

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
@@ -17,635 +17,635 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
 {
-/// <summary>
-/// The main class
-/// </summary>
-public sealed class Pdb : IDisposable, IDiaLoadCallback2
-{
-    private IDiaDataSource dataSource;
-    private IDiaSession session;
-    private StringBuilder loadTrace;
-    private readonly string peOrPdbPath;
-    private readonly Lazy<Symbol> globalScope;
-    private bool restrictReferenceAndOriginalPathAccess;
-    private PdbFileType pdbFileType;
-    private const string s_windowsPdbSignature = "Microsoft C/C++ MSF 7.00\r\n\x001ADS\x0000\x0000\x0000";
-    private const string s_portablePdbSignature = "BSJB";
-    public static readonly ImmutableArray<byte> WindowsPdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_windowsPdbSignature));
-    public static readonly ImmutableArray<byte> PortablePdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_portablePdbSignature));
-
     /// <summary>
-    /// Load debug info from PE, using symbolPath to help find symbols
+    /// The main class
     /// </summary>
-    /// <param name="pePath">The path to the portable executable.</param>
-    /// <param name="symbolPath">The symsrv.dll symbol path.</param>
-    /// <param name="localSymbolDirectories">An option collection of local directories that should be examined for PDBs.</param>
-    public Pdb(
-        string pePath,
-        string symbolPath = null,
-        string localSymbolDirectories = null,
-        bool traceLoads = false)
+    public sealed class Pdb : IDisposable, IDiaLoadCallback2
     {
-        this.peOrPdbPath = pePath;
-        this.loadTrace = traceLoads ? new StringBuilder() : null;
-        this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
-        this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
-        this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
-        this.Init(pePath, symbolPath, localSymbolDirectories);
-    }
+        private IDiaDataSource dataSource;
+        private IDiaSession session;
+        private StringBuilder loadTrace;
+        private readonly string peOrPdbPath;
+        private readonly Lazy<Symbol> globalScope;
+        private bool restrictReferenceAndOriginalPathAccess;
+        private PdbFileType pdbFileType;
+        private const string s_windowsPdbSignature = "Microsoft C/C++ MSF 7.00\r\n\x001ADS\x0000\x0000\x0000";
+        private const string s_portablePdbSignature = "BSJB";
+        public static readonly ImmutableArray<byte> WindowsPdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_windowsPdbSignature));
+        public static readonly ImmutableArray<byte> PortablePdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_portablePdbSignature));
 
-    /// <summary>
-    /// Load debug info from PDB
-    /// </summary>
-    /// <param name="pdbPath">The path to the pdb.</param>
-    public Pdb(
-        string pdbPath,
-        bool traceLoads = false)
-    {
-        this.peOrPdbPath = pdbPath;
-        this.loadTrace = traceLoads ? new StringBuilder() : null;
-        this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
-        this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
-        this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
-        this.Init(pdbPath);
-    }
-
-    public string LoadTrace
-    {
-        get
+        /// <summary>
+        /// Load debug info from PE, using symbolPath to help find symbols
+        /// </summary>
+        /// <param name="pePath">The path to the portable executable.</param>
+        /// <param name="symbolPath">The symsrv.dll symbol path.</param>
+        /// <param name="localSymbolDirectories">An option collection of local directories that should be examined for PDBs.</param>
+        public Pdb(
+            string pePath,
+            string symbolPath = null,
+            string localSymbolDirectories = null,
+            bool traceLoads = false)
         {
-            return $"{this.loadTrace}";
+            this.peOrPdbPath = pePath;
+            this.loadTrace = traceLoads ? new StringBuilder() : null;
+            this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
+            this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
+            this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
+            this.Init(pePath, symbolPath, localSymbolDirectories);
         }
-        set
+
+        /// <summary>
+        /// Load debug info from PDB
+        /// </summary>
+        /// <param name="pdbPath">The path to the pdb.</param>
+        public Pdb(
+            string pdbPath,
+            bool traceLoads = false)
         {
-            // We make this settable to allow the tool to clear the trace. This
-            // prevents multiple reports (for every PDB loading rule) that the
-            // PDB couldn't, in fact, be loaded.
-            this.loadTrace = !string.IsNullOrEmpty(value)
-                ? new StringBuilder(value)
-                : null;
+            this.peOrPdbPath = pdbPath;
+            this.loadTrace = traceLoads ? new StringBuilder() : null;
+            this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
+            this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
+            this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
+            this.Init(pdbPath);
         }
-    }
 
-    /// <summary>
-    /// Returns the symbol for the global scope. Does not give up ownership of the symbol; callers
-    /// must NOT dispose it.
-    /// </summary>
-    /// <value>The global scope.</value>
-    public Symbol GlobalScope => this.globalScope.Value;
-
-    public bool IsStripped => this.GlobalScope.IsStripped;
-
-    public PdbFileType FileType
-    {
-        get
+        public string LoadTrace
         {
-            if (this.pdbFileType != PdbFileType.Unknown)
+            get
             {
-                return this.pdbFileType;
+                return $"{this.loadTrace}";
             }
-
-            int max = Math.Max(WindowsPdbSignature.Length, PortablePdbSignature.Length);
-
-            byte[] b = new byte[max];
-
-            // When we are at this step, we were able to read the pdb.
-            // If PdbLocation is a directory, it means that PdbType is embedded.
-            if (Directory.Exists(PdbLocation))
+            set
             {
-                return this.pdbFileType;
+                // We make this settable to allow the tool to clear the trace. This
+                // prevents multiple reports (for every PDB loading rule) that the
+                // PDB couldn't, in fact, be loaded.
+                this.loadTrace = !string.IsNullOrEmpty(value)
+                    ? new StringBuilder(value)
+                    : null;
             }
+        }
 
-            using (FileStream fs = File.OpenRead(PdbLocation))
+        /// <summary>
+        /// Returns the symbol for the global scope. Does not give up ownership of the symbol; callers
+        /// must NOT dispose it.
+        /// </summary>
+        /// <value>The global scope.</value>
+        public Symbol GlobalScope => this.globalScope.Value;
+
+        public bool IsStripped => this.GlobalScope.IsStripped;
+
+        public PdbFileType FileType
+        {
+            get
             {
-                if (fs.Read(b, 0, b.Length) != b.Length)
+                if (this.pdbFileType != PdbFileType.Unknown)
                 {
                     return this.pdbFileType;
                 }
-            }
 
-            Span<byte> span = b.AsSpan();
+                int max = Math.Max(WindowsPdbSignature.Length, PortablePdbSignature.Length);
 
-            if (WindowsPdbSignature.AsSpan().SequenceEqual(span.Slice(0, WindowsPdbSignature.Length)))
-            {
-                this.pdbFileType = PdbFileType.Windows;
-            }
-            else if (PortablePdbSignature.AsSpan().SequenceEqual(span.Slice(0, PortablePdbSignature.Length)))
-            {
-                this.pdbFileType = PdbFileType.Portable;
-            }
+                byte[] b = new byte[max];
 
-            return this.pdbFileType;
+                // When we are at this step, we were able to read the pdb.
+                // If PdbLocation is a directory, it means that PdbType is embedded.
+                if (Directory.Exists(PdbLocation))
+                {
+                    return this.pdbFileType;
+                }
+
+                using (FileStream fs = File.OpenRead(PdbLocation))
+                {
+                    if (fs.Read(b, 0, b.Length) != b.Length)
+                    {
+                        return this.pdbFileType;
+                    }
+                }
+
+                Span<byte> span = b.AsSpan();
+
+                if (WindowsPdbSignature.AsSpan().SequenceEqual(span.Slice(0, WindowsPdbSignature.Length)))
+                {
+                    this.pdbFileType = PdbFileType.Windows;
+                }
+                else if (PortablePdbSignature.AsSpan().SequenceEqual(span.Slice(0, PortablePdbSignature.Length)))
+                {
+                    this.pdbFileType = PdbFileType.Portable;
+                }
+
+                return this.pdbFileType;
+            }
         }
-    }
 
-    /// <summary>
-    /// Get the list of modules in this executable
-    /// </summary>
-    public DisposableEnumerable<Symbol> CreateObjectModuleIterator()
-    {
-        return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagCompiland);
-    }
-
-    /// <summary>
-    /// Returns global variables defined in this executable
-    /// </summary>
-    public DisposableEnumerable<Symbol> CreateGlobalVariableIterator()
-    {
-        return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagData);
-    }
-
-    /// <summary>
-    /// Returns global functions defined in this executable
-    /// </summary>
-    public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator()
-    {
-        return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagFunction);
-    }
-
-    /// <summary>
-    /// Returns global functions defined in this executable that meet the supplied filter
-    /// </summary>
-    public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator(string functionName, NameSearchOptions searchOptions)
-    {
-        return this.GlobalScope.CreateChildren(SymTagEnum.SymTagFunction, functionName, searchOptions);
-    }
-
-    public DisposableEnumerable<SourceFile> CreateSourceFileIterator()
-    {
-        return this.CreateSourceFileIterator(null);
-    }
-
-    public DisposableEnumerable<SourceFile> CreateSourceFileIterator(Symbol inObjectModule)
-    {
-        return new DisposableEnumerable<SourceFile>(this.CreateSourceFileIteratorImpl(inObjectModule.UnderlyingSymbol));
-    }
-
-    private IEnumerable<SourceFile> CreateSourceFileIteratorImpl(IDiaSymbol inObjectModule)
-    {
-        IDiaEnumSourceFiles sourceFilesEnum = null;
-        try
+        /// <summary>
+        /// Get the list of modules in this executable
+        /// </summary>
+        public DisposableEnumerable<Symbol> CreateObjectModuleIterator()
         {
-            this.session.findFile(inObjectModule, null, 0, out sourceFilesEnum);
+            return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagCompiland);
+        }
 
-            while (true)
+        /// <summary>
+        /// Returns global variables defined in this executable
+        /// </summary>
+        public DisposableEnumerable<Symbol> CreateGlobalVariableIterator()
+        {
+            return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagData);
+        }
+
+        /// <summary>
+        /// Returns global functions defined in this executable
+        /// </summary>
+        public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator()
+        {
+            return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagFunction);
+        }
+
+        /// <summary>
+        /// Returns global functions defined in this executable that meet the supplied filter
+        /// </summary>
+        public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator(string functionName, NameSearchOptions searchOptions)
+        {
+            return this.GlobalScope.CreateChildren(SymTagEnum.SymTagFunction, functionName, searchOptions);
+        }
+
+        public DisposableEnumerable<SourceFile> CreateSourceFileIterator()
+        {
+            return this.CreateSourceFileIterator(null);
+        }
+
+        public DisposableEnumerable<SourceFile> CreateSourceFileIterator(Symbol inObjectModule)
+        {
+            return new DisposableEnumerable<SourceFile>(this.CreateSourceFileIteratorImpl(inObjectModule.UnderlyingSymbol));
+        }
+
+        private IEnumerable<SourceFile> CreateSourceFileIteratorImpl(IDiaSymbol inObjectModule)
+        {
+            IDiaEnumSourceFiles sourceFilesEnum = null;
+            try
             {
-                sourceFilesEnum.Next(1, out IDiaSourceFile sourceFile, out uint celt);
-                if (celt != 1)
+                this.session.findFile(inObjectModule, null, 0, out sourceFilesEnum);
+
+                while (true)
+                {
+                    sourceFilesEnum.Next(1, out IDiaSourceFile sourceFile, out uint celt);
+                    if (celt != 1)
+                    {
+                        break;
+                    }
+
+                    yield return new SourceFile(this, sourceFile);
+                }
+            }
+            finally
+            {
+                if (sourceFilesEnum != null)
+                {
+                    Marshal.ReleaseComObject(sourceFilesEnum);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns an IEnumerable collection of injected files filtered by a file name.
+        /// </summary>
+        /// <param name="fileName">The file name to look for.</param>
+        /// <returns>All the sources that match the <paramref name="fileName"/>.</returns>
+        public IEnumerable<IDiaInjectedSource> InjectedSources(string fileName)
+        {
+            this.session.findInjectedSource(fileName, out IDiaEnumInjectedSources enumSources);
+
+            foreach (IDiaInjectedSource diaInjectedSource in enumSources)
+            {
+                yield return diaInjectedSource;
+            }
+        }
+
+        private T CreateDiaTable<T>() where T : class
+        {
+            IDiaEnumTables enumTables = null;
+
+            try
+            {
+                this.session.getEnumTables(out enumTables);
+                if (enumTables == null)
+                {
+                    return null;
+                }
+
+                // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
+                for (int i = 0; i < enumTables.Count; i++)
+                {
+                    IDiaTable table = enumTables.Item(i);
+                    if (!(table is T result))
+                    {
+                        Marshal.ReleaseComObject(table);
+                    }
+                    else
+                    {
+                        return result;
+                    }
+                }
+            }
+            finally
+            {
+                if (enumTables != null)
+                {
+                    Marshal.ReleaseComObject(enumTables);
+                }
+            }
+
+            return null;
+        }
+
+        private readonly Lazy<HashSet<uint>> writableSegmentIds;
+
+        private HashSet<uint> GenerateWritableSegmentSet()
+        {
+            var result = new HashSet<uint>();
+            IDiaEnumSegments enumSegments = null;
+
+            try
+            {
+                enumSegments = this.CreateDiaTable<IDiaEnumSegments>();
+            }
+            catch (NotImplementedException) { }
+
+            try
+            {
+                // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
+                for (uint i = 0; i < (uint)enumSegments.Count; i++)
+                {
+                    IDiaSegment segment = enumSegments.Item(i);
+                    try
+                    {
+                        if (segment.write != 0)
+                        {
+                            result.Add(segment.addressSection);
+                        }
+                    }
+                    finally
+                    {
+                        Marshal.ReleaseComObject(segment);
+                    }
+                }
+            }
+            finally
+            {
+                if (enumSegments != null)
+                {
+                    Marshal.ReleaseComObject(enumSegments);
+                }
+            }
+
+            return result;
+        }
+
+        public bool IsSegmentWithIdWritable(uint addressSection)
+        {
+            return this.writableSegmentIds.Value.Contains(addressSection);
+        }
+
+        private readonly Lazy<HashSet<uint>> executableSectionContribCompilandIds;
+
+        private HashSet<uint> GenerateExecutableSectionContribIds()
+        {
+            var result = new HashSet<uint>();
+            IDiaEnumSectionContribs enumSectionContribs = null;
+
+            try
+            {
+                enumSectionContribs = this.CreateDiaTable<IDiaEnumSectionContribs>();
+            }
+            catch (NotImplementedException) { }
+
+            if (enumSectionContribs == null)
+            {
+                return result;
+            }
+
+            try
+            {
+                // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
+                for (uint i = 0; i < (uint)enumSectionContribs.Count; i++)
+                {
+                    IDiaSectionContrib sectionContrib = enumSectionContribs.Item(i);
+                    try
+                    {
+                        if (sectionContrib.execute != 0)
+                        {
+                            result.Add(sectionContrib.compilandId);
+                        }
+                    }
+                    finally
+                    {
+                        Marshal.ReleaseComObject(sectionContrib);
+                    }
+                }
+            }
+            finally
+            {
+                if (enumSectionContribs != null)
+                {
+                    Marshal.ReleaseComObject(enumSectionContribs);
+                }
+            }
+            return result;
+        }
+
+        public bool CompilandWithIdIsInExecutableSectionContrib(uint segmentId)
+        {
+            return this.executableSectionContribCompilandIds.Value.Contains(segmentId);
+        }
+
+        public bool ContainsExecutableSectionContribs()
+        {
+            return this.executableSectionContribCompilandIds.Value.Count != 0;
+        }
+
+        /// <summary>
+        /// Returns the location of the PDB for this module
+        /// </summary>
+        public string PdbLocation
+        {
+            get
+            {
+                string path = this.session.globalScope.symbolsFileName;
+                if (File.Exists(path) && !Directory.Exists(path))
+                {
+                    return path;
+                }
+
+                string extension = Path.GetExtension(this.peOrPdbPath);
+                if (File.Exists(this.peOrPdbPath.Replace(extension, ".pdb")))
+                {
+                    return this.peOrPdbPath.Replace(extension, ".pdb");
+                }
+
+                return path;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.globalScope.IsValueCreated)
+            {
+                this.globalScope.Value.Dispose();
+            }
+
+            if (this.session != null)
+            {
+                Marshal.ReleaseComObject(this.session);
+            }
+
+            if (this.dataSource != null)
+            {
+                Marshal.ReleaseComObject(this.dataSource);
+            }
+        }
+
+        /// <summary>
+        /// Load debug info from a PE path.
+        /// </summary>
+        /// <param name="pePath"></param>
+        /// <param name="symbolPath"></param>
+        private void Init(string pePath, string symbolPath, string localSymbolDirectories)
+        {
+            try
+            {
+                PlatformSpecificHelpers.ThrowIfNotOnWindows();
+                this.WindowsNativeLoadPdbFromPEUsingDia(pePath, symbolPath, localSymbolDirectories);
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
+            }
+            catch (COMException ce)
+            {
+                if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
+                {
+                    throw new PdbException(DiaHresult.E_FAIL, ce)
+                    {
+                        LoadTrace = $"{this.loadTrace}"
+                    };
+                }
+
+                throw new PdbException(ce)
+                {
+                    LoadTrace = $"{this.loadTrace}"
+                };
+            }
+        }
+
+        /// <summary>
+        /// Load debug info from a PDB path.
+        /// </summary>
+        /// <param name="pdbPath"></param>
+        private void Init(string pdbPath)
+        {
+            try
+            {
+                PlatformSpecificHelpers.ThrowIfNotOnWindows();
+                this.WindowsNativeLoadPdbUsingDia(pdbPath);
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. Failed, platform is not Windows.");
+                throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
+            }
+        }
+
+        private void WindowsNativeLoadPdbFromPEUsingDia(string peOrPdbPath, string symbolPath, string localSymbolDirectories)
+        {
+            IDiaDataSource diaSource = null;
+            Environment.SetEnvironmentVariable("_NT_SYMBOL_PATH", "");
+            Environment.SetEnvironmentVariable("_NT_ALT_SYMBOL_PATH", "");
+
+            object pCallback = this.loadTrace != null ? this : (object)IntPtr.Zero;
+
+            if (!string.IsNullOrEmpty(localSymbolDirectories))
+            {
+                // If we have one or more local symbol directories, we want
+                // to probe them before any other default load behavior. If
+                // this load code path fails, we fill fallback to these
+                // defaults locations in the second load pass below.
+                this.restrictReferenceAndOriginalPathAccess = true;
+                try
+                {
+                    diaSource = MsdiaComWrapper.GetDiaSource();
+
+                    diaSource.loadDataForExe(peOrPdbPath,
+                                             localSymbolDirectories,
+                                             pCallback);
+                }
+                catch
+                {
+                    diaSource = null;
+                }
+            }
+
+            if (diaSource == null)
+            {
+                this.restrictReferenceAndOriginalPathAccess = false;
+
+                diaSource = MsdiaComWrapper.GetDiaSource();
+
+                diaSource.loadDataForExe(peOrPdbPath,
+                                         symbolPath,
+                                         pCallback);
+            }
+
+            diaSource.openSession(out this.session);
+            this.dataSource = diaSource;
+        }
+
+        private void WindowsNativeLoadPdbUsingDia(string pdbPath)
+        {
+            this.restrictReferenceAndOriginalPathAccess = false;
+
+            IDiaDataSource diaSource = MsdiaComWrapper.GetDiaSource();
+            try
+            {
+                diaSource.loadDataFromPdb(pdbPath);
+            }
+            catch (OutOfMemoryException ex)
+            {
+                this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.E_OUTOFMEMORY}. This may indicate the PDB is corrupt.");
+
+                throw new PdbException(DiaHresult.E_OUTOFMEMORY, ex)
+                {
+                    LoadTrace = $"{this.loadTrace}"
+                };
+            }
+            catch (COMException ce)
+            {
+                this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {ce.HResult}.");
+                if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
+                {
+                    throw new PdbException(DiaHresult.E_FAIL, ce)
+                    {
+                        LoadTrace = $"{this.loadTrace}"
+                    };
+                }
+
+                throw new PdbException(ce)
+                {
+                    LoadTrace = $"{this.loadTrace}"
+                };
+            }
+
+            diaSource.openSession(out this.session);
+            this.dataSource = diaSource;
+
+            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.S_OK}.");
+        }
+
+        private Symbol GetGlobalScope()
+        {
+            return Symbol.Create(this.session.globalScope);
+        }
+
+        public void NotifyDebugDir([MarshalAs(UnmanagedType.Bool)] bool executable, int dataSize, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] byte[] data)
+        {
+        }
+
+        public void NotifyOpenDbg([MarshalAs(UnmanagedType.LPWStr)] string dbgPath, DiaHresult resultCode)
+        {
+            this.loadTrace.AppendLine($"  Examined DBG path: '{dbgPath}'. HResult: {resultCode}.");
+        }
+
+        public void NotifyOpenPdb([MarshalAs(UnmanagedType.LPWStr)] string pdbPath, DiaHresult resultCode)
+        {
+            this.loadTrace.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {resultCode}.");
+        }
+
+        public IEnumerable<string> WindowsPdbGetSourceLinkDocuments()
+        {
+            // Source Link is stored in windows pdb in *EITHER* the 'sourcelink' stream *OR* 1 or more 'sourcelink$n' streams where n starts at 1.
+            // For multi stream format, we read the streams starting at 1 until we receive a stream size of 0.
+            string sourceLink = WindowsGetUtf8Stream("sourcelink");
+            if (!string.IsNullOrEmpty(sourceLink))
+            {
+                yield return sourceLink;
+            }
+
+            for (int streamNumber = 1; streamNumber < int.MaxValue; streamNumber++)
+            {
+                string streamName = "sourcelink$" + streamNumber.ToString(CultureInfo.InvariantCulture);
+                sourceLink = this.WindowsGetUtf8Stream(streamName);
+                if (string.IsNullOrEmpty(sourceLink))
                 {
                     break;
                 }
 
-                yield return new SourceFile(this, sourceFile);
+                yield return sourceLink;
             }
         }
-        finally
+
+        private unsafe byte[] WindowsGetRawStream(string streamName)
         {
-            if (sourceFilesEnum != null)
+            if (string.IsNullOrEmpty(streamName))
             {
-                Marshal.ReleaseComObject(sourceFilesEnum);
+                throw new ArgumentException($"'{nameof(streamName)}' cannot be null or empty.", nameof(streamName));
             }
-        }
-    }
 
-    /// <summary>
-    /// Returns an IEnumerable collection of injected files filtered by a file name.
-    /// </summary>
-    /// <param name="fileName">The file name to look for.</param>
-    /// <returns>All the sources that match the <paramref name="fileName"/>.</returns>
-    public IEnumerable<IDiaInjectedSource> InjectedSources(string fileName)
-    {
-        this.session.findInjectedSource(fileName, out IDiaEnumInjectedSources enumSources);
-
-        foreach (IDiaInjectedSource diaInjectedSource in enumSources)
-        {
-            yield return diaInjectedSource;
-        }
-    }
-
-    private T CreateDiaTable<T>() where T : class
-    {
-        IDiaEnumTables enumTables = null;
-
-        try
-        {
-            this.session.getEnumTables(out enumTables);
-            if (enumTables == null)
+            var diaDataSource = (IDiaDataSource3)this.dataSource;
+            diaDataSource.getStreamSize(streamName, out uint size);
+            if (size == 0)
             {
                 return null;
             }
 
-            // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
-            for (int i = 0; i < enumTables.Count; i++)
+            byte[] buffer = new byte[size];
+            fixed (byte* bufferPtr = buffer)
             {
-                IDiaTable table = enumTables.Item(i);
-                if (!(table is T result))
-                {
-                    Marshal.ReleaseComObject(table);
-                }
-                else
-                {
-                    return result;
-                }
-            }
-        }
-        finally
-        {
-            if (enumTables != null)
-            {
-                Marshal.ReleaseComObject(enumTables);
+                diaDataSource.getStreamRawData(streamName, size, out *bufferPtr);
+                return buffer;
             }
         }
 
-        return null;
-    }
-
-    private readonly Lazy<HashSet<uint>> writableSegmentIds;
-
-    private HashSet<uint> GenerateWritableSegmentSet()
-    {
-        var result = new HashSet<uint>();
-        IDiaEnumSegments enumSegments = null;
-
-        try
+        private unsafe string WindowsGetUtf8Stream(string streamName)
         {
-            enumSegments = this.CreateDiaTable<IDiaEnumSegments>();
-        }
-        catch (NotImplementedException) { }
-
-        try
-        {
-            // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
-            for (uint i = 0; i < (uint)enumSegments.Count; i++)
-            {
-                IDiaSegment segment = enumSegments.Item(i);
-                try
-                {
-                    if (segment.write != 0)
-                    {
-                        result.Add(segment.addressSection);
-                    }
-                }
-                finally
-                {
-                    Marshal.ReleaseComObject(segment);
-                }
-            }
-        }
-        finally
-        {
-            if (enumSegments != null)
-            {
-                Marshal.ReleaseComObject(enumSegments);
-            }
+            byte[] rawStream = WindowsGetRawStream(streamName);
+            return rawStream is null ? null : Encoding.UTF8.GetString(rawStream);
         }
 
-        return result;
-    }
-
-    public bool IsSegmentWithIdWritable(uint addressSection)
-    {
-        return this.writableSegmentIds.Value.Contains(addressSection);
-    }
-
-    private readonly Lazy<HashSet<uint>> executableSectionContribCompilandIds;
-
-    private HashSet<uint> GenerateExecutableSectionContribIds()
-    {
-        var result = new HashSet<uint>();
-        IDiaEnumSectionContribs enumSectionContribs = null;
-
-        try
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool RestrictRegistryAccess()
         {
-            enumSectionContribs = this.CreateDiaTable<IDiaEnumSectionContribs>();
-        }
-        catch (NotImplementedException) { }
-
-        if (enumSectionContribs == null)
-        {
-            return result;
+            return true;
         }
 
-        try
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool RestrictSymbolServerAccess()
         {
-            // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
-            for (uint i = 0; i < (uint)enumSectionContribs.Count; i++)
-            {
-                IDiaSectionContrib sectionContrib = enumSectionContribs.Item(i);
-                try
-                {
-                    if (sectionContrib.execute != 0)
-                    {
-                        result.Add(sectionContrib.compilandId);
-                    }
-                }
-                finally
-                {
-                    Marshal.ReleaseComObject(sectionContrib);
-                }
-            }
+            return false;
         }
-        finally
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool RestrictOriginalPathAccess()
         {
-            if (enumSectionContribs != null)
-            {
-                Marshal.ReleaseComObject(enumSectionContribs);
-            }
+            return this.restrictReferenceAndOriginalPathAccess;
         }
-        return result;
-    }
 
-    public bool CompilandWithIdIsInExecutableSectionContrib(uint segmentId)
-    {
-        return this.executableSectionContribCompilandIds.Value.Contains(segmentId);
-    }
-
-    public bool ContainsExecutableSectionContribs()
-    {
-        return this.executableSectionContribCompilandIds.Value.Count != 0;
-    }
-
-    /// <summary>
-    /// Returns the location of the PDB for this module
-    /// </summary>
-    public string PdbLocation
-    {
-        get
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool RestrictReferencePathAccess()
         {
-            string path = this.session.globalScope.symbolsFileName;
-            if (File.Exists(path) && !Directory.Exists(path))
-            {
-                return path;
-            }
+            return this.restrictReferenceAndOriginalPathAccess;
+        }
 
-            string extension = Path.GetExtension(this.peOrPdbPath);
-            if (File.Exists(this.peOrPdbPath.Replace(extension, ".pdb")))
-            {
-                return this.peOrPdbPath.Replace(extension, ".pdb");
-            }
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool RestrictDbgAccess()
+        {
+            return false;
+        }
 
-            return path;
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool RestrictSystemRootAccess()
+        {
+            return true;
         }
     }
-
-    public void Dispose()
-    {
-        if (this.globalScope.IsValueCreated)
-        {
-            this.globalScope.Value.Dispose();
-        }
-
-        if (this.session != null)
-        {
-            Marshal.ReleaseComObject(this.session);
-        }
-
-        if (this.dataSource != null)
-        {
-            Marshal.ReleaseComObject(this.dataSource);
-        }
-    }
-
-    /// <summary>
-    /// Load debug info from a PE path.
-    /// </summary>
-    /// <param name="pePath"></param>
-    /// <param name="symbolPath"></param>
-    private void Init(string pePath, string symbolPath, string localSymbolDirectories)
-    {
-        try
-        {
-            PlatformSpecificHelpers.ThrowIfNotOnWindows();
-            this.WindowsNativeLoadPdbFromPEUsingDia(pePath, symbolPath, localSymbolDirectories);
-        }
-        catch (PlatformNotSupportedException ex)
-        {
-            throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
-        }
-        catch (COMException ce)
-        {
-            if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
-            {
-                throw new PdbException(DiaHresult.E_FAIL, ce)
-                {
-                    LoadTrace = $"{this.loadTrace}"
-                };
-            }
-
-            throw new PdbException(ce)
-            {
-                LoadTrace = $"{this.loadTrace}"
-            };
-        }
-    }
-
-    /// <summary>
-    /// Load debug info from a PDB path.
-    /// </summary>
-    /// <param name="pdbPath"></param>
-    private void Init(string pdbPath)
-    {
-        try
-        {
-            PlatformSpecificHelpers.ThrowIfNotOnWindows();
-            this.WindowsNativeLoadPdbUsingDia(pdbPath);
-        }
-        catch (PlatformNotSupportedException ex)
-        {
-            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. Failed, platform is not Windows.");
-            throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
-        }
-    }
-
-    private void WindowsNativeLoadPdbFromPEUsingDia(string peOrPdbPath, string symbolPath, string localSymbolDirectories)
-    {
-        IDiaDataSource diaSource = null;
-        Environment.SetEnvironmentVariable("_NT_SYMBOL_PATH", "");
-        Environment.SetEnvironmentVariable("_NT_ALT_SYMBOL_PATH", "");
-
-        object pCallback = this.loadTrace != null ? this : (object)IntPtr.Zero;
-
-        if (!string.IsNullOrEmpty(localSymbolDirectories))
-        {
-            // If we have one or more local symbol directories, we want
-            // to probe them before any other default load behavior. If
-            // this load code path fails, we fill fallback to these
-            // defaults locations in the second load pass below.
-            this.restrictReferenceAndOriginalPathAccess = true;
-            try
-            {
-                diaSource = MsdiaComWrapper.GetDiaSource();
-
-                diaSource.loadDataForExe(peOrPdbPath,
-                                         localSymbolDirectories,
-                                         pCallback);
-            }
-            catch
-            {
-                diaSource = null;
-            }
-        }
-
-        if (diaSource == null)
-        {
-            this.restrictReferenceAndOriginalPathAccess = false;
-
-            diaSource = MsdiaComWrapper.GetDiaSource();
-
-            diaSource.loadDataForExe(peOrPdbPath,
-                                     symbolPath,
-                                     pCallback);
-        }
-
-        diaSource.openSession(out this.session);
-        this.dataSource = diaSource;
-    }
-
-    private void WindowsNativeLoadPdbUsingDia(string pdbPath)
-    {
-        this.restrictReferenceAndOriginalPathAccess = false;
-
-        IDiaDataSource diaSource = MsdiaComWrapper.GetDiaSource();
-        try
-        {
-            diaSource.loadDataFromPdb(pdbPath);
-        }
-        catch (OutOfMemoryException ex)
-        {
-            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.E_OUTOFMEMORY}. This may indicate the PDB is corrupt.");
-
-            throw new PdbException(DiaHresult.E_OUTOFMEMORY, ex)
-            {
-                LoadTrace = $"{this.loadTrace}"
-            };
-        }
-        catch (COMException ce)
-        {
-            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {ce.HResult}.");
-            if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
-            {
-                throw new PdbException(DiaHresult.E_FAIL, ce)
-                {
-                    LoadTrace = $"{this.loadTrace}"
-                };
-            }
-
-            throw new PdbException(ce)
-            {
-                LoadTrace = $"{this.loadTrace}"
-            };
-        }
-
-        diaSource.openSession(out this.session);
-        this.dataSource = diaSource;
-
-        this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.S_OK}.");
-    }
-
-    private Symbol GetGlobalScope()
-    {
-        return Symbol.Create(this.session.globalScope);
-    }
-
-    public void NotifyDebugDir([MarshalAs(UnmanagedType.Bool)] bool executable, int dataSize, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] byte[] data)
-    {
-    }
-
-    public void NotifyOpenDbg([MarshalAs(UnmanagedType.LPWStr)] string dbgPath, DiaHresult resultCode)
-    {
-        this.loadTrace.AppendLine($"  Examined DBG path: '{dbgPath}'. HResult: {resultCode}.");
-    }
-
-    public void NotifyOpenPdb([MarshalAs(UnmanagedType.LPWStr)] string pdbPath, DiaHresult resultCode)
-    {
-        this.loadTrace.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {resultCode}.");
-    }
-
-    public IEnumerable<string> WindowsPdbGetSourceLinkDocuments()
-    {
-        // Source Link is stored in windows pdb in *EITHER* the 'sourcelink' stream *OR* 1 or more 'sourcelink$n' streams where n starts at 1.
-        // For multi stream format, we read the streams starting at 1 until we receive a stream size of 0.
-        string sourceLink = WindowsGetUtf8Stream("sourcelink");
-        if (!string.IsNullOrEmpty(sourceLink))
-        {
-            yield return sourceLink;
-        }
-
-        for (int streamNumber = 1; streamNumber < int.MaxValue; streamNumber++)
-        {
-            string streamName = "sourcelink$" + streamNumber.ToString(CultureInfo.InvariantCulture);
-            sourceLink = this.WindowsGetUtf8Stream(streamName);
-            if (string.IsNullOrEmpty(sourceLink))
-            {
-                break;
-            }
-
-            yield return sourceLink;
-        }
-    }
-
-    private unsafe byte[] WindowsGetRawStream(string streamName)
-    {
-        if (string.IsNullOrEmpty(streamName))
-        {
-            throw new ArgumentException($"'{nameof(streamName)}' cannot be null or empty.", nameof(streamName));
-        }
-
-        var diaDataSource = (IDiaDataSource3)this.dataSource;
-        diaDataSource.getStreamSize(streamName, out uint size);
-        if (size == 0)
-        {
-            return null;
-        }
-
-        byte[] buffer = new byte[size];
-        fixed (byte* bufferPtr = buffer)
-        {
-            diaDataSource.getStreamRawData(streamName, size, out *bufferPtr);
-            return buffer;
-        }
-    }
-
-    private unsafe string WindowsGetUtf8Stream(string streamName)
-    {
-        byte[] rawStream = WindowsGetRawStream(streamName);
-        return rawStream is null ? null : Encoding.UTF8.GetString(rawStream);
-    }
-
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public bool RestrictRegistryAccess()
-    {
-        return true;
-    }
-
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public bool RestrictSymbolServerAccess()
-    {
-        return false;
-    }
-
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public bool RestrictOriginalPathAccess()
-    {
-        return this.restrictReferenceAndOriginalPathAccess;
-    }
-
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public bool RestrictReferencePathAccess()
-    {
-        return this.restrictReferenceAndOriginalPathAccess;
-    }
-
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public bool RestrictDbgAccess()
-    {
-        return false;
-    }
-
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public bool RestrictSystemRootAccess()
-    {
-        return true;
-    }
-}
 }

--- a/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
+++ b/src/BinaryParsers/PEBinary/ProgramDatabase/Pdb.cs
@@ -17,635 +17,635 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase
 {
+/// <summary>
+/// The main class
+/// </summary>
+public sealed class Pdb : IDisposable, IDiaLoadCallback2
+{
+    private IDiaDataSource dataSource;
+    private IDiaSession session;
+    private StringBuilder loadTrace;
+    private readonly string peOrPdbPath;
+    private readonly Lazy<Symbol> globalScope;
+    private bool restrictReferenceAndOriginalPathAccess;
+    private PdbFileType pdbFileType;
+    private const string s_windowsPdbSignature = "Microsoft C/C++ MSF 7.00\r\n\x001ADS\x0000\x0000\x0000";
+    private const string s_portablePdbSignature = "BSJB";
+    public static readonly ImmutableArray<byte> WindowsPdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_windowsPdbSignature));
+    public static readonly ImmutableArray<byte> PortablePdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_portablePdbSignature));
+
     /// <summary>
-    /// The main class
+    /// Load debug info from PE, using symbolPath to help find symbols
     /// </summary>
-    public sealed class Pdb : IDisposable, IDiaLoadCallback2
+    /// <param name="pePath">The path to the portable executable.</param>
+    /// <param name="symbolPath">The symsrv.dll symbol path.</param>
+    /// <param name="localSymbolDirectories">An option collection of local directories that should be examined for PDBs.</param>
+    public Pdb(
+        string pePath,
+        string symbolPath = null,
+        string localSymbolDirectories = null,
+        bool traceLoads = false)
     {
-        private IDiaDataSource dataSource;
-        private IDiaSession session;
-        private StringBuilder loadTrace;
-        private readonly string peOrPdbPath;
-        private readonly Lazy<Symbol> globalScope;
-        private bool restrictReferenceAndOriginalPathAccess;
-        private PdbFileType pdbFileType;
-        private const string s_windowsPdbSignature = "Microsoft C/C++ MSF 7.00\r\n\x001ADS\x0000\x0000\x0000";
-        private const string s_portablePdbSignature = "BSJB";
-        public static readonly ImmutableArray<byte> WindowsPdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_windowsPdbSignature));
-        public static readonly ImmutableArray<byte> PortablePdbSignature = ImmutableArray.Create(Encoding.ASCII.GetBytes(s_portablePdbSignature));
+        this.peOrPdbPath = pePath;
+        this.loadTrace = traceLoads ? new StringBuilder() : null;
+        this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
+        this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
+        this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
+        this.Init(pePath, symbolPath, localSymbolDirectories);
+    }
 
-        /// <summary>
-        /// Load debug info from PE, using symbolPath to help find symbols
-        /// </summary>
-        /// <param name="pePath">The path to the portable executable.</param>
-        /// <param name="symbolPath">The symsrv.dll symbol path.</param>
-        /// <param name="localSymbolDirectories">An option collection of local directories that should be examined for PDBs.</param>
-        public Pdb(
-            string pePath,
-            string symbolPath = null,
-            string localSymbolDirectories = null,
-            bool traceLoads = false)
+    /// <summary>
+    /// Load debug info from PDB
+    /// </summary>
+    /// <param name="pdbPath">The path to the pdb.</param>
+    public Pdb(
+        string pdbPath,
+        bool traceLoads = false)
+    {
+        this.peOrPdbPath = pdbPath;
+        this.loadTrace = traceLoads ? new StringBuilder() : null;
+        this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
+        this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
+        this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
+        this.Init(pdbPath);
+    }
+
+    public string LoadTrace
+    {
+        get
         {
-            this.peOrPdbPath = pePath;
-            this.loadTrace = traceLoads ? new StringBuilder() : null;
-            this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
-            this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
-            this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
-            this.Init(pePath, symbolPath, localSymbolDirectories);
+            return $"{this.loadTrace}";
         }
-
-        /// <summary>
-        /// Load debug info from PDB
-        /// </summary>
-        /// <param name="pdbPath">The path to the pdb.</param>
-        public Pdb(
-            string pdbPath,
-            bool traceLoads = false)
+        set
         {
-            this.peOrPdbPath = pdbPath;
-            this.loadTrace = traceLoads ? new StringBuilder() : null;
-            this.globalScope = new Lazy<Symbol>(this.GetGlobalScope, LazyThreadSafetyMode.ExecutionAndPublication);
-            this.writableSegmentIds = new Lazy<HashSet<uint>>(this.GenerateWritableSegmentSet);
-            this.executableSectionContribCompilandIds = new Lazy<HashSet<uint>>(this.GenerateExecutableSectionContribIds);
-            this.Init(pdbPath);
+            // We make this settable to allow the tool to clear the trace. This
+            // prevents multiple reports (for every PDB loading rule) that the
+            // PDB couldn't, in fact, be loaded.
+            this.loadTrace = !string.IsNullOrEmpty(value)
+                ? new StringBuilder(value)
+                : null;
         }
+    }
 
-        public string LoadTrace
+    /// <summary>
+    /// Returns the symbol for the global scope. Does not give up ownership of the symbol; callers
+    /// must NOT dispose it.
+    /// </summary>
+    /// <value>The global scope.</value>
+    public Symbol GlobalScope => this.globalScope.Value;
+
+    public bool IsStripped => this.GlobalScope.IsStripped;
+
+    public PdbFileType FileType
+    {
+        get
         {
-            get
+            if (this.pdbFileType != PdbFileType.Unknown)
             {
-                return $"{this.loadTrace}";
-            }
-            set
-            {
-                // We make this settable to allow the tool to clear the trace. This
-                // prevents multiple reports (for every PDB loading rule) that the
-                // PDB couldn't, in fact, be loaded.
-                this.loadTrace = !string.IsNullOrEmpty(value)
-                    ? new StringBuilder(value)
-                    : null;
-            }
-        }
-
-        /// <summary>
-        /// Returns the symbol for the global scope. Does not give up ownership of the symbol; callers
-        /// must NOT dispose it.
-        /// </summary>
-        /// <value>The global scope.</value>
-        public Symbol GlobalScope => this.globalScope.Value;
-
-        public bool IsStripped => this.GlobalScope.IsStripped;
-
-        public PdbFileType FileType
-        {
-            get
-            {
-                if (this.pdbFileType != PdbFileType.Unknown)
-                {
-                    return this.pdbFileType;
-                }
-
-                int max = Math.Max(WindowsPdbSignature.Length, PortablePdbSignature.Length);
-
-                byte[] b = new byte[max];
-
-                // When we are at this step, we were able to read the pdb.
-                // If PdbLocation is a directory, it means that PdbType is embedded.
-                if (Directory.Exists(PdbLocation))
-                {
-                    return this.pdbFileType;
-                }
-
-                using (FileStream fs = File.OpenRead(PdbLocation))
-                {
-                    if (fs.Read(b, 0, b.Length) != b.Length)
-                    {
-                        return this.pdbFileType;
-                    }
-                }
-
-                Span<byte> span = b.AsSpan();
-
-                if (WindowsPdbSignature.AsSpan().SequenceEqual(span.Slice(0, WindowsPdbSignature.Length)))
-                {
-                    this.pdbFileType = PdbFileType.Windows;
-                }
-                else if (PortablePdbSignature.AsSpan().SequenceEqual(span.Slice(0, PortablePdbSignature.Length)))
-                {
-                    this.pdbFileType = PdbFileType.Portable;
-                }
-
                 return this.pdbFileType;
             }
-        }
 
-        /// <summary>
-        /// Get the list of modules in this executable
-        /// </summary>
-        public DisposableEnumerable<Symbol> CreateObjectModuleIterator()
-        {
-            return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagCompiland);
-        }
+            int max = Math.Max(WindowsPdbSignature.Length, PortablePdbSignature.Length);
 
-        /// <summary>
-        /// Returns global variables defined in this executable
-        /// </summary>
-        public DisposableEnumerable<Symbol> CreateGlobalVariableIterator()
-        {
-            return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagData);
-        }
+            byte[] b = new byte[max];
 
-        /// <summary>
-        /// Returns global functions defined in this executable
-        /// </summary>
-        public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator()
-        {
-            return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagFunction);
-        }
-
-        /// <summary>
-        /// Returns global functions defined in this executable that meet the supplied filter
-        /// </summary>
-        public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator(string functionName, NameSearchOptions searchOptions)
-        {
-            return this.GlobalScope.CreateChildren(SymTagEnum.SymTagFunction, functionName, searchOptions);
-        }
-
-        public DisposableEnumerable<SourceFile> CreateSourceFileIterator()
-        {
-            return this.CreateSourceFileIterator(null);
-        }
-
-        public DisposableEnumerable<SourceFile> CreateSourceFileIterator(Symbol inObjectModule)
-        {
-            return new DisposableEnumerable<SourceFile>(this.CreateSourceFileIteratorImpl(inObjectModule.UnderlyingSymbol));
-        }
-
-        private IEnumerable<SourceFile> CreateSourceFileIteratorImpl(IDiaSymbol inObjectModule)
-        {
-            IDiaEnumSourceFiles sourceFilesEnum = null;
-            try
+            // When we are at this step, we were able to read the pdb.
+            // If PdbLocation is a directory, it means that PdbType is embedded.
+            if (Directory.Exists(PdbLocation))
             {
-                this.session.findFile(inObjectModule, null, 0, out sourceFilesEnum);
-
-                while (true)
-                {
-                    sourceFilesEnum.Next(1, out IDiaSourceFile sourceFile, out uint celt);
-                    if (celt != 1)
-                    {
-                        break;
-                    }
-
-                    yield return new SourceFile(this, sourceFile);
-                }
+                return this.pdbFileType;
             }
-            finally
+
+            using (FileStream fs = File.OpenRead(PdbLocation))
             {
-                if (sourceFilesEnum != null)
+                if (fs.Read(b, 0, b.Length) != b.Length)
                 {
-                    Marshal.ReleaseComObject(sourceFilesEnum);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Returns an IEnumerable collection of injected files filtered by a file name.
-        /// </summary>
-        /// <param name="fileName">The file name to look for.</param>
-        /// <returns>All the sources that match the <paramref name="fileName"/>.</returns>
-        public IEnumerable<IDiaInjectedSource> InjectedSources(string fileName)
-        {
-            this.session.findInjectedSource(fileName, out IDiaEnumInjectedSources enumSources);
-
-            foreach (IDiaInjectedSource diaInjectedSource in enumSources)
-            {
-                yield return diaInjectedSource;
-            }
-        }
-
-        private T CreateDiaTable<T>() where T : class
-        {
-            IDiaEnumTables enumTables = null;
-
-            try
-            {
-                this.session.getEnumTables(out enumTables);
-                if (enumTables == null)
-                {
-                    return null;
-                }
-
-                // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
-                for (int i = 0; i < enumTables.Count; i++)
-                {
-                    IDiaTable table = enumTables.Item(i);
-                    if (!(table is T result))
-                    {
-                        Marshal.ReleaseComObject(table);
-                    }
-                    else
-                    {
-                        return result;
-                    }
-                }
-            }
-            finally
-            {
-                if (enumTables != null)
-                {
-                    Marshal.ReleaseComObject(enumTables);
+                    return this.pdbFileType;
                 }
             }
 
-            return null;
+            Span<byte> span = b.AsSpan();
+
+            if (WindowsPdbSignature.AsSpan().SequenceEqual(span.Slice(0, WindowsPdbSignature.Length)))
+            {
+                this.pdbFileType = PdbFileType.Windows;
+            }
+            else if (PortablePdbSignature.AsSpan().SequenceEqual(span.Slice(0, PortablePdbSignature.Length)))
+            {
+                this.pdbFileType = PdbFileType.Portable;
+            }
+
+            return this.pdbFileType;
         }
+    }
 
-        private readonly Lazy<HashSet<uint>> writableSegmentIds;
+    /// <summary>
+    /// Get the list of modules in this executable
+    /// </summary>
+    public DisposableEnumerable<Symbol> CreateObjectModuleIterator()
+    {
+        return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagCompiland);
+    }
 
-        private HashSet<uint> GenerateWritableSegmentSet()
+    /// <summary>
+    /// Returns global variables defined in this executable
+    /// </summary>
+    public DisposableEnumerable<Symbol> CreateGlobalVariableIterator()
+    {
+        return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagData);
+    }
+
+    /// <summary>
+    /// Returns global functions defined in this executable
+    /// </summary>
+    public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator()
+    {
+        return this.GlobalScope.CreateChildIterator(SymTagEnum.SymTagFunction);
+    }
+
+    /// <summary>
+    /// Returns global functions defined in this executable that meet the supplied filter
+    /// </summary>
+    public DisposableEnumerable<Symbol> CreateGlobalFunctionIterator(string functionName, NameSearchOptions searchOptions)
+    {
+        return this.GlobalScope.CreateChildren(SymTagEnum.SymTagFunction, functionName, searchOptions);
+    }
+
+    public DisposableEnumerable<SourceFile> CreateSourceFileIterator()
+    {
+        return this.CreateSourceFileIterator(null);
+    }
+
+    public DisposableEnumerable<SourceFile> CreateSourceFileIterator(Symbol inObjectModule)
+    {
+        return new DisposableEnumerable<SourceFile>(this.CreateSourceFileIteratorImpl(inObjectModule.UnderlyingSymbol));
+    }
+
+    private IEnumerable<SourceFile> CreateSourceFileIteratorImpl(IDiaSymbol inObjectModule)
+    {
+        IDiaEnumSourceFiles sourceFilesEnum = null;
+        try
         {
-            var result = new HashSet<uint>();
-            IDiaEnumSegments enumSegments = null;
+            this.session.findFile(inObjectModule, null, 0, out sourceFilesEnum);
 
-            try
+            while (true)
             {
-                enumSegments = this.CreateDiaTable<IDiaEnumSegments>();
-            }
-            catch (NotImplementedException) { }
-
-            try
-            {
-                // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
-                for (uint i = 0; i < (uint)enumSegments.Count; i++)
-                {
-                    IDiaSegment segment = enumSegments.Item(i);
-                    try
-                    {
-                        if (segment.write != 0)
-                        {
-                            result.Add(segment.addressSection);
-                        }
-                    }
-                    finally
-                    {
-                        Marshal.ReleaseComObject(segment);
-                    }
-                }
-            }
-            finally
-            {
-                if (enumSegments != null)
-                {
-                    Marshal.ReleaseComObject(enumSegments);
-                }
-            }
-
-            return result;
-        }
-
-        public bool IsSegmentWithIdWritable(uint addressSection)
-        {
-            return this.writableSegmentIds.Value.Contains(addressSection);
-        }
-
-        private readonly Lazy<HashSet<uint>> executableSectionContribCompilandIds;
-
-        private HashSet<uint> GenerateExecutableSectionContribIds()
-        {
-            var result = new HashSet<uint>();
-            IDiaEnumSectionContribs enumSectionContribs = null;
-
-            try
-            {
-                enumSectionContribs = this.CreateDiaTable<IDiaEnumSectionContribs>();
-            }
-            catch (NotImplementedException) { }
-
-            if (enumSectionContribs == null)
-            {
-                return result;
-            }
-
-            try
-            {
-                // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
-                for (uint i = 0; i < (uint)enumSectionContribs.Count; i++)
-                {
-                    IDiaSectionContrib sectionContrib = enumSectionContribs.Item(i);
-                    try
-                    {
-                        if (sectionContrib.execute != 0)
-                        {
-                            result.Add(sectionContrib.compilandId);
-                        }
-                    }
-                    finally
-                    {
-                        Marshal.ReleaseComObject(sectionContrib);
-                    }
-                }
-            }
-            finally
-            {
-                if (enumSectionContribs != null)
-                {
-                    Marshal.ReleaseComObject(enumSectionContribs);
-                }
-            }
-            return result;
-        }
-
-        public bool CompilandWithIdIsInExecutableSectionContrib(uint segmentId)
-        {
-            return this.executableSectionContribCompilandIds.Value.Contains(segmentId);
-        }
-
-        public bool ContainsExecutableSectionContribs()
-        {
-            return this.executableSectionContribCompilandIds.Value.Count != 0;
-        }
-
-        /// <summary>
-        /// Returns the location of the PDB for this module
-        /// </summary>
-        public string PdbLocation
-        {
-            get
-            {
-                string path = this.session.globalScope.symbolsFileName;
-                if (File.Exists(path) && !Directory.Exists(path))
-                {
-                    return path;
-                }
-
-                string extension = Path.GetExtension(this.peOrPdbPath);
-                if (File.Exists(this.peOrPdbPath.Replace(extension, ".pdb")))
-                {
-                    return this.peOrPdbPath.Replace(extension, ".pdb");
-                }
-
-                return path;
-            }
-        }
-
-        public void Dispose()
-        {
-            if (this.globalScope.IsValueCreated)
-            {
-                this.globalScope.Value.Dispose();
-            }
-
-            if (this.session != null)
-            {
-                Marshal.ReleaseComObject(this.session);
-            }
-
-            if (this.dataSource != null)
-            {
-                Marshal.ReleaseComObject(this.dataSource);
-            }
-        }
-
-        /// <summary>
-        /// Load debug info from a PE path.
-        /// </summary>
-        /// <param name="pePath"></param>
-        /// <param name="symbolPath"></param>
-        private void Init(string pePath, string symbolPath, string localSymbolDirectories)
-        {
-            try
-            {
-                PlatformSpecificHelpers.ThrowIfNotOnWindows();
-                this.WindowsNativeLoadPdbFromPEUsingDia(pePath, symbolPath, localSymbolDirectories);
-            }
-            catch (PlatformNotSupportedException ex)
-            {
-                throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
-            }
-            catch (COMException ce)
-            {
-                if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
-                {
-                    throw new PdbException(DiaHresult.E_FAIL, ce)
-                    {
-                        LoadTrace = $"{this.loadTrace}"
-                    };
-                }
-
-                throw new PdbException(ce)
-                {
-                    LoadTrace = $"{this.loadTrace}"
-                };
-            }
-        }
-
-        /// <summary>
-        /// Load debug info from a PDB path.
-        /// </summary>
-        /// <param name="pdbPath"></param>
-        private void Init(string pdbPath)
-        {
-            try
-            {
-                PlatformSpecificHelpers.ThrowIfNotOnWindows();
-                this.WindowsNativeLoadPdbUsingDia(pdbPath);
-            }
-            catch (PlatformNotSupportedException ex)
-            {
-                this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. Failed, platform is not Windows.");
-                throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
-            }
-        }
-
-        private void WindowsNativeLoadPdbFromPEUsingDia(string peOrPdbPath, string symbolPath, string localSymbolDirectories)
-        {
-            IDiaDataSource diaSource = null;
-            Environment.SetEnvironmentVariable("_NT_SYMBOL_PATH", "");
-            Environment.SetEnvironmentVariable("_NT_ALT_SYMBOL_PATH", "");
-
-            object pCallback = this.loadTrace != null ? this : (object)IntPtr.Zero;
-
-            if (!string.IsNullOrEmpty(localSymbolDirectories))
-            {
-                // If we have one or more local symbol directories, we want
-                // to probe them before any other default load behavior. If
-                // this load code path fails, we fill fallback to these
-                // defaults locations in the second load pass below.
-                this.restrictReferenceAndOriginalPathAccess = true;
-                try
-                {
-                    diaSource = MsdiaComWrapper.GetDiaSource();
-
-                    diaSource.loadDataForExe(peOrPdbPath,
-                                             localSymbolDirectories,
-                                             pCallback);
-                }
-                catch
-                {
-                    diaSource = null;
-                }
-            }
-
-            if (diaSource == null)
-            {
-                this.restrictReferenceAndOriginalPathAccess = false;
-
-                diaSource = MsdiaComWrapper.GetDiaSource();
-
-                diaSource.loadDataForExe(peOrPdbPath,
-                                         symbolPath,
-                                         pCallback);
-            }
-
-            diaSource.openSession(out this.session);
-            this.dataSource = diaSource;
-        }
-
-        private void WindowsNativeLoadPdbUsingDia(string pdbPath)
-        {
-            this.restrictReferenceAndOriginalPathAccess = false;
-
-            IDiaDataSource diaSource = MsdiaComWrapper.GetDiaSource();
-            try
-            {
-                diaSource.loadDataFromPdb(pdbPath);
-            }
-            catch (OutOfMemoryException ex)
-            {
-                this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.E_OUTOFMEMORY}. This may indicate the PDB is corrupt.");
-
-                throw new PdbException(DiaHresult.E_OUTOFMEMORY, ex)
-                {
-                    LoadTrace = $"{this.loadTrace}"
-                };
-            }
-            catch (COMException ce)
-            {
-                this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {ce.HResult}.");
-                if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
-                {
-                    throw new PdbException(DiaHresult.E_FAIL, ce)
-                    {
-                        LoadTrace = $"{this.loadTrace}"
-                    };
-                }
-
-                throw new PdbException(ce)
-                {
-                    LoadTrace = $"{this.loadTrace}"
-                };
-            }
-
-            diaSource.openSession(out this.session);
-            this.dataSource = diaSource;
-
-            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.S_OK}.");
-        }
-
-        private Symbol GetGlobalScope()
-        {
-            return Symbol.Create(this.session.globalScope);
-        }
-
-        public void NotifyDebugDir([MarshalAs(UnmanagedType.Bool)] bool executable, int dataSize, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] byte[] data)
-        {
-        }
-
-        public void NotifyOpenDbg([MarshalAs(UnmanagedType.LPWStr)] string dbgPath, DiaHresult resultCode)
-        {
-            this.loadTrace.AppendLine($"  Examined DBG path: '{dbgPath}'. HResult: {resultCode}.");
-        }
-
-        public void NotifyOpenPdb([MarshalAs(UnmanagedType.LPWStr)] string pdbPath, DiaHresult resultCode)
-        {
-            this.loadTrace.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {resultCode}.");
-        }
-
-        public IEnumerable<string> WindowsPdbGetSourceLinkDocuments()
-        {
-            // Source Link is stored in windows pdb in *EITHER* the 'sourcelink' stream *OR* 1 or more 'sourcelink$n' streams where n starts at 1.
-            // For multi stream format, we read the streams starting at 1 until we receive a stream size of 0.
-            string sourceLink = WindowsGetUtf8Stream("sourcelink");
-            if (!string.IsNullOrEmpty(sourceLink))
-            {
-                yield return sourceLink;
-            }
-
-            for (int streamNumber = 1; streamNumber < int.MaxValue; streamNumber++)
-            {
-                string streamName = "sourcelink$" + streamNumber.ToString(CultureInfo.InvariantCulture);
-                sourceLink = this.WindowsGetUtf8Stream(streamName);
-                if (string.IsNullOrEmpty(sourceLink))
+                sourceFilesEnum.Next(1, out IDiaSourceFile sourceFile, out uint celt);
+                if (celt != 1)
                 {
                     break;
                 }
 
-                yield return sourceLink;
+                yield return new SourceFile(this, sourceFile);
             }
         }
-
-        private unsafe byte[] WindowsGetRawStream(string streamName)
+        finally
         {
-            if (string.IsNullOrEmpty(streamName))
+            if (sourceFilesEnum != null)
             {
-                throw new ArgumentException($"'{nameof(streamName)}' cannot be null or empty.", nameof(streamName));
+                Marshal.ReleaseComObject(sourceFilesEnum);
             }
+        }
+    }
 
-            var diaDataSource = (IDiaDataSource3)this.dataSource;
-            diaDataSource.getStreamSize(streamName, out uint size);
-            if (size == 0)
+    /// <summary>
+    /// Returns an IEnumerable collection of injected files filtered by a file name.
+    /// </summary>
+    /// <param name="fileName">The file name to look for.</param>
+    /// <returns>All the sources that match the <paramref name="fileName"/>.</returns>
+    public IEnumerable<IDiaInjectedSource> InjectedSources(string fileName)
+    {
+        this.session.findInjectedSource(fileName, out IDiaEnumInjectedSources enumSources);
+
+        foreach (IDiaInjectedSource diaInjectedSource in enumSources)
+        {
+            yield return diaInjectedSource;
+        }
+    }
+
+    private T CreateDiaTable<T>() where T : class
+    {
+        IDiaEnumTables enumTables = null;
+
+        try
+        {
+            this.session.getEnumTables(out enumTables);
+            if (enumTables == null)
             {
                 return null;
             }
 
-            byte[] buffer = new byte[size];
-            fixed (byte* bufferPtr = buffer)
+            // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
+            for (int i = 0; i < enumTables.Count; i++)
             {
-                diaDataSource.getStreamRawData(streamName, size, out *bufferPtr);
-                return buffer;
+                IDiaTable table = enumTables.Item(i);
+                if (!(table is T result))
+                {
+                    Marshal.ReleaseComObject(table);
+                }
+                else
+                {
+                    return result;
+                }
+            }
+        }
+        finally
+        {
+            if (enumTables != null)
+            {
+                Marshal.ReleaseComObject(enumTables);
             }
         }
 
-        private unsafe string WindowsGetUtf8Stream(string streamName)
+        return null;
+    }
+
+    private readonly Lazy<HashSet<uint>> writableSegmentIds;
+
+    private HashSet<uint> GenerateWritableSegmentSet()
+    {
+        var result = new HashSet<uint>();
+        IDiaEnumSegments enumSegments = null;
+
+        try
         {
-            byte[] rawStream = WindowsGetRawStream(streamName);
-            return rawStream is null ? null : Encoding.UTF8.GetString(rawStream);
+            enumSegments = this.CreateDiaTable<IDiaEnumSegments>();
+        }
+        catch (NotImplementedException) { }
+
+        try
+        {
+            // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
+            for (uint i = 0; i < (uint)enumSegments.Count; i++)
+            {
+                IDiaSegment segment = enumSegments.Item(i);
+                try
+                {
+                    if (segment.write != 0)
+                    {
+                        result.Add(segment.addressSection);
+                    }
+                }
+                finally
+                {
+                    Marshal.ReleaseComObject(segment);
+                }
+            }
+        }
+        finally
+        {
+            if (enumSegments != null)
+            {
+                Marshal.ReleaseComObject(enumSegments);
+            }
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public bool RestrictRegistryAccess()
+        return result;
+    }
+
+    public bool IsSegmentWithIdWritable(uint addressSection)
+    {
+        return this.writableSegmentIds.Value.Contains(addressSection);
+    }
+
+    private readonly Lazy<HashSet<uint>> executableSectionContribCompilandIds;
+
+    private HashSet<uint> GenerateExecutableSectionContribIds()
+    {
+        var result = new HashSet<uint>();
+        IDiaEnumSectionContribs enumSectionContribs = null;
+
+        try
         {
-            return true;
+            enumSectionContribs = this.CreateDiaTable<IDiaEnumSectionContribs>();
+        }
+        catch (NotImplementedException) { }
+
+        if (enumSectionContribs == null)
+        {
+            return result;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public bool RestrictSymbolServerAccess()
+        try
         {
-            return false;
+            // GetEnumerator() fails in netcoreapp2.0--need to iterate without foreach.
+            for (uint i = 0; i < (uint)enumSectionContribs.Count; i++)
+            {
+                IDiaSectionContrib sectionContrib = enumSectionContribs.Item(i);
+                try
+                {
+                    if (sectionContrib.execute != 0)
+                    {
+                        result.Add(sectionContrib.compilandId);
+                    }
+                }
+                finally
+                {
+                    Marshal.ReleaseComObject(sectionContrib);
+                }
+            }
         }
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public bool RestrictOriginalPathAccess()
+        finally
         {
-            return this.restrictReferenceAndOriginalPathAccess;
+            if (enumSectionContribs != null)
+            {
+                Marshal.ReleaseComObject(enumSectionContribs);
+            }
         }
+        return result;
+    }
 
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public bool RestrictReferencePathAccess()
-        {
-            return this.restrictReferenceAndOriginalPathAccess;
-        }
+    public bool CompilandWithIdIsInExecutableSectionContrib(uint segmentId)
+    {
+        return this.executableSectionContribCompilandIds.Value.Contains(segmentId);
+    }
 
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public bool RestrictDbgAccess()
-        {
-            return false;
-        }
+    public bool ContainsExecutableSectionContribs()
+    {
+        return this.executableSectionContribCompilandIds.Value.Count != 0;
+    }
 
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public bool RestrictSystemRootAccess()
+    /// <summary>
+    /// Returns the location of the PDB for this module
+    /// </summary>
+    public string PdbLocation
+    {
+        get
         {
-            return true;
+            string path = this.session.globalScope.symbolsFileName;
+            if (File.Exists(path) && !Directory.Exists(path))
+            {
+                return path;
+            }
+
+            string extension = Path.GetExtension(this.peOrPdbPath);
+            if (File.Exists(this.peOrPdbPath.Replace(extension, ".pdb")))
+            {
+                return this.peOrPdbPath.Replace(extension, ".pdb");
+            }
+
+            return path;
         }
     }
+
+    public void Dispose()
+    {
+        if (this.globalScope.IsValueCreated)
+        {
+            this.globalScope.Value.Dispose();
+        }
+
+        if (this.session != null)
+        {
+            Marshal.ReleaseComObject(this.session);
+        }
+
+        if (this.dataSource != null)
+        {
+            Marshal.ReleaseComObject(this.dataSource);
+        }
+    }
+
+    /// <summary>
+    /// Load debug info from a PE path.
+    /// </summary>
+    /// <param name="pePath"></param>
+    /// <param name="symbolPath"></param>
+    private void Init(string pePath, string symbolPath, string localSymbolDirectories)
+    {
+        try
+        {
+            PlatformSpecificHelpers.ThrowIfNotOnWindows();
+            this.WindowsNativeLoadPdbFromPEUsingDia(pePath, symbolPath, localSymbolDirectories);
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
+        }
+        catch (COMException ce)
+        {
+            if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
+            {
+                throw new PdbException(DiaHresult.E_FAIL, ce)
+                {
+                    LoadTrace = $"{this.loadTrace}"
+                };
+            }
+
+            throw new PdbException(ce)
+            {
+                LoadTrace = $"{this.loadTrace}"
+            };
+        }
+    }
+
+    /// <summary>
+    /// Load debug info from a PDB path.
+    /// </summary>
+    /// <param name="pdbPath"></param>
+    private void Init(string pdbPath)
+    {
+        try
+        {
+            PlatformSpecificHelpers.ThrowIfNotOnWindows();
+            this.WindowsNativeLoadPdbUsingDia(pdbPath);
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. Failed, platform is not Windows.");
+            throw new PdbException(message: BinaryParsersResources.PdbPlatformUnsupported, ex);
+        }
+    }
+
+    private void WindowsNativeLoadPdbFromPEUsingDia(string peOrPdbPath, string symbolPath, string localSymbolDirectories)
+    {
+        IDiaDataSource diaSource = null;
+        Environment.SetEnvironmentVariable("_NT_SYMBOL_PATH", "");
+        Environment.SetEnvironmentVariable("_NT_ALT_SYMBOL_PATH", "");
+
+        object pCallback = this.loadTrace != null ? this : (object)IntPtr.Zero;
+
+        if (!string.IsNullOrEmpty(localSymbolDirectories))
+        {
+            // If we have one or more local symbol directories, we want
+            // to probe them before any other default load behavior. If
+            // this load code path fails, we fill fallback to these
+            // defaults locations in the second load pass below.
+            this.restrictReferenceAndOriginalPathAccess = true;
+            try
+            {
+                diaSource = MsdiaComWrapper.GetDiaSource();
+
+                diaSource.loadDataForExe(peOrPdbPath,
+                                         localSymbolDirectories,
+                                         pCallback);
+            }
+            catch
+            {
+                diaSource = null;
+            }
+        }
+
+        if (diaSource == null)
+        {
+            this.restrictReferenceAndOriginalPathAccess = false;
+
+            diaSource = MsdiaComWrapper.GetDiaSource();
+
+            diaSource.loadDataForExe(peOrPdbPath,
+                                     symbolPath,
+                                     pCallback);
+        }
+
+        diaSource.openSession(out this.session);
+        this.dataSource = diaSource;
+    }
+
+    private void WindowsNativeLoadPdbUsingDia(string pdbPath)
+    {
+        this.restrictReferenceAndOriginalPathAccess = false;
+
+        IDiaDataSource diaSource = MsdiaComWrapper.GetDiaSource();
+        try
+        {
+            diaSource.loadDataFromPdb(pdbPath);
+        }
+        catch (OutOfMemoryException ex)
+        {
+            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.E_OUTOFMEMORY}. This may indicate the PDB is corrupt.");
+
+            throw new PdbException(DiaHresult.E_OUTOFMEMORY, ex)
+            {
+                LoadTrace = $"{this.loadTrace}"
+            };
+        }
+        catch (COMException ce)
+        {
+            this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {ce.HResult}.");
+            if (!string.IsNullOrEmpty(ce.Message) && ce.Message.StartsWith("Error HRESULT E_FAIL"))
+            {
+                throw new PdbException(DiaHresult.E_FAIL, ce)
+                {
+                    LoadTrace = $"{this.loadTrace}"
+                };
+            }
+
+            throw new PdbException(ce)
+            {
+                LoadTrace = $"{this.loadTrace}"
+            };
+        }
+
+        diaSource.openSession(out this.session);
+        this.dataSource = diaSource;
+
+        this.loadTrace?.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {DiaHresult.S_OK}.");
+    }
+
+    private Symbol GetGlobalScope()
+    {
+        return Symbol.Create(this.session.globalScope);
+    }
+
+    public void NotifyDebugDir([MarshalAs(UnmanagedType.Bool)] bool executable, int dataSize, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] byte[] data)
+    {
+    }
+
+    public void NotifyOpenDbg([MarshalAs(UnmanagedType.LPWStr)] string dbgPath, DiaHresult resultCode)
+    {
+        this.loadTrace.AppendLine($"  Examined DBG path: '{dbgPath}'. HResult: {resultCode}.");
+    }
+
+    public void NotifyOpenPdb([MarshalAs(UnmanagedType.LPWStr)] string pdbPath, DiaHresult resultCode)
+    {
+        this.loadTrace.AppendLine($"  Examined PDB path: '{pdbPath}'. HResult: {resultCode}.");
+    }
+
+    public IEnumerable<string> WindowsPdbGetSourceLinkDocuments()
+    {
+        // Source Link is stored in windows pdb in *EITHER* the 'sourcelink' stream *OR* 1 or more 'sourcelink$n' streams where n starts at 1.
+        // For multi stream format, we read the streams starting at 1 until we receive a stream size of 0.
+        string sourceLink = WindowsGetUtf8Stream("sourcelink");
+        if (!string.IsNullOrEmpty(sourceLink))
+        {
+            yield return sourceLink;
+        }
+
+        for (int streamNumber = 1; streamNumber < int.MaxValue; streamNumber++)
+        {
+            string streamName = "sourcelink$" + streamNumber.ToString(CultureInfo.InvariantCulture);
+            sourceLink = this.WindowsGetUtf8Stream(streamName);
+            if (string.IsNullOrEmpty(sourceLink))
+            {
+                break;
+            }
+
+            yield return sourceLink;
+        }
+    }
+
+    private unsafe byte[] WindowsGetRawStream(string streamName)
+    {
+        if (string.IsNullOrEmpty(streamName))
+        {
+            throw new ArgumentException($"'{nameof(streamName)}' cannot be null or empty.", nameof(streamName));
+        }
+
+        var diaDataSource = (IDiaDataSource3)this.dataSource;
+        diaDataSource.getStreamSize(streamName, out uint size);
+        if (size == 0)
+        {
+            return null;
+        }
+
+        byte[] buffer = new byte[size];
+        fixed (byte* bufferPtr = buffer)
+        {
+            diaDataSource.getStreamRawData(streamName, size, out *bufferPtr);
+            return buffer;
+        }
+    }
+
+    private unsafe string WindowsGetUtf8Stream(string streamName)
+    {
+        byte[] rawStream = WindowsGetRawStream(streamName);
+        return rawStream is null ? null : Encoding.UTF8.GetString(rawStream);
+    }
+
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public bool RestrictRegistryAccess()
+    {
+        return true;
+    }
+
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public bool RestrictSymbolServerAccess()
+    {
+        return false;
+    }
+
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public bool RestrictOriginalPathAccess()
+    {
+        return this.restrictReferenceAndOriginalPathAccess;
+    }
+
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public bool RestrictReferencePathAccess()
+    {
+        return this.restrictReferenceAndOriginalPathAccess;
+    }
+
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public bool RestrictDbgAccess()
+    {
+        return false;
+    }
+
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public bool RestrictSystemRootAccess()
+    {
+        return true;
+    }
+}
 }

--- a/src/BinaryParsers/VersionConstants.cs
+++ b/src/BinaryParsers/VersionConstants.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT         
 // license. See LICENSE file in the project root for full license information.  
-namespace Microsoft.CodeAnalysis.IL
-{
-    public static class VersionConstants
-    {
-        public const string Prerelease = "";
-        public const string AssemblyVersion = "4.3.1" + ".0";
-        public const string FileVersion = "4.3.1" + ".0";
-        public const string Version = AssemblyVersion + Prerelease;
-    }
-}
+namespace Microsoft.CodeAnalysis.IL                                             
+{                                                                               
+    public static class VersionConstants                                        
+    {                                                                           
+        public const string Prerelease = "";                        
+        public const string AssemblyVersion = "4.3.1" + ".0"; 
+        public const string FileVersion = "4.3.1" + ".0";     
+        public const string Version = AssemblyVersion + Prerelease;             
+    }                                                                           
+ }                                                                              

--- a/src/BinaryParsers/VersionConstants.cs
+++ b/src/BinaryParsers/VersionConstants.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT         
 // license. See LICENSE file in the project root for full license information.  
-namespace Microsoft.CodeAnalysis.IL                                             
-{                                                                               
-    public static class VersionConstants                                        
-    {                                                                           
-        public const string Prerelease = "";                        
-        public const string AssemblyVersion = "4.3.1" + ".0"; 
-        public const string FileVersion = "4.3.1" + ".0";     
-        public const string Version = AssemblyVersion + Prerelease;             
-    }                                                                           
- }                                                                              
+namespace Microsoft.CodeAnalysis.IL
+{
+    public static class VersionConstants
+    {
+        public const string Prerelease = "";
+        public const string AssemblyVersion = "4.3.1" + ".0";
+        public const string FileVersion = "4.3.1" + ".0";
+        public const string Version = AssemblyVersion + Prerelease;
+    }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,25 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
+    <PackageVersion Include="ELFSharp" Version="2.17.3" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Sarif.Driver" Version="4.5.4" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Include="System.Composition" Version="9.0.0" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>

--- a/src/Nuget/BinSkim.nuspec
+++ b/src/Nuget/BinSkim.nuspec
@@ -19,7 +19,6 @@
   <files>
     <file src="bld\bin\x64_$configuration$\Publish\**\*" target="tools"/>   
     <file src="ReleaseHistory.md" target="tools\ReleaseHistory.md" />
-    <file src="src\sarif-sdk\ReleaseHistory.md" target="tools\ReleaseHistory-Sarif-Sdk.md" />
     <file src="src\BinaryParsers\**\*.cs" target="src\BinaryParsers" />
     <file src="src\BinSkim.Driver\**\*.cs" target="src\BinSkim.Driver" />
     <file src="src\BinSkim.Rules\**\*.cs" target="src\BinSkim.Rules" />

--- a/src/Shared/SharedAssemblyInfo.cs
+++ b/src/Shared/SharedAssemblyInfo.cs
@@ -5,9 +5,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion(Microsoft.CodeAnalysis.IL.VersionConstants.AssemblyVersion)]
-[assembly: AssemblyFileVersion(Microsoft.CodeAnalysis.IL.VersionConstants.FileVersion)]
-
 [assembly: AssemblyProduct("BinSkim Portable Executable Analyzer")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Driver/Test.FunctionalTests.BinSkim.Driver.csproj
@@ -10,28 +10,26 @@
   <PropertyGroup>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\BaselineTests.runsettings</RunSettingsFilePath>
   </PropertyGroup>
-
   <ItemGroup>
-	<RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />
     <ProjectReference Include="..\BinSkim.Driver\BinSkim.Driver.csproj" />
@@ -41,17 +39,14 @@
     <ProjectReference Include="..\Test.UnitTests.BinSkim.Driver\Test.UnitTests.BinSkim.Driver.csproj" />
     <ProjectReference Include="..\Test.UnitTests.BinSkim.Rules\Test.UnitTests.BinSkim.Rules.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="BaselineTestData\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <None Update="BaselineTestData\Wix_3.11.1_VS2017_Bootstrapper.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj
+++ b/src/Test.FunctionalTests.BinSkim.Rules/Test.FunctionalTests.BinSkim.Rules.csproj
@@ -1,43 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.netcore.props))\build.netcore.props" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreVersion)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <TargetLatestRuntimePatch>True</TargetLatestRuntimePatch>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Sarif.Driver" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />
     <ProjectReference Include="..\BinSkim.Driver\BinSkim.Driver.csproj" />
     <ProjectReference Include="..\BinSkim.Rules\BinSkim.Rules.csproj" />
     <ProjectReference Include="..\BinSkim.Sdk\BinSkim.Sdk.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="FunctionalTestData\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj
+++ b/src/Test.UnitTests.BinSkim.Driver/Test.UnitTests.BinSkim.Driver.csproj
@@ -10,16 +10,17 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Sarif.Driver" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />

--- a/src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj
+++ b/src/Test.UnitTests.BinSkim.Rules/Test.UnitTests.BinSkim.Rules.csproj
@@ -10,15 +10,16 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />

--- a/src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj
+++ b/src/Test.UnitTests.BinaryParsers/Test.UnitTests.BinaryParsers.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.netcore.props))\build.netcore.props" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.BinaryParsers</RootNamespace>
     <TargetFrameworks>$(NetCoreVersion)</TargetFrameworks>
@@ -10,26 +9,23 @@
     <TargetLatestRuntimePatch>True</TargetLatestRuntimePatch>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sarif.Driver" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\BinaryParsers\BinaryParsers.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Dia2Lib">
       <HintPath>..\..\refs\Dia2Lib.dll</HintPath>
     </Reference>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
# Move from Submodule to NuGet
## Overview
This pull request aims to migrate the BinSkim project from using the sarif-sdk submodule to a NuGet package. This change is intended to streamline the dependency management process and improve build reliability.

## Changes
Removed the sarif-sdk submodule.
Added the sarif-sdk NuGet package to the project.
Updated the project files to reference the NuGet package instead of the submodule.
## Benefits

Simplified Dependency Management: Using NuGet packages simplifies the process of managing dependencies, making it easier to update and maintain them.
Improved Build Reliability: By moving away from submodules, we reduce the potential for errors related to submodule synchronization and updates.

## Testing
Verified that the project builds successfully with the new NuGet package.
Ran all existing tests to ensure no regressions were introduced.
Conducted manual testing to confirm that the functionality remains intact.
Additional Notes
If you encounter any issues or have questions about this migration, please feel free to reach out.