### PR TITLE
Add environment variable preparation in unit test

### DIFF
--- a/src/Test.UnitTests.BinSkim.Driver/AnalysisSummaryExtractorUnitTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/AnalysisSummaryExtractorUnitTests.cs
@@ -121,6 +121,20 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
         public void ExtractAnalysisSummary_WithoutBuildPipelineInfo()
         {
             var summary = new AnalysisSummary();
+
+            PrepareEnvironmentVariables(new List<(string, string)>
+            {
+                (AnalysisSummaryExtractor.BuildDefinitionIdVariableName, null),
+                (AnalysisSummaryExtractor.BuildDefinitionNameVariableName, null),
+                (AnalysisSummaryExtractor.BuildDefinitionRunIdVariableName, null),
+                (AnalysisSummaryExtractor.RepositoryIdVariableName, null),
+                (AnalysisSummaryExtractor.RepositoryNameVariableName, null),
+                (AnalysisSummaryExtractor.OrganizationIdVariableName, null),
+                (AnalysisSummaryExtractor.OrganizationNameVariableName, null),
+                (AnalysisSummaryExtractor.ProjectIdVariableName, null),
+                (AnalysisSummaryExtractor.ProjectNameVariableName, null),
+            });
+
             AnalysisSummaryExtractor.UpdateBuildPipelineInfo(summary);
 
             summary.BuildDefinitionId.Should().BeNullOrEmpty();


### PR DESCRIPTION
This commit introduces a new method to prepare environment variables for the `AnalysisSummary` object in the `ExtractAnalysisSummary_WithoutBuildPipelineInfo` test. It initializes a list of tuples with build and repository-related variable names set to `null`, ensuring that the `UpdateBuildPipelineInfo` method can be tested in a clean state. This allows for verification that the summary fields remain null or empty as expected.