### PR TITLE
BA3003: tolerate exceptions from DWARF CommandLineInfos parser

### DIFF
--- a/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
@@ -160,12 +160,23 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 // aborts BA3003 entirely for the target via ERR998. Treat such
                 // failures as "no DWARF compile-unit information available" so
                 // the rule can fall back to the symbol-table heuristic below.
+                //
+                // The DWARF parser code paths reachable from CommandLineInfos
+                // can throw any of InvalidOperationException, NotImplementedException,
+                // ArgumentException, DwarfBufferOverreadException, and bare
+                // System.Exception (see DwarfCompilationUnit / DwarfMemoryReader /
+                // DwarfCommonInformationEntry). Because some call sites throw the
+                // base Exception type directly, we cannot narrow this catch any
+                // further without re-introducing the ERR998 abort for inputs the
+                // parser doesn't yet recognise.
                 List<DwarfCompileCommandLineInfo> commandLineInfos;
                 try
                 {
                     commandLineInfos = binary.CommandLineInfos;
                 }
+#pragma warning disable CA1031 // Do not catch general exception types -- intentional, see comment above.
                 catch (Exception)
+#pragma warning restore CA1031
                 {
                     commandLineInfos = new List<DwarfCompileCommandLineInfo>();
                 }

--- a/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
@@ -151,7 +151,26 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             if (binary is ElfBinary elf)
             {
                 var validGccCommandLineInfos = new List<DwarfCompileCommandLineInfo>();
-                foreach (DwarfCompileCommandLineInfo info in binary.CommandLineInfos)
+
+                // Some real-world ELF binaries contain DWARF producer entries that
+                // the DWARF parser does not yet understand (for example, newer
+                // DW_FORM_* values emitted by recent toolchains, or string-form
+                // references whose backing section the parser can't resolve).
+                // In those cases binary.CommandLineInfos throws, which currently
+                // aborts BA3003 entirely for the target via ERR998. Treat such
+                // failures as "no DWARF compile-unit information available" so
+                // the rule can fall back to the symbol-table heuristic below.
+                List<DwarfCompileCommandLineInfo> commandLineInfos;
+                try
+                {
+                    commandLineInfos = binary.CommandLineInfos;
+                }
+                catch (Exception)
+                {
+                    commandLineInfos = new List<DwarfCompileCommandLineInfo>();
+                }
+
+                foreach (DwarfCompileCommandLineInfo info in commandLineInfos)
                 {
                     if (ElfUtility.GetDwarfCommandLineType(info.CommandLine) != DwarfCommandLineType.Gcc)
                     {


### PR DESCRIPTION
## Summary

When `binary.CommandLineInfos` throws while parsing DWARF producer entries, BA3003 currently aborts for the entire target with an ERR998 instead of falling back to the symbol-table heuristic the rule already has for ELF binaries with no DWARF info.

This happens in practice on real-world binaries where the DWARF parser encounters producer entries it does not yet understand — e.g. newer `DW_FORM_*` values emitted by recent toolchains (GCC 15 with `-gdwarf-5`), or string-form references whose backing section the parser cannot resolve (e.g. `DW_FORM_GNU_strp_alt` pointing into a `.gnu_debugaltlink` alt file produced by `dwz`).

## Change

Wrap the `binary.CommandLineInfos` access in a try/catch. On exception, treat the binary as having no DWARF compile-unit information, which lets the existing symbol-table fallback (`__stack_chk_fail` / `__stack_chk_guard` / `__intel_security_cookie`) run as it already does for ELF binaries that simply have no DWARF info.

No behavior change for inputs whose DWARF producer tags parse successfully.

## Repro that motivated this

Stripped ELF binaries shipped by Azure Linux 4 (e.g. `/usr/lib/dracut/skipcpio` from `dracut-107-9.azl4.x86_64.rpm`) cause BinSkim 4.4.x to throw `InvalidOperationException` (`Producer : 7969`) inside BA3003 when `--local-symbol-directories` is pointed at the matching `*-debuginfo` tree, because the producer tag in the separate `.debug` file uses `DW_FORM_GNU_strp_alt`. With this patch the rule still cannot affirmatively validate the producer (that requires alt-file support, a separate change), but it no longer hard-fails — it falls back to the symbol heuristic, which is the documented behavior for the no-DWARF case.

## Testing

- Builds clean against `main` (commit 696f2ba) with `dotnet build src/BinSkim.Rules/BinSkim.Rules.csproj -c Release`.
- Verified locally with a self-contained `linux-x64` publish that the previously-crashing skipcpio scan now completes and falls through to the symbol check, matching the no-DWARF code path.

I am happy to add a functional-test fixture if maintainers can suggest the preferred shape (a minimal ELF with a deliberately malformed producer abbrev) — the existing BA3003 test data only exercises the happy path.