### PR TITLE
BA3003: report NotApplicable for Rust-only binaries

### DIFF
--- a/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA3003.EnableStackProtector.cs
@@ -159,6 +159,27 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     }
                     validGccCommandLineInfos.Add(info);
                 }
+
+                // If the binary's only DWARF producer is rustc, the GCC
+                // stack-protector heuristic does not apply: rustc enables stack
+                // protection via LLVM and does not emit __stack_chk_fail /
+                // __stack_chk_guard symbols, so the symbol-table fallback below
+                // would false-flag every Rust binary as missing stack-protector.
+                // Report NotApplicable in that case.
+                if (validGccCommandLineInfos.Count == 0
+                    && elf.Compilers != null
+                    && elf.Compilers.Any(c => c.Compiler == ElfCompilerType.Rust)
+                    && !elf.Compilers.Any(c => c.Compiler == ElfCompilerType.GCC))
+                {
+                    context.Logger.Log(this,
+                        RuleUtilities.BuildResult(ResultKind.NotApplicable, context, null,
+                            nameof(RuleResources.NotApplicable_InvalidMetadata),
+                            context.CurrentTarget.Uri.GetFileName(),
+                            this.Name,
+                            "binary was produced by rustc; the GCC stack-protector heuristic does not apply"));
+                    return;
+                }
+
                 if (validGccCommandLineInfos.Count > 0)
                 {
                     // Check using DWARF info


### PR DESCRIPTION
## Summary

rustc-built ELF binaries are currently always reported as **error BA3003** ("stack protector not found"), even when Rust stack protection is enabled. This PR makes BA3003 report `NotApplicable` for binaries whose only DWARF producer is rustc.

## Why

BA3003 has two detection paths for ELF:

1. **DWARF**: look for a GCC compile unit whose producer command line contains `-fstack-protector-strong` / `-fstack-protector-all`.
2. **Symbol fallback** (only when no GCC compile units are present): look for `__stack_chk_fail`, `__stack_chk_guard`, or `__intel_security_cookie` in the symbol table.

rustc:
- does not produce GCC-style DWARF compile units, so path (1) yields zero valid entries;
- enables stack protection through LLVM and does not emit `__stack_chk_fail` / `__stack_chk_guard`, so path (2) returns false.

Result: every rustc-only binary is reported as `error BA3003` regardless of the actual stack-protection setting.

## Change

In the ELF branch of `Analyze`, after building `validGccCommandLineInfos`, if:

- the GCC list is empty, **and**
- `elf.Compilers` contains `ElfCompilerType.Rust`, **and**
- `elf.Compilers` does **not** contain `ElfCompilerType.GCC`

…then report `ResultKind.NotApplicable` (re-using the existing `RuleResources.NotApplicable_InvalidMetadata` message) with text explaining that the GCC stack-protector heuristic does not apply. Mixed C/Rust binaries (anything with at least one GCC CU) continue through the existing DWARF path unchanged.

## Repro that motivated this

`/usr/lib/dracut/dracut-cpio` from Azure Linux 4 (`dracut-107-9.azl4.x86_64.rpm`) is a small rustc-built helper. BinSkim 4.4.x reports `error BA3003` on it even though the Rust source enables stack protection. With this patch the same scan reports `NotApplicable` with a clear reason, matching the rule’s contract.

## Testing

- Builds clean against `main` (commit 696f2ba) with `dotnet build src/BinSkim.Rules/BinSkim.Rules.csproj -c Release`.
- Verified locally with a self-contained `linux-x64` publish that a rustc-only binary now reports NotApplicable while a GCC-built binary with the same flags is unchanged.

Happy to add a Rust binary fixture under `Test.FunctionalTests.BinSkim.Driver/TestData/BA3003.EnableStackProtector/NotApplicable/` if maintainers can confirm the preferred way to commit a rustc-produced ELF into the repo.