### PR TITLE
Implement new ignore setting when PE file cannot be analyzed

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -17,6 +17,7 @@
 
 ## UNRELEASED
 * NEW: Remove sarif-sdk submodule and use nuget package instead
+* NEW: Add `--ignorePELoadErrors` argument to disable exit code 1 when an exception is thrown in `CanAnalyze` method
 
 ## **v4.3.1** [NuGet Package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.3.1)
 * DEP: Update `msdia140.dll` from 14.40.33810.0 to 14.40.33812. [1000](https://github.com/microsoft/binskim/pull/1002)

--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -54,6 +54,11 @@ namespace Microsoft.CodeAnalysis.IL
         public bool? IgnorePdbLoadError { get; set; }
 
         [Option(
+            "ignorePELoadErrors",
+            HelpText = "If enabled, BinSkim won't break if we have a ExceptionInCanAnalyzeError")]
+        public bool? IgnorePELoadError { get; set; }
+
+        [Option(
             "disable-telemetry",
             HelpText = "If enabled, BinSkim will disable telemetry.")]
         public bool? DisableTelemetry { get; set; }

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CodeAnalysis.IL
             // Update context object based on command-line parameters.
             context.SymbolPath = options.SymbolsPath ?? context.SymbolPath;
             context.IgnorePdbLoadError = options.IgnorePdbLoadError != null ? options.IgnorePdbLoadError.Value : context.IgnorePdbLoadError;
+            context.IgnorePELoadError = options.IgnorePELoadError != null ? options.IgnorePELoadError.Value : context.IgnorePELoadError;
             context.DisableTelemetry = options.DisableTelemetry != null ? options.DisableTelemetry.Value : context.DisableTelemetry;
             context.LocalSymbolDirectories = options.LocalSymbolDirectories ?? context.LocalSymbolDirectories;
             context.TracePdbLoads = options.Trace.Contains(nameof(Traces.PdbLoad));
@@ -118,6 +119,7 @@ namespace Microsoft.CodeAnalysis.IL
             scanTargetContext.SymbolPath = context.SymbolPath;
             scanTargetContext.IncludeWixBinaries = context.IncludeWixBinaries;
             scanTargetContext.IgnorePdbLoadError = context.IgnorePdbLoadError;
+            scanTargetContext.IgnorePELoadError = context.IgnorePELoadError;
             scanTargetContext.LocalSymbolDirectories = context.LocalSymbolDirectories;
             scanTargetContext.TracePdbLoads = context.TracePdbLoads;
 

--- a/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
+++ b/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
@@ -1,5 +1,11 @@
-﻿using Microsoft.CodeAnalysis.BinaryParsers;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.IL.Sdk;
+using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.IL.Rules
@@ -13,13 +19,55 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             if (context.IsPE())
             {
                 PEBinary target = context.PEBinary();
-                return target.PE?.IsPEFile == true
-                    ? this.CanAnalyzePE(target, context, out reasonForNotAnalyzing)
-                    : AnalysisApplicability.NotApplicableToSpecifiedTarget;
+                try
+                {
+                    return target.PE?.IsPEFile == true
+                        ? this.CanAnalyzePE(target, context, out reasonForNotAnalyzing)
+                        : AnalysisApplicability.NotApplicableToSpecifiedTarget;
+                }
+                catch (Exception ex)
+                {
+                    if (context.IgnorePELoadError)
+                    {
+                        LogExceptionInCanAnalyzeError(context, ex);
+                        return AnalysisApplicability.NotApplicableToSpecifiedTarget;
+                    }
+                    throw;
+                }
+
             }
             else
             {
                 return AnalysisApplicability.NotApplicableToSpecifiedTarget;
+            }
+        }
+
+        public static void LogExceptionInCanAnalyzeError(IAnalysisContext context, Exception ex)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            string path = context.CurrentTarget.Uri.OriginalString;
+
+            // The exception may have resulted from a problem related to parsing the analysis target and not specific to the rule, however..
+            context.Logger.LogConfigurationNotification(
+                Errors.CreateNotification(
+                    context.CurrentTarget.Uri,
+                    "ERR998.ExceptionInCanAnalyze",
+                    string.Empty,
+                    FailureLevel.Error,
+                    ex,
+                    persistExceptionStack: false,
+                    RuleResources.ERR998_ExceptionInCanAnalyze,
+                    context.CurrentTarget.Uri.GetFileName(),
+                    ex.ToString()));
+
+
+            if (context is BinaryAnalyzerContext binaryAnalyzerContext && !binaryAnalyzerContext.IgnorePELoadError)
+            {
+                context.RuntimeErrors |= RuntimeConditions.ExceptionRaisedInSkimmerCanAnalyze;
             }
         }
 

--- a/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
+++ b/src/BinSkim.Rules/PERules/PEBinarySkimmerBase.cs
@@ -49,8 +49,6 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 throw new ArgumentNullException(nameof(context));
             }
 
-            string path = context.CurrentTarget.Uri.OriginalString;
-
             // The exception may have resulted from a problem related to parsing the analysis target and not specific to the rule, however..
             context.Logger.LogConfigurationNotification(
                 Errors.CreateNotification(
@@ -63,7 +61,6 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     RuleResources.ERR998_ExceptionInCanAnalyze,
                     context.CurrentTarget.Uri.GetFileName(),
                     ex.ToString()));
-
 
             if (context is BinaryAnalyzerContext binaryAnalyzerContext && !binaryAnalyzerContext.IgnorePELoadError)
             {

--- a/src/BinSkim.Rules/RuleResources.Designer.cs
+++ b/src/BinSkim.Rules/RuleResources.Designer.cs
@@ -1699,6 +1699,15 @@ namespace Microsoft.CodeAnalysis.IL.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An exception was raised attempting to determine whether &apos;{0}&apos; is a valid analysis target for check &apos;{1}&apos; (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target and not specific to the rule, however..
+        /// </summary>
+        internal static string ERR998_ExceptionInCanAnalyze {
+            get {
+                return ResourceManager.GetString("ERR998_ExceptionInCanAnalyze", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; was not evaluated for check &apos;{1}&apos; as the analysis is not relevant based on observed metadata: {2}..
         /// </summary>
         internal static string NotApplicable_InvalidMetadata {

--- a/src/BinSkim.Rules/RuleResources.resx
+++ b/src/BinSkim.Rules/RuleResources.resx
@@ -785,4 +785,7 @@ For VC projects use ItemDefinitionGroup - ClCompile - DebugInformationFormat pro
     <value>The following modules were compiled with a toolset that supports /Qspectre but a compiland `RawCommandLine` value is missing and the rule is therefore not able to determine if `/Qspectre` is specified.
 The likely cause is that the code was linked to a static library with no debug information: {0}</value>
   </data>
+  <data name="ERR998_ExceptionInCanAnalyze" xml:space="preserve">
+    <value>An exception was raised attempting to determine whether '{0}' is a valid analysis target for check '{1}' (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target and not specific to the rule, however.</value>
+  </data>
 </root>

--- a/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
+++ b/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.Sarif;
@@ -80,6 +79,12 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         {
             get => this.Policy?.GetProperty(BinaryParsersProperties.IgnorePdbLoadError) == true;
             set => this.Policy.SetProperty(BinaryParsersProperties.IgnorePdbLoadError, value);
+        }
+
+        public bool IgnorePELoadError
+        {
+            get => this.Policy?.GetProperty(BinaryParsersProperties.IgnorePELoadError) == true;
+            set => this.Policy.SetProperty(BinaryParsersProperties.IgnorePELoadError, value);
         }
 
         public bool DisableTelemetry

--- a/src/BinaryParsers/BinaryParsersProperties.cs
+++ b/src/BinaryParsers/BinaryParsersProperties.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -20,7 +19,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 DisableTelemetry,
                 IncludeWixBinaries,
                 LocalSymbolDirectories,
-                SymbolPath
+                SymbolPath,
+                IgnorePELoadError
             }.ToImmutableArray();
         }
 
@@ -60,5 +60,10 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 "environment variables at runtime. Use this argument instead for specifying the symbol path." +
                 "WARNING: Be sure to specify a local file cache in the symbol path if at all possible, in order " +
                 "to avoid the possibility of significance time-to-analyze performance degradataion.");
+
+        public static PerLanguageOption<bool> IgnorePELoadError { get; } =
+            new PerLanguageOption<bool>(
+                "BinaryParsers", nameof(IgnorePELoadError), defaultValue: () => false,
+                "Set this value to 'true' to ignore exceptions thrown in CanAnalyze method.");
     }
 }

--- a/src/BinaryParsers/BinaryParsersProperties.cs
+++ b/src/BinaryParsers/BinaryParsersProperties.cs
@@ -64,6 +64,6 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
         public static PerLanguageOption<bool> IgnorePELoadError { get; } =
             new PerLanguageOption<bool>(
                 "BinaryParsers", nameof(IgnorePELoadError), defaultValue: () => false,
-                "Set this value to 'true' to ignore exceptions thrown in CanAnalyze method.");
+                "Set this value to 'true' to ignore exceptions thrown in reading PE files.");
     }
 }

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
@@ -136,9 +136,8 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         }
 
         [Fact]
-        public void AnalyzeCommand_IgnoreExceptionInCanAnalyzeErrorTest()
+        public void AnalyzeCommand_IgnoreExceptionInReadingPeFiles()
         {
-            if (!PlatformSpecificHelpers.RunningOnWindows()) { return; }
             string fileName = Path.Combine(Path.GetTempPath(), "AnalyzeCommand_IgnoreExceptionInCanAnalyzeErrorTest.sarif");
             string pathDeterminismTest = Path.Combine(PEBinaryTests.TestData, "PE", "PELoadErrors", "*.exe");
             var options = new AnalyzeOptions
@@ -162,9 +161,8 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         }
 
         [Fact]
-        public void AnalyzeCommand_NotIgnoreExceptionInCanAnalyzeErrorTest()
+        public void AnalyzeCommand_NotIgnoreExceptionInReadingPeFiles()
         {
-            if (!PlatformSpecificHelpers.RunningOnWindows()) { return; }
             string fileName = Path.Combine(Path.GetTempPath(), "AnalyzeCommand_IgnoreExceptionInCanAnalyzeErrorTest.sarif");
             string pathDeterminismTest = Path.Combine(PEBinaryTests.TestData, "PE", "PELoadErrors", "*.exe");
             var options = new AnalyzeOptions

--- a/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Driver/AnalyzeCommandTests.cs
@@ -138,6 +138,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         [Fact]
         public void AnalyzeCommand_IgnoreExceptionInReadingPeFiles()
         {
+            if (!PlatformSpecificHelpers.RunningOnWindows()) { return; }
             string fileName = Path.Combine(Path.GetTempPath(), "AnalyzeCommand_IgnoreExceptionInCanAnalyzeErrorTest.sarif");
             string pathDeterminismTest = Path.Combine(PEBinaryTests.TestData, "PE", "PELoadErrors", "*.exe");
             var options = new AnalyzeOptions
@@ -163,6 +164,7 @@ namespace Microsoft.CodeAnalysis.BinSkim.Driver
         [Fact]
         public void AnalyzeCommand_NotIgnoreExceptionInReadingPeFiles()
         {
+            if (!PlatformSpecificHelpers.RunningOnWindows()) { return; }
             string fileName = Path.Combine(Path.GetTempPath(), "AnalyzeCommand_IgnoreExceptionInCanAnalyzeErrorTest.sarif");
             string pathDeterminismTest = Path.Combine(PEBinaryTests.TestData, "PE", "PELoadErrors", "*.exe");
             var options = new AnalyzeOptions


### PR DESCRIPTION
### Issue Description: 
The error ERR998.ExceptionInCanAnalyze occurs when BinSkim attempts to determine if 'netfile.exe' is a valid analysis target for the `'EnableControlFlowGuard'` check. The exception is caused by an `InvalidOperationException` related to RVA not belonging to any section. We want to not break the build but proceed instead and control breaking based on the Sarif logs.

### Steps to Reproduce: 
The error can be reproduced by running BinSkim analysis for `'netfile.exe'` stored in TestData or similar files. Which cannot be easily read by PEReader.

### Proposed Fix: 
Update BinSkim to handle exceptions during the analysis process without breaking the build. This includes proceeding with the analysis even if a file cannot be read or analyzed properly. 

### Additional Context: 
The fix should apply to all occurrences of ERR998.ExceptionInCanAnalyze. The release of the fix is planned for Wednesday/Thursday next week.