### PR TITLE
Remove sarif-sdk subproject folder and update dotnet-format tool version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.1.x
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -75,7 +75,7 @@ echo BuildPackages.cmd
 call BuildPackages.cmd || goto :ExitFailed
 
 echo dotnet-format
-dotnet tool update --global dotnet-format --version 4.1.131201
+dotnet tool update --global dotnet-format
 
 ::Update BinSkimRules.md to cover any xml changes
 echo Exporting any BinSkim rules


### PR DESCRIPTION
Removal of sarif-sdk folder. Folder is causing issue in Azure Pipelines when checkout of the repository is happening.