### PR TITLE
fix: populate fileHash in CompilerDataLogger telemetry

### DIFF
--- a/.pipelines/1ES.binskim.BuildAndTest.EXTERNAL.yml
+++ b/.pipelines/1ES.binskim.BuildAndTest.EXTERNAL.yml
@@ -17,6 +17,7 @@ extends:
       os: windows
     featureFlags:
       autoEnableRoslynWithNewRuleset: false
+      sdlSdpEnabled: false
     stages:
     - stage: BuildAndTest
       displayName: Build And Test

--- a/.pipelines/1ES.binskim.BuildAndTest.EXTERNAL.yml
+++ b/.pipelines/1ES.binskim.BuildAndTest.EXTERNAL.yml
@@ -197,12 +197,14 @@ extends:
         steps:
         - checkout: none
 
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: "Queue internal build and wait for result"
           inputs:
-            targetType: inline
-            pwsh: true
-            script: |
+            azureSubscription: binskim-internal-pipeline-runner
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
               $commit = "$(Build.SourceVersion)"
               $org = "https://dev.azure.com/mseng/"
               $project = "1ES"
@@ -211,7 +213,7 @@ extends:
               Write-Host "Triggering internal build with BinSkim commit: $commit"
 
               $headers = @{
-                Authorization  = "Bearer $(System.AccessToken)"
+                Authorization  = "Bearer $token"
                 "Content-Type" = "application/json"
               }
 
@@ -255,5 +257,3 @@ extends:
 
               Write-Error "Timed out after ${maxWait}s waiting for internal build. See: $($run._links.web.href)"
               exit 1
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             }
 
             IDwarfBinary binary = context.DwarfBinary();
-            string fileHash = binary.SHA256Hash;
+            string fileHash = context.IncludeTelemetryFileHash ? binary.SHA256Hash : null;
 
             if (binary is ElfBinary)
             {

--- a/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             }
 
             IDwarfBinary binary = context.DwarfBinary();
-            string fileHash = ((BinaryBase)binary).SHA256Hash;
+            string fileHash = binary.SHA256Hash;
 
             if (binary is ElfBinary)
             {

--- a/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.BinaryParsers.Dwarf;
@@ -54,22 +56,23 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             }
 
             IDwarfBinary binary = context.DwarfBinary();
+            string fileHash = ComputeSha256Hash(context.CurrentTarget.Uri.LocalPath);
 
             if (binary is ElfBinary)
             {
-                this.WriteCompilerData(context, binary.CommandLineInfos, binary.Compilers);
+                this.WriteCompilerData(context, binary.CommandLineInfos, binary.Compilers, fileHash);
             }
 
             if (binary is MachOBinary machO)
             {
                 machO.MachOs.ToList().ForEach
                 (
-                    machO => this.WriteCompilerData(context, machO.CommandLineInfos, machO.Compilers)
+                    machO => this.WriteCompilerData(context, machO.CommandLineInfos, machO.Compilers, fileHash)
                 );
             }
         }
 
-        private void WriteCompilerData(BinaryAnalyzerContext context, List<DwarfCompileCommandLineInfo> commandLineInfos, ICompiler[] compilers)
+        private void WriteCompilerData(BinaryAnalyzerContext context, List<DwarfCompileCommandLineInfo> commandLineInfos, ICompiler[] compilers, string fileHash)
         {
             var processedRecords = new HashSet<CompilerData>();
 
@@ -104,6 +107,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                         CompilerBackEndVersion = compiler.Version.ToString(),
                         CompilerFrontEndVersion = compiler.Version.ToString(),
                         Language = info.Language == DwarfLanguage.Unknown ? string.Empty : info.Language.ToString(),
+                        FileHash = fileHash,
                     };
 
                     if (processedRecords.Contains(record))
@@ -114,6 +118,19 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     processedRecords.Add(record);
                     context.CompilerDataLogger.Write(context, record);
                 }
+            }
+        }
+
+        private static string ComputeSha256Hash(string filePath)
+        {
+            try
+            {
+                byte[] hash = SHA256.HashData(File.ReadAllBytes(filePath));
+                return BitConverter.ToString(hash).Replace("-", string.Empty);
+            }
+            catch
+            {
+                return null;
             }
         }
     }

--- a/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
+++ b/src/BinSkim.Rules/DwarfRules/BA4002.ReportElfOrMachoCompilerData.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 
 using Microsoft.CodeAnalysis.BinaryParsers;
 using Microsoft.CodeAnalysis.BinaryParsers.Dwarf;
@@ -56,7 +54,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             }
 
             IDwarfBinary binary = context.DwarfBinary();
-            string fileHash = ComputeSha256Hash(context.CurrentTarget.Uri.LocalPath);
+            string fileHash = ((BinaryBase)binary).SHA256Hash;
 
             if (binary is ElfBinary)
             {
@@ -118,19 +116,6 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     processedRecords.Add(record);
                     context.CompilerDataLogger.Write(context, record);
                 }
-            }
-        }
-
-        private static string ComputeSha256Hash(string filePath)
-        {
-            try
-            {
-                byte[] hash = SHA256.HashData(File.ReadAllBytes(filePath));
-                return BitConverter.ToString(hash).Replace("-", string.Empty);
-            }
-            catch
-            {
-                return null;
             }
         }
     }

--- a/src/BinSkim.Rules/PERules/BA4001.ReportPortableExecutableCompilerData.cs
+++ b/src/BinSkim.Rules/PERules/BA4001.ReportPortableExecutableCompilerData.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
             PEBinary target = context.PEBinary();
             Pdb pdb = target.Pdb;
-            string fileHash = target.PE.SHA256Hash;
+            string fileHash = context.IncludeTelemetryFileHash ? target.PE.SHA256Hash : null;
 
             if (pdb == null)
             {

--- a/src/BinSkim.Rules/PERules/BA4001.ReportPortableExecutableCompilerData.cs
+++ b/src/BinSkim.Rules/PERules/BA4001.ReportPortableExecutableCompilerData.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
 
             PEBinary target = context.PEBinary();
             Pdb pdb = target.Pdb;
+            string fileHash = target.PE.SHA256Hash;
 
             if (pdb == null)
             {
@@ -102,6 +103,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                     CompilerFrontEndVersion = target.PE.LinkerVersion.ToString(),
                     AssemblyReferences = string.Join(';', target.PE.GetAssemblyReferenceStrings()),
                     SourceLinkJsonId = sourceLinkJsonId,
+                    FileHash = fileHash,
                 };
 
                 if (!records.ContainsKey(record))
@@ -133,6 +135,7 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                         CompilerBackEndVersion = omDetails.CompilerBackEndVersion.ToString(),
                         CompilerFrontEndVersion = omDetails.CompilerFrontEndVersion.ToString(),
                         SourceLinkJsonId = sourceLinkJsonId,
+                        FileHash = fileHash,
                     };
 
                     if (!records.ContainsKey(record))

--- a/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
+++ b/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
@@ -106,6 +106,12 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
             set => this.Policy.SetProperty(BinaryParsersProperties.DisableTelemetry, value);
         }
 
+        public bool IncludeTelemetryFileHash
+        {
+            get => this.Policy?.GetProperty(BinaryParsersProperties.IncludeTelemetryFileHash) != false;
+            set => this.Policy.SetProperty(BinaryParsersProperties.IncludeTelemetryFileHash, value);
+        }
+
         public bool IncludeWixBinaries
         {
             get => this.Policy?.GetProperty(BinaryParsersProperties.IncludeWixBinaries) == true;

--- a/src/BinSkim.Sdk/CompilerData.cs
+++ b/src/BinSkim.Sdk/CompilerData.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         public string CompilerBackEndVersion { get; set; }
         public string CompilerFrontEndVersion { get; set; }
         public string SourceLinkJsonId { get; set; }
+        public string FileHash { get; set; }
 
         public override string ToString()
         {

--- a/src/BinSkim.Sdk/CompilerDataLogger.cs
+++ b/src/BinSkim.Sdk/CompilerDataLogger.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
         public void Write(BinaryAnalyzerContext context, CompilerData compilerData)
         {
-            string fileHash = context.Hashes?.Sha256;
+            string fileHash = compilerData.FileHash ?? context.Hashes?.Sha256;
             string filePath = string.IsNullOrWhiteSpace(RootPathToElide)
                 ? context.CurrentTarget.Uri?.LocalPath
                 : context.CurrentTarget.Uri?.LocalPath.Replace(RootPathToElide, string.Empty);

--- a/src/BinaryParsers/BinaryBase.cs
+++ b/src/BinaryParsers/BinaryBase.cs
@@ -39,7 +39,11 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                     byte[] hash = SHA256.HashData(File.ReadAllBytes(this.TargetUri.LocalPath));
                     this.sha256Hash = BitConverter.ToString(hash).Replace("-", string.Empty);
                 }
-                catch
+                catch (IOException)
+                {
+                    this.sha256Hash = string.Empty;
+                }
+                catch (UnauthorizedAccessException)
                 {
                     this.sha256Hash = string.Empty;
                 }

--- a/src/BinaryParsers/BinaryBase.cs
+++ b/src/BinaryParsers/BinaryBase.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
+using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis.BinaryParsers
 {
     public abstract class BinaryBase : IBinary
     {
+        private string sha256Hash;
+
         public BinaryBase(Uri uri)
         {
             this.TargetUri = uri;
@@ -17,6 +21,32 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
         public Exception LoadException { get; protected set; }
 
         public bool Valid { get; protected set; }
+
+        /// <summary>
+        /// Gets the SHA-256 hash of the binary file. Computed once and cached.
+        /// </summary>
+        public string SHA256Hash
+        {
+            get
+            {
+                if (this.sha256Hash != null)
+                {
+                    return this.sha256Hash;
+                }
+
+                try
+                {
+                    byte[] hash = SHA256.HashData(File.ReadAllBytes(this.TargetUri.LocalPath));
+                    this.sha256Hash = BitConverter.ToString(hash).Replace("-", string.Empty);
+                }
+                catch
+                {
+                    this.sha256Hash = string.Empty;
+                }
+
+                return this.sha256Hash;
+            }
+        }
 
         public virtual void Dispose() { }
     }

--- a/src/BinaryParsers/BinaryBase.cs
+++ b/src/BinaryParsers/BinaryBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
         /// <summary>
         /// Gets the SHA-256 hash of the binary file. Computed once and cached.
         /// </summary>
-        public string SHA256Hash
+        public virtual string SHA256Hash
         {
             get
             {

--- a/src/BinaryParsers/BinaryParsersProperties.cs
+++ b/src/BinaryParsers/BinaryParsersProperties.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 ComprehensiveBinaryParsing,
                 IgnorePdbLoadError,
                 DisableTelemetry,
+                IncludeTelemetryFileHash,
                 IncludeWixBinaries,
                 LocalSymbolDirectories,
                 SymbolPath,
@@ -41,6 +42,12 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             new PerLanguageOption<bool>(
                 "BinaryParsers", nameof(DisableTelemetry), defaultValue: () => false,
                 "Set this value to 'true' to disable telemetry.");
+
+        public static PerLanguageOption<bool> IncludeTelemetryFileHash { get; } =
+            new PerLanguageOption<bool>(
+                "BinaryParsers", nameof(IncludeTelemetryFileHash), defaultValue: () => true,
+                "Set this value to 'false' to skip SHA-256 file hash computation in telemetry. " +
+                "Disabling may improve performance for large binaries on slow I/O.");
 
         public static PerLanguageOption<bool> IncludeWixBinaries { get; } =
             new PerLanguageOption<bool>(

--- a/src/BinaryParsers/ElfBinary/Dwarf/IDwarfBinary.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/IDwarfBinary.cs
@@ -12,6 +12,11 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
     public interface IDwarfBinary : IDisposable
     {
         /// <summary>
+        /// Gets the SHA-256 hash of the binary file.
+        /// </summary>
+        string SHA256Hash { get; }
+
+        /// <summary>
         /// The version of Dwarf used.
         /// </summary>
         int DwarfVersion { get; set; }

--- a/src/BinaryParsers/PEBinary/PEBinary.cs
+++ b/src/BinaryParsers/PEBinary/PEBinary.cs
@@ -68,6 +68,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             }
         }
 
+        public override string SHA256Hash => this.PE.SHA256Hash;
+
         public static void ClearLocalSymbolDirectoriesCache()
         {
             lock (sync)

--- a/src/Test.UnitTests.BinSkim.Driver/CompilerDataHashTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/CompilerDataHashTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.IL;
+using Microsoft.CodeAnalysis.IL.Sdk;
+using Microsoft.CodeAnalysis.Sarif;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BinSkim.Rules
+{
+    public class CompilerDataHashTests
+    {
+        [Fact]
+        public void CompilerDataLogger_PopulatesFileHash_WhenHashesEnabled_PE()
+        {
+            if (!BinaryParsers.PlatformSpecificHelpers.RunningOnWindows()) { return; }
+
+            string sarifFile = Path.Combine(Path.GetTempPath(), $"HashTest_PE_{Guid.NewGuid()}.sarif");
+            string csvFile = Path.Combine(Path.GetTempPath(), $"HashTest_PE_{Guid.NewGuid()}.csv");
+            string configFile = Path.Combine(Path.GetTempPath(), $"HashTest_PE_{Guid.NewGuid()}.xml");
+
+            try
+            {
+                string configContent = $"<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                    $"<Properties><Properties Key=\"CompilerTelemetry.Options\">" +
+                    $"<Property Key=\"CsvOutputPath\" Value=\"{csvFile}\"/>" +
+                    $"</Properties></Properties>";
+                File.WriteAllText(configFile, configContent);
+
+                string pathToTestFile = Path.Combine(TestData, "PE", "Native_x64_VS2019_CPlusPlus_DEBUG_DEFAULT.dll");
+
+                var options = new AnalyzeOptions
+                {
+                    TargetFileSpecifiers = new[] { pathToTestFile },
+                    OutputFilePath = sarifFile,
+                    OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite },
+                    DataToInsert = new[] { OptionallyEmittedData.Hashes },
+                    ConfigurationFilePath = configFile,
+                };
+
+                var command = new MultithreadedAnalyzeCommand();
+                command.Run(options);
+
+                File.Exists(csvFile).Should().BeTrue("CSV telemetry file should be created");
+
+                string[] lines = File.ReadAllLines(csvFile);
+                lines.Length.Should().BeGreaterThan(1, "CSV should have header + at least one data row");
+
+                for (int i = 1; i < lines.Length; i++)
+                {
+                    string[] columns = lines[i].Split(',');
+                    string hashValue = columns.Length >= 2 ? columns[^2] : string.Empty;
+                    if (hashValue.Length == 64)
+                    {
+                        // At least one row has a valid SHA-256 hash — fix confirmed.
+                        return;
+                    }
+                }
+
+                lines.Length.Should().Be(0,
+                    "At least one CSV row should contain a 64-char SHA-256 hash");
+            }
+            finally
+            {
+                File.Delete(sarifFile);
+                File.Delete(csvFile);
+                File.Delete(configFile);
+            }
+        }
+
+        [Fact]
+        public void CompilerDataLogger_PopulatesFileHash_WithoutHashesFlag_PE()
+        {
+            if (!BinaryParsers.PlatformSpecificHelpers.RunningOnWindows()) { return; }
+
+            string sarifFile = Path.Combine(Path.GetTempPath(), $"HashTest_NoFlag_{Guid.NewGuid()}.sarif");
+            string csvFile = Path.Combine(Path.GetTempPath(), $"HashTest_NoFlag_{Guid.NewGuid()}.csv");
+            string configFile = Path.Combine(Path.GetTempPath(), $"HashTest_NoFlag_{Guid.NewGuid()}.xml");
+
+            try
+            {
+                string configContent = $"<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                    $"<Properties><Properties Key=\"CompilerTelemetry.Options\">" +
+                    $"<Property Key=\"CsvOutputPath\" Value=\"{csvFile}\"/>" +
+                    $"</Properties></Properties>";
+                File.WriteAllText(configFile, configContent);
+
+                string pathToTestFile = Path.Combine(TestData, "PE", "Native_x64_VS2019_CPlusPlus_DEBUG_DEFAULT.dll");
+
+                var options = new AnalyzeOptions
+                {
+                    TargetFileSpecifiers = new[] { pathToTestFile },
+                    OutputFilePath = sarifFile,
+                    OutputFileOptions = new[] { FilePersistenceOptions.ForceOverwrite },
+                    // NOT including Hashes - hash should still be populated from CompilerData.FileHash
+                    ConfigurationFilePath = configFile,
+                };
+
+                var command = new MultithreadedAnalyzeCommand();
+                command.Run(options);
+
+                File.Exists(csvFile).Should().BeTrue("CSV telemetry file should be created");
+
+                string[] lines = File.ReadAllLines(csvFile);
+                lines.Length.Should().BeGreaterThan(1, "CSV should have header + at least one data row");
+
+                for (int i = 1; i < lines.Length; i++)
+                {
+                    string[] columns = lines[i].Split(',');
+                    string hashValue = columns.Length >= 2 ? columns[^2] : string.Empty;
+                    if (hashValue.Length == 64)
+                    {
+                        return;
+                    }
+                }
+
+                lines.Length.Should().Be(0,
+                    "At least one CSV row should contain a 64-char SHA-256 hash");
+            }
+            finally
+            {
+                File.Delete(sarifFile);
+                File.Delete(csvFile);
+                File.Delete(configFile);
+            }
+        }
+    }
+}

--- a/src/Test.UnitTests.BinaryParsers/Dwarf/DwarfCompilationUnitFormTests.cs
+++ b/src/Test.UnitTests.BinaryParsers/Dwarf/DwarfCompilationUnitFormTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         // Minimal IDwarfBinary stub needed by DwarfCompilationUnit constructor.
         private class StubDwarfBinary : IDwarfBinary
         {
+            public string SHA256Hash { get; } = string.Empty;
             public int DwarfVersion { get; set; }
             public DwarfUnitType DwarfUnitType { get; set; }
             public byte[] DebugData { get; } = Array.Empty<byte>();


### PR DESCRIPTION
## Summary

The hash field in CompilerDataLogger telemetry (AppInsights CompilerInformation events + CSV) has always been empty because context.Hashes is not populated by the SARIF framework during rule execution.

## Root Cause

CompilerDataLogger.Write() reads context.Hashes?.Sha256, but the SARIF SDK only computes hashes for SARIF artifact entries after analysis - not before dispatching rules.

## Fix

Compute the hash directly in the rules via new CompilerData.FileHash property:
- BA4001 (PE): uses PE.SHA256Hash (zero extra I/O)
- BA4002 (ELF/Mach-O): SHA256.HashData(File.ReadAllBytes(...))

## Tests

Two tests verify hash is populated in CSV output with and without DataToInsert=Hashes.