### PR TITLE
Update BinSkim to use Net8

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -63,12 +63,9 @@ call :RunTestProject BinSkim.Rules Functional  || goto :ExitFailed
 
 ::Create the BinSkim platform specific publish packages
 echo Creating Platform Specific BinSkim 'Publish' Packages
-call :CreatePublishPackage netcoreapp3.1 win-x64 || goto :ExitFailed
-call :CreatePublishPackage netcoreapp3.1 linux-x64 || goto :ExitFailed
-call :CreatePublishPackage netcoreapp3.1 osx-x64 || goto :ExitFailed
-call :CreatePublishPackage net6.0 win-x64 || goto :ExitFailed
-call :CreatePublishPackage net6.0 linux-x64 || goto :ExitFailed
-call :CreatePublishPackage net6.0 osx-x64 || goto :ExitFailed
+call :CreatePublishPackage net8.0 win-x64 || goto :ExitFailed
+call :CreatePublishPackage net8.0 linux-x64 || goto :ExitFailed
+call :CreatePublishPackage net8.0 osx-x64 || goto :ExitFailed
 
 ::Build NuGet package
 echo BuildPackages.cmd
@@ -79,7 +76,7 @@ dotnet tool update --global dotnet-format
 
 ::Update BinSkimRules.md to cover any xml changes
 echo Exporting any BinSkim rules
-.\bld\bin\x64_Release\netcoreapp3.1\BinSkim.exe export-rules .\docs\BinSkimRules.md
+.\bld\bin\x64_Release\net8.0\BinSkim.exe export-rules .\docs\BinSkimRules.md
 
 goto :Exit
 

--- a/BuildAndTest.sh
+++ b/BuildAndTest.sh
@@ -9,7 +9,7 @@ fi
 
 dotnet build src/BinSkimUnix.sln --configuration Release /p:Platform="x64"
 
-dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Driver.dll
-dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.FunctionalTests.BinSkim.Rules.dll
-dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinaryParsers.dll
-dotnet test bld/bin/x64_Release/netcoreapp3.1/Test.UnitTests.BinSkim.Rules.dll
+dotnet test bld/bin/x64_Release/net8.0/Test.FunctionalTests.BinSkim.Driver.dll
+dotnet test bld/bin/x64_Release/net8.0/Test.FunctionalTests.BinSkim.Rules.dll
+dotnet test bld/bin/x64_Release/net8.0/Test.UnitTests.BinaryParsers.dll
+dotnet test bld/bin/x64_Release/net8.0/Test.UnitTests.BinSkim.Rules.dll

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you only want to run the Binskim tool without installing anything, then you c
 1. Download BinSkim from **[NuGet](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/)**
 2. Rename the file extension from .nupkg to .zip (ie. via commandline: `rename microsoft.codeanalysis.binskim.x.y.z.nupkg microsoft.codeanalysis.binskim.x.y.z.zip`)
 3. Unzip
-4. Executable files are now available in the OS specific folder within _tools\netcoreapp3.1_ (ie. linux-x64, win-x64, and osx-x64).
+4. Executable files are now available in the OS specific folder within _tools\net8.0_ (ie. linux-x64, win-x64, and osx-x64).
 5. Navigate to this location to invoke the executable:
     - Windows: `binskim.exe analyze c:\bld\*.dll --recurse true --output MyRun.sarif`
     - Linux/Unix: `./BinSkim analyze /someDirectory/testBinary -o MyRun.sarif`

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -16,6 +16,7 @@
 - NEW => new feature 
 
 ## UNRELEASED
+* DEP: Upgrade BinSkim to .net8.0 as .net6.0 reached end of support on 11/12/2024.
 * NEW: Remove sarif-sdk submodule and use nuget package instead
 
 ## **v4.3.1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.3.1)

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -97,4 +97,4 @@ jobs:
         displayName: "Run BinSkim"
         inputs:
           targetType: "inline"
-          script: "dotnet bld/bin/x64_Release/netcoreapp3.1/binskim.dll analyze src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/macho.*"
+          script: "dotnet bld/bin/x64_Release/net8.0/binskim.dll analyze src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/macho.*"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.404",
+    "version": "8.0.112",
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.112",
+    "version": "8.0.404",
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {

--- a/scripts/SimpleStressTest.ps1
+++ b/scripts/SimpleStressTest.ps1
@@ -12,7 +12,7 @@
 [CmdletBinding()]
 param(
     [string]
-    $BinSkimFolder = "..\bld\bin\x64_Release\netcoreapp3.1",
+    $BinSkimFolder = "..\bld\bin\x64_Release\net8.0",
 
     [string]
     $SessionName = "stress",

--- a/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
+++ b/src/Test.ConcurrencyTests/Test.ConcurrencyTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	 <CoyoteVersion>1.7.9</CoyoteVersion>
 	 <PowershellExecutable Condition="'$(OS)'=='Windows_NT'">powershell</PowershellExecutable>
 	 <PowershellExecutable Condition="'$(PowershellExecutable)'==''">pwsh</PowershellExecutable>
@@ -33,7 +33,7 @@
 	  </None>
 	</ItemGroup>
 
-	<Target Name="CoyoteRewriting" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)'=='netcoreapp3.1' And '$(OS)'=='Windows_NT' ">
+	<Target Name="CoyoteRewriting" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)'=='net8.0' And '$(OS)'=='Windows_NT' ">
 		<Exec Command="$(ExecCommand)" />
 	</Target>		
 

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Debug.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Debug.json
@@ -1,4 +1,4 @@
 {
-  "AssembliesPath": ".\\bin\\Debug\\netcoreapp3.1",
+  "AssembliesPath": ".\\bin\\Debug\\net8.0",
   "Assemblies": [ "Test.ConcurrencyTests.dll" ]
 }

--- a/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
+++ b/src/Test.ConcurrencyTests/rewrite.coyote.Windows.Release.json
@@ -1,4 +1,4 @@
 {
-  "AssembliesPath": ".\\bin\\Release\\netcoreapp3.1",
+  "AssembliesPath": ".\\bin\\Release\\net8.0",
   "Assemblies": [ "Test.ConcurrencyTests.dll" ]
 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/UpdateBaselines.ps1
+++ b/src/Test.FunctionalTests.BinSkim.Driver/UpdateBaselines.ps1
@@ -4,7 +4,7 @@ Param(
 
 $tool = "BinSkim"
 $repoRoot = ( Resolve-Path "$PSScriptRoot\..\..\" ).ToString()
-$utility = "$repoRoot\bld\bin\AnyCPU_Release\netcoreapp3.1\win-x64\$tool.exe"
+$utility = "$repoRoot\bld\bin\AnyCPU_Release\net8.0\win-x64\$tool.exe"
 
 function Build-Tool()
 {

--- a/src/Test.FunctionalTests.BinSkim.Driver/UpdateBaselines.sh
+++ b/src/Test.FunctionalTests.BinSkim.Driver/UpdateBaselines.sh
@@ -4,14 +4,14 @@ ScriptDir=`dirname $0`
 
 TOOL="BinSkim"
 repoRoot=`readlink -f $ScriptDir/../../`
-BuildOutputPath="$repoRoot/bld/bin/AnyCPU_Release/netcoreapp3.1/linux-x64"
+BuildOutputPath="$repoRoot/bld/bin/AnyCPU_Release/net8.0/linux-x64"
 PROJECT="$repoRoot/src/BinSkim.Driver/BinSkim.Driver.csproj"
 
 BuildTool () 
 {
     # Linux specific for now.
     echo "Building BinSkim..."
-    dotnet build $PROJECT -c Release --framework netcoreapp3.1 --runtime linux-x64
+    dotnet build $PROJECT -c Release --framework net8.0 --runtime linux-x64
 }
 
 RunBaseline () 

--- a/src/build.common.props
+++ b/src/build.common.props
@@ -19,9 +19,9 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AnalysisLevel>latest</AnalysisLevel>
-    <!-- This property exists temporarily while we support netcoreapp3.1,
+    <!-- This property exists temporarily while we support net8.0,
          it suppresses build warnings about how some dependencies aren't
-         completely tested with netcoreapp3.1. We should remove this property
+         completely tested with net8.0. We should remove this property
          when we drop support for this framework version (soon).-->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>

--- a/src/build.common.props
+++ b/src/build.common.props
@@ -19,11 +19,6 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AnalysisLevel>latest</AnalysisLevel>
-    <!-- This property exists temporarily while we support net8.0,
-         it suppresses build warnings about how some dependencies aren't
-         completely tested with net8.0. We should remove this property
-         when we drop support for this framework version (soon).-->
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   
   <!-- Configuration specific properties -->

--- a/src/build.netcore.props
+++ b/src/build.netcore.props
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)build.common.props" />
 
   <PropertyGroup>    
-    <NetCoreVersion>netcoreapp3.1;net6.0</NetCoreVersion>  
+    <NetCoreVersion>net8.0</NetCoreVersion>
     <NetStandardVersion>netstandard2.1</NetStandardVersion>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     </PropertyGroup>


### PR DESCRIPTION
DotNet 6 left support back in November; we need to roll forward to continue getting security updates.