### PR TITLE
Release v4.4.9.12

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -22,7 +22,6 @@
 
 ## **v4.4.9.12** [https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.4.9.12]
 * FIX: Populate file hash in CompilerDataLogger telemetry (was always empty) [1199](https://github.com/microsoft/binskim/pull/1199)
-* FPS: Suppress ERR997 for IL-only managed assemblies [1174](https://github.com/microsoft/binskim/pull/1174)
 
 ## **4.4.9.11** [https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.4.9.11]
 * DEP: Update dependency version

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -19,6 +19,11 @@
 - NEW => new feature 
 
 ## UNRELEASED
+
+## **v4.4.9.12** [https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.4.9.12]
+* FIX: Populate file hash in CompilerDataLogger telemetry (was always empty) [1199](https://github.com/microsoft/binskim/pull/1199)
+* FPS: Suppress ERR997 for IL-only managed assemblies [1174](https://github.com/microsoft/binskim/pull/1174)
+
 ## **4.4.9.11** [https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.4.9.11]
 * DEP: Update dependency version
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -21,7 +21,7 @@
 ## UNRELEASED
 
 ## **v4.4.9.12** [https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.4.9.12]
-* FIX: Populate file hash in CompilerDataLogger telemetry (was always empty) [1199](https://github.com/microsoft/binskim/pull/1199)
+* ADM: Fix pipeline - disable sdlSdp and use service connection for internal build trigger [1201](https://github.com/microsoft/binskim/pull/1201)
 
 ## **4.4.9.11** [https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/4.4.9.11]
 * DEP: Update dependency version

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <!-- Submodule's own version (used when built standalone) -->
   <PropertyGroup>
     <AssemblyVersion>4.4.9</AssemblyVersion>
-    <BinSkimVersion>$(AssemblyVersion).11</BinSkimVersion>
+    <BinSkimVersion>$(AssemblyVersion).12</BinSkimVersion>
     <Version>$(BinSkimVersion)</Version>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>


### PR DESCRIPTION
## Summary

Bump BinSkim version to 4.4.9.12 and update release history.

## Changes

- \src/Directory.Build.props\: version 4.4.9.11 → 4.4.9.12
- \ReleaseHistory.md\: changelog entry for v4.4.9.12

## Changelog

* **ADM**: Fix pipeline - disable sdlSdp and use service connection for internal build trigger #1201

## Dependencies

Requires PR #1201 (pipeline fixes) to be merged first.