### PR TITLE
Adding possibility for SelfContained and R2R Publish

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -46,7 +46,7 @@ dotnet restore %~dp0src\BinSkim.sln /p:Configuration=%Configuration% --packages 
 
 :: Build the solution 
 echo Building solution...
-dotnet build /verbosity:minimal %~dp0src\BinSkim.sln /p:Configuration=%Configuration% /filelogger /fileloggerparameters:Verbosity=detailed || goto :ExitFailed
+dotnet build --no-restore /verbosity:minimal %~dp0src\BinSkim.sln /p:Configuration=%Configuration% /filelogger /fileloggerparameters:Verbosity=detailed || goto :ExitFailed
 
 :nightly
 if "%NightlyTest%" EQU "nightly" (

--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -46,7 +46,7 @@ dotnet restore %~dp0src\BinSkim.sln /p:Configuration=%Configuration% --packages 
 
 :: Build the solution 
 echo Building solution...
-dotnet build --no-restore /verbosity:minimal %~dp0src\BinSkim.sln /p:Configuration=%Configuration% /filelogger /fileloggerparameters:Verbosity=detailed || goto :ExitFailed
+dotnet build /verbosity:minimal %~dp0src\BinSkim.sln /p:Configuration=%Configuration% /filelogger /fileloggerparameters:Verbosity=detailed || goto :ExitFailed
 
 :nightly
 if "%NightlyTest%" EQU "nightly" (
@@ -77,7 +77,7 @@ dotnet tool update --global dotnet-format
 
 ::Update BinSkimRules.md to cover any xml changes
 echo Exporting any BinSkim rules
-.\bld\bin\x64_Release\net9.0\BinSkim.exe export-rules .\docs\BinSkimRules.md
+.\bld\bin\x64_Release\Publish\net9.0\win-x64\BinSkim.exe export-rules .\docs\BinSkimRules.md
 
 goto :Exit
 
@@ -91,7 +91,7 @@ Exit /B %ERRORLEVEL%
 :CreatePublishPackage
 set Framework=%~1
 set RuntimeArg=%~2
-dotnet publish %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-restore -c %Configuration% -f %Framework% --runtime %RuntimeArg% --self-contained
+dotnet publish %~dp0src\BinSkim.Driver\BinSkim.Driver.csproj --no-restore -c %Configuration% -f %Framework% --runtime %RuntimeArg% --self-contained true
 Exit /B %ERRORLEVEL%
 
 :ExitFailed

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -4,8 +4,8 @@ SETLOCAL
 
 call SetCurrentVersion.cmd
 
-%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinSkim.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
-%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinaryParsers.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
+%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinSkim.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
+%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinaryParsers.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
 
 goto Exit
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -4,8 +4,8 @@ SETLOCAL
 
 call SetCurrentVersion.cmd
 
-%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinSkim.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
-%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinaryParsers.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
+%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinSkim.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
+%~dp0.nuget\NuGet.exe pack %~dp0src\Nuget\BinaryParsers.nuspec -Properties configuration=%Configuration%;version=%MAJOR%.%MINOR%.%PATCH%%PRERELEASE% -Verbosity Quiet -BasePath %~dp0 -OutputDirectory %~dp0bld\bin\Nuget || goto :ExitFailed
 
 goto Exit
 

--- a/ado-build.yml
+++ b/ado-build.yml
@@ -61,4 +61,4 @@ jobs:
         displayName: "Run BinSkim"
         inputs:
           targetType: "inline"
-          script: "dotnet bld/bin/x64_Release/net9.0/binskim.dll analyze src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/macho.*"
+          script: "dotnet bld/bin/x64_Release/net9.0/osx-x64/BinSkim.dll analyze src/Test.FunctionalTests.BinSkim.Driver/BaselineTestData/macho.*"

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -9,7 +9,6 @@
     <OutputType>Exe</OutputType>
     <Platforms>x64</Platforms>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/BinSkim.Driver/BinSkim.Driver.csproj
+++ b/src/BinSkim.Driver/BinSkim.Driver.csproj
@@ -8,6 +8,8 @@
     <TargetLatestRuntimePatch>True</TargetLatestRuntimePatch>
     <OutputType>Exe</OutputType>
     <Platforms>x64</Platforms>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
This pull request includes several changes to the build and publish processes in the `BuildAndTest.cmd`, `BuildPackages.cmd`, and `BinSkim.Driver.csproj` files. The changes primarily focus on improving the build configuration, updating paths, and ensuring the application is self-contained and ready to run.

Improvements to build and publish processes:

* [`BuildAndTest.cmd`](diffhunk://#diff-a17fe36ab1b8b2ea4b8558b6310714ae6a031a2c138374e6f1d4d7335b9c071bL49-R49): Removed the `--no-restore` flag from the `dotnet build` command to simplify the build process.
* [`BuildAndTest.cmd`](diffhunk://#diff-a17fe36ab1b8b2ea4b8558b6310714ae6a031a2c138374e6f1d4d7335b9c071bL80-R80): Updated the path for the `BinSkim.exe` export rules to ensure it points to the correct publish directory.
* [`BuildAndTest.cmd`](diffhunk://#diff-a17fe36ab1b8b2ea4b8558b6310714ae6a031a2c138374e6f1d4d7335b9c071bL94-R94): Added the `--self-contained true` flag to the `dotnet publish` command to ensure the application is self-contained.

Configuration updates:

* [`src/BinSkim.Driver/BinSkim.Driver.csproj`](diffhunk://#diff-28e9c785e5241ca1f9f86fac5aef5763d92980c4f130feffa5803e8e75e37d8bR11-R12): Added `<SelfContained>true</SelfContained>` and `<PublishReadyToRun>true</PublishReadyToRun>` properties to ensure the application is self-contained and optimized for faster startup.