### PR TITLE
Handle DWARF string sections larger than 2 GB

### DIFF
--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.IL
         public string LocalSymbolDirectories { get; internal set; }
 
         [Option(
-            "dwarf-string-section-file-read-threshold-bytes",
+            "dwarf-string-read-threshold",
             HelpText = "Use file-backed reads for DWARF string sections whose size is at least this many bytes. " +
                        "By default, DWARF string sections are loaded into memory.")]
         public ulong? DwarfStringSectionFileReadThreshold { get; set; }

--- a/src/BinSkim.Driver/AnalyzeOptions.cs
+++ b/src/BinSkim.Driver/AnalyzeOptions.cs
@@ -49,6 +49,12 @@ namespace Microsoft.CodeAnalysis.IL
         public string LocalSymbolDirectories { get; internal set; }
 
         [Option(
+            "dwarf-string-section-file-read-threshold-bytes",
+            HelpText = "Use file-backed reads for DWARF string sections whose size is at least this many bytes. " +
+                       "By default, DWARF string sections are loaded into memory.")]
+        public ulong? DwarfStringSectionFileReadThreshold { get; set; }
+
+        [Option(
             "ignorePdbLoadError",
             HelpText = "If enabled, BinSkim won't break if we have a 'PdbLoadingException'.")]
         public bool? IgnorePdbLoadError { get; set; }

--- a/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
+++ b/src/BinSkim.Driver/MultithreadedAnalyzeCommand.cs
@@ -102,6 +102,7 @@ namespace Microsoft.CodeAnalysis.IL
             }
 
             context.LocalSymbolDirectories = options.LocalSymbolDirectories ?? context.LocalSymbolDirectories;
+            context.DwarfStringSectionFileReadThreshold = options.DwarfStringSectionFileReadThreshold;
             context.TracePdbLoads = options.Trace.Contains(nameof(Traces.PdbLoad));
             context.VerboseErrors = options.Trace.Any();
 
@@ -283,6 +284,7 @@ namespace Microsoft.CodeAnalysis.IL
             scanTargetContext.IgnorePELoadError = context.IgnorePELoadError;
             scanTargetContext.IgnoreBinaryAnalysisErrors = context.IgnoreBinaryAnalysisErrors;
             scanTargetContext.LocalSymbolDirectories = context.LocalSymbolDirectories;
+            scanTargetContext.DwarfStringSectionFileReadThreshold = context.DwarfStringSectionFileReadThreshold;
             scanTargetContext.TracePdbLoads = context.TracePdbLoads;
             scanTargetContext.VerboseErrors = context.VerboseErrors;
 

--- a/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
+++ b/src/BinSkim.Sdk/BinaryAnalyzerContext.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                                                           this.SymbolPath,
                                                           this.LocalSymbolDirectories,
                                                           this.TracePdbLoads,
-                                                          this.ComprehensiveBinaryParsing);
+                                                          this.ComprehensiveBinaryParsing,
+                                                          this.DwarfStringSectionFileReadThreshold);
 
                 return this.iBinary;
             }
@@ -50,6 +51,8 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
         }
 
         public bool TracePdbLoads { get; set; }
+
+        public ulong? DwarfStringSectionFileReadThreshold { get; set; }
 
         public string SymbolPath
         {

--- a/src/BinSkim.Sdk/BinaryTargetManager.cs
+++ b/src/BinSkim.Sdk/BinaryTargetManager.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
                                                 string symbolPath = null,
                                                 string localSymbolDirectories = null,
                                                 bool tracePdbLoad = false,
-                                                bool forceComprehensiveParsing = false)
+                                                bool forceComprehensiveParsing = false,
+                                                ulong? dwarfStringSectionFileReadThreshold = null)
         {
             // TryLoadBinary avoids the separate CanLoadBinary sniff,
             // eliminating a redundant file open for every PE file.
@@ -27,7 +28,10 @@ namespace Microsoft.CodeAnalysis.IL.Sdk
 
             if (ElfBinary.CanLoadBinary(uri))
             {
-                return new ElfBinary(uri, localSymbolDirectories, forceComprehensiveParsing);
+                return new ElfBinary(uri,
+                                     localSymbolDirectories,
+                                     forceComprehensiveParsing,
+                                     dwarfStringSectionFileReadThreshold);
             }
             else if (MachOBinary.CanLoadBinary(uri))
             {

--- a/src/BinaryParsers/ElfBinary/Dwarf/DwarfCompilationUnit.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/DwarfCompilationUnit.cs
@@ -37,6 +37,23 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
                                     DwarfMemoryReader debugLineStrings,
                                     IList<int> debugStringOffsets,
                                     NormalizeAddressDelegate addressNormalizer)
+            : this(dwarfBinary,
+                   debugData,
+                   debugDataDescription,
+                   (IDwarfStringReader)debugStrings,
+                   debugLineStrings,
+                   debugStringOffsets,
+                   addressNormalizer)
+        {
+        }
+
+        internal DwarfCompilationUnit(IDwarfBinary dwarfBinary,
+                                    DwarfMemoryReader debugData,
+                                    DwarfMemoryReader debugDataDescription,
+                                    IDwarfStringReader debugStrings,
+                                    DwarfMemoryReader debugLineStrings,
+                                    IList<int> debugStringOffsets,
+                                    NormalizeAddressDelegate addressNormalizer)
         {
             ReadData(dwarfBinary,
                      debugData,
@@ -73,7 +90,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         private void ReadData(IDwarfBinary dwarfBinary,
                               DwarfMemoryReader debugData,
                               DwarfMemoryReader debugDataDescription,
-                              DwarfMemoryReader debugStrings,
+                              IDwarfStringReader debugStrings,
                               DwarfMemoryReader debugLineStrings,
                               IList<int> debugStringOffsets,
                               NormalizeAddressDelegate addressNormalizer)

--- a/src/BinaryParsers/ElfBinary/Dwarf/DwarfFileStringReader.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/DwarfFileStringReader.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
+{
+    /// <summary>
+    /// Reads individual null-terminated strings directly from a DWARF section
+    /// without loading the entire section into a single byte array.
+    /// </summary>
+    internal sealed class DwarfFileStringReader : IDwarfStringReader
+    {
+        internal DwarfFileStringReader(string path, ulong sectionOffset, ulong sectionSize)
+            : this(File.OpenRead(path), sectionOffset, sectionSize, leaveOpen: false)
+        {
+        }
+
+        internal DwarfFileStringReader(Stream stream, ulong sectionOffset, ulong sectionSize, bool leaveOpen)
+        {
+            this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            this.sectionOffset = checked((long)sectionOffset);
+            this.sectionSize = sectionSize;
+            this.leaveOpen = leaveOpen;
+        }
+
+        public string ReadString(uint position)
+        {
+            if (position >= this.sectionSize)
+            {
+                return string.Empty;
+            }
+
+            this.stream.Seek(checked(this.sectionOffset + position), SeekOrigin.Begin);
+
+            var bytes = new List<byte>();
+            while ((ulong)position + (ulong)bytes.Count < this.sectionSize)
+            {
+                int value = this.stream.ReadByte();
+                if (value <= 0)
+                {
+                    break;
+                }
+
+                bytes.Add((byte)value);
+            }
+
+            return Encoding.UTF8.GetString(bytes.ToArray());
+        }
+
+        public void Dispose()
+        {
+            if (!this.leaveOpen)
+            {
+                this.stream.Dispose();
+            }
+        }
+
+        private readonly bool leaveOpen;
+        private readonly long sectionOffset;
+        private readonly ulong sectionSize;
+        private readonly Stream stream;
+    }
+}

--- a/src/BinaryParsers/ElfBinary/Dwarf/DwarfLineNumberProgram.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/DwarfLineNumberProgram.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         /// <param name="addressNormalizer">Normalize address delegate (<see cref="NormalizeAddressDelegate"/>)</param>
         internal DwarfLineNumberProgram(int dwarfVersion,
                                         DwarfMemoryReader debugLine,
-                                        DwarfMemoryReader debugStrings,
+                                        IDwarfStringReader debugStrings,
                                         NormalizeAddressDelegate addressNormalizer)
         {
             Files = ReadData(dwarfVersion, debugLine, debugStrings, addressNormalizer);
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         /// <returns>List of file information.</returns>
         private static List<DwarfFileInformation> ReadData(int dwarfVersion,
                                                            DwarfMemoryReader debugLine,
-                                                           DwarfMemoryReader debugStrings,
+                                                           IDwarfStringReader debugStrings,
                                                            NormalizeAddressDelegate addressNormalizer)
         {
             // Read header
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
             return files;
         }
 
-        private static string ParsePathValue(DwarfFormat format, bool is64bit, DwarfMemoryReader debugLine, DwarfMemoryReader debugStrings)
+        private static string ParsePathValue(DwarfFormat format, bool is64bit, DwarfMemoryReader debugLine, IDwarfStringReader debugStrings)
         {
             switch (format)
             {

--- a/src/BinaryParsers/ElfBinary/Dwarf/DwarfMemoryReader.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/DwarfMemoryReader.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
     /// Simple memory reader that provides specific functionality to read DWARF streams.
     /// </summary>
     /// <seealso cref="System.IDisposable" />
-    public class DwarfMemoryReader : IDisposable
+    public class DwarfMemoryReader : IDwarfStringReader
     {
         /// <summary>
         /// The pinned data

--- a/src/BinaryParsers/ElfBinary/Dwarf/DwarfSymbolProvider.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/DwarfSymbolProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         internal static List<DwarfCompilationUnit> ParseAllCompilationUnits(IDwarfBinary dwarfBinary,
                                                                             byte[] debugData,
                                                                             byte[] debugDataDescription,
-                                                                            byte[] debugStrings,
+                                                                            IDwarfStringReader debugStrings,
                                                                             byte[] debugLineStrings,
                                                                             byte[] debugStringOffsets,
                                                                             NormalizeAddressDelegate addressNormalizer)
@@ -76,14 +76,13 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         internal static DwarfCompilationUnit ParseOneCompilationUnitByOffset(IDwarfBinary dwarfBinary,
                                                                              byte[] debugData,
                                                                              byte[] debugDataDescription,
-                                                                             byte[] debugStrings,
+                                                                             IDwarfStringReader debugStrings,
                                                                              byte[] debugLineStrings,
                                                                              byte[] debugStringOffsets,
                                                                              NormalizeAddressDelegate addressNormalizer,
                                                                              uint offset)
         {
             using var debugDataReader = new DwarfMemoryReader(debugData);
-            using var debugStringsReader = new DwarfMemoryReader(debugStrings);
             using var debugLineStringsReader = new DwarfMemoryReader(debugLineStrings);
             using var debugDataDescriptionReader = new DwarfMemoryReader(debugDataDescription);
             IList<int> debugStringOffsetsReader = ParseDebugStringOffsets(debugStringOffsets, dwarfBinary.Is64bit);
@@ -98,7 +97,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
                 return new DwarfCompilationUnit(dwarfBinary,
                                                 debugDataReader,
                                                 debugDataDescriptionReader,
-                                                debugStringsReader,
+                                                debugStrings,
                                                 debugLineStringsReader,
                                                 debugStringOffsetsReader,
                                                 addressNormalizer);
@@ -146,13 +145,12 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
         /// <param name="addressNormalizer">Normalize address delegate (<see cref="NormalizeAddressDelegate"/>)</param>
         internal static List<DwarfLineNumberProgram> ParseLineNumberPrograms(IDwarfBinary dwarfBinary,
                                                                              byte[] debugLine,
-                                                                             byte[] debugStrings,
+                                                                             IDwarfStringReader debugStrings,
                                                                              byte[] debugLineStrings,
                                                                              NormalizeAddressDelegate addressNormalizer)
         {
             int dwarfVersion = dwarfBinary.DwarfVersion;
             using var debugLineReader = new DwarfMemoryReader(debugLine);
-            using var debugStringsReader = new DwarfMemoryReader(debugStrings);
             using var debugLineStringsReader = new DwarfMemoryReader(debugLineStrings);
 
             var programs = new List<DwarfLineNumberProgram>();
@@ -165,7 +163,7 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
                     program =
                         new DwarfLineNumberProgram(dwarfVersion,
                                                    debugLineReader,
-                                                   debugStringsReader,
+                                                   debugStrings,
                                                    addressNormalizer);
                 }
                 catch (InvalidOperationException)

--- a/src/BinaryParsers/ElfBinary/Dwarf/IDwarfStringReader.cs
+++ b/src/BinaryParsers/ElfBinary/Dwarf/IDwarfStringReader.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
+{
+    internal interface IDwarfStringReader : IDisposable
+    {
+        string ReadString(uint position);
+    }
+}

--- a/src/BinaryParsers/ElfBinary/ElfBinary.cs
+++ b/src/BinaryParsers/ElfBinary/ElfBinary.cs
@@ -23,10 +23,10 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
     {
         public ElfBinary(Uri uri, string localSymbolDirectories = null, bool forceComprehensiveParsing = false) : base(uri)
         {
+            this.path = Path.GetFullPath(uri.LocalPath);
             try
             {
-                string path = Path.GetFullPath(uri.LocalPath);
-                ELF = ELFReader.Load<ulong>(path);
+                ELF = ELFReader.Load<ulong>(this.path);
 
                 Compilers = ElfUtility.GetELFCompilers(this.ELF);
 
@@ -56,25 +56,31 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 PublicSymbols = publicSymbols;
                 SectionRegions = ELF.Sections.Where(s => s.LoadAddress > 0).OrderBy(s => s.LoadAddress).ToArray();
 
-                CompilationUnits = new Lazy<List<DwarfCompilationUnit>>(()
-                    => LoadDebug(DwarfSymbolProvider.ParseAllCompilationUnits(this,
-                                                                              DebugData,
-                                                                              DebugDataDescription,
-                                                                              DebugDataStrings,
-                                                                              DebugLineStrings,
-                                                                              DebugStringOffsets,
-                                                                              NormalizeAddress),
-                                                                              localSymbolDirectories));
+                CompilationUnits = new Lazy<List<DwarfCompilationUnit>>(() =>
+                {
+                    using IDwarfStringReader debugStrings = CreateDebugStringsReader();
+                    return LoadDebug(DwarfSymbolProvider.ParseAllCompilationUnits(this,
+                                                                                  DebugData,
+                                                                                  DebugDataDescription,
+                                                                                  debugStrings,
+                                                                                  DebugLineStrings,
+                                                                                  DebugStringOffsets,
+                                                                                  NormalizeAddress),
+                                                                                  localSymbolDirectories);
+                });
 
                 commandLineInfos = new Lazy<List<DwarfCompileCommandLineInfo>>(()
                     => DwarfSymbolProvider.ParseAllCommandLineInfos(CompilationUnits.Value));
 
-                LineNumberPrograms = new Lazy<IReadOnlyList<DwarfLineNumberProgram>>(()
-                    => DwarfSymbolProvider.ParseLineNumberPrograms(this,
-                                                                   DebugLine,
-                                                                   DebugDataStrings,
-                                                                   DebugLineStrings,
-                                                                   NormalizeAddress));
+                LineNumberPrograms = new Lazy<IReadOnlyList<DwarfLineNumberProgram>>(() =>
+                {
+                    using IDwarfStringReader debugStrings = CreateDebugStringsReader();
+                    return DwarfSymbolProvider.ParseLineNumberPrograms(this,
+                                                                       DebugLine,
+                                                                       debugStrings,
+                                                                       DebugLineStrings,
+                                                                       NormalizeAddress);
+                });
 
                 CommonInformationEntries = new Lazy<IReadOnlyList<DwarfCommonInformationEntry>>(()
                     => DwarfSymbolProvider.ParseCommonInformationEntries(DebugFrame, EhFrame, new DwarfExceptionHandlingFrameParsingInput(this)));
@@ -390,6 +396,21 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             return Array.Empty<byte>();
         }
 
+        private IDwarfStringReader CreateDebugStringsReader()
+        {
+            Section<ulong> section = ELF.Sections
+                .OfType<Section<ulong>>()
+                .FirstOrDefault(candidate => candidate.Name == SectionName.DebugStr ||
+                                             candidate.Name == SectionName.DebugStr + ".dwo");
+
+            if (section != null && section.Size > int.MaxValue)
+            {
+                return new DwarfFileStringReader(this.path, section.Offset, section.Size);
+            }
+
+            return new DwarfMemoryReader(DebugDataStrings);
+        }
+
         /// <summary>
         /// Gets the section address after loading into memory.
         /// </summary>
@@ -523,6 +544,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
         }
 
         private readonly Lazy<List<DwarfCompileCommandLineInfo>> commandLineInfos;
+
+        private readonly string path;
 
         private DebugFileType debugFileType = DebugFileType.Unknown;
 

--- a/src/BinaryParsers/ElfBinary/ElfBinary.cs
+++ b/src/BinaryParsers/ElfBinary/ElfBinary.cs
@@ -21,9 +21,13 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
     /// </summary>
     public class ElfBinary : BinaryBase, IDwarfBinary
     {
-        public ElfBinary(Uri uri, string localSymbolDirectories = null, bool forceComprehensiveParsing = false) : base(uri)
+        public ElfBinary(Uri uri,
+                         string localSymbolDirectories = null,
+                         bool forceComprehensiveParsing = false,
+                         ulong? dwarfStringSectionFileReadThreshold = null) : base(uri)
         {
             this.path = Path.GetFullPath(uri.LocalPath);
+            this.dwarfStringSectionFileReadThreshold = dwarfStringSectionFileReadThreshold;
             try
             {
                 ELF = ELFReader.Load<ulong>(this.path);
@@ -403,12 +407,21 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                 .FirstOrDefault(candidate => candidate.Name == SectionName.DebugStr ||
                                              candidate.Name == SectionName.DebugStr + ".dwo");
 
-            if (section != null && section.Size > int.MaxValue)
+            if (section != null && ShouldUseFileBackedDwarfStringReader(
+                section.Size,
+                this.dwarfStringSectionFileReadThreshold))
             {
                 return new DwarfFileStringReader(this.path, section.Offset, section.Size);
             }
 
             return new DwarfMemoryReader(DebugDataStrings);
+        }
+
+        internal static bool ShouldUseFileBackedDwarfStringReader(
+            ulong sectionSize,
+            ulong? fileReadThreshold)
+        {
+            return fileReadThreshold.HasValue && sectionSize >= fileReadThreshold.Value;
         }
 
         /// <summary>
@@ -491,7 +504,9 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                     }
                     else
                     {
-                        var dwoBinary = new ElfBinary(debugFileUri);
+                        var dwoBinary = new ElfBinary(
+                            debugFileUri,
+                            dwarfStringSectionFileReadThreshold: this.dwarfStringSectionFileReadThreshold);
 
                         if (dwoBinary != null && dwoBinary.CompilationUnits.Value.Count > 0)
                         {
@@ -542,6 +557,8 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
 
             return currentCompilationUnits;
         }
+
+        private readonly ulong? dwarfStringSectionFileReadThreshold;
 
         private readonly Lazy<List<DwarfCompileCommandLineInfo>> commandLineInfos;
 

--- a/src/BinaryParsers/MachOBinary/SingleMachOBinary.cs
+++ b/src/BinaryParsers/MachOBinary/SingleMachOBinary.cs
@@ -84,11 +84,12 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
                     byte[] debugData = this.LoadSection(SECTIONNAME_DEBUG_LINE);
                     byte[] debugStrings = this.LoadSection(SECTIONNAME_DEBUG_STR);
                     byte[] debugLineStrings = this.LoadSection(SECTIONNAME_DEBUG_LINE_STR);
+                    using var debugStringsReader = new DwarfMemoryReader(debugStrings);
 
                     lineNumberPrograms =
                         DwarfSymbolProvider.ParseLineNumberPrograms(this,
                                                                     debugData,
-                                                                    debugStrings,
+                                                                    debugStringsReader,
                                                                     debugLineStrings,
                                                                     NormalizeAddress);
                 }
@@ -225,11 +226,12 @@ namespace Microsoft.CodeAnalysis.BinaryParsers
             byte[] debugAbbrev = this.LoadSection(SECTIONNAME_DEBUG_ABBREV);
             byte[] debugLineStr = this.LoadSection(SECTIONNAME_DEBUG_LINE_STR);
             byte[] debugStrOffsets = this.LoadSection(SECTIONNAME_DEBUG_STR_OFFS);
+            using var debugStringsReader = new DwarfMemoryReader(debugStr);
 
             return DwarfSymbolProvider.ParseAllCompilationUnits(this,
                                                                 debugData,
                                                                 debugAbbrev,
-                                                                debugStr,
+                                                                debugStringsReader,
                                                                 debugLineStr,
                                                                 debugStrOffsets,
                                                                 NormalizeAddress);

--- a/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
+++ b/src/Test.UnitTests.BinSkim.Driver/MultithreadedAnalyzeCommandTests.cs
@@ -376,6 +376,42 @@ namespace Microsoft.CodeAnalysis.BinSkim.Rules
         }
 
         [Fact]
+        public void MultithreadedAnalyzeCommand_InitializeGlobalContextFromOptions_DwarfStringFileReadIsOptIn()
+        {
+            var options = new AnalyzeOptions
+            {
+                TargetFileSpecifiers = new List<string> { "test.dll" },
+                DisableTelemetry = true,
+                OutputFilePath = "test/path/",
+            };
+            var context = new BinaryAnalyzerContext();
+
+            var command = new MultithreadedAnalyzeCommand();
+            command.InitializeGlobalContextFromOptions(options, ref context);
+
+            context.DwarfStringSectionFileReadThreshold.Should().BeNull();
+        }
+
+        [Fact]
+        public void MultithreadedAnalyzeCommand_InitializeGlobalContextFromOptions_SetsDwarfStringFileReadThreshold()
+        {
+            const ulong threshold = 2UL * 1024 * 1024 * 1024;
+            var options = new AnalyzeOptions
+            {
+                TargetFileSpecifiers = new List<string> { "test.dll" },
+                DisableTelemetry = true,
+                OutputFilePath = "test/path/",
+                DwarfStringSectionFileReadThreshold = threshold,
+            };
+            var context = new BinaryAnalyzerContext();
+
+            var command = new MultithreadedAnalyzeCommand();
+            command.InitializeGlobalContextFromOptions(options, ref context);
+
+            context.DwarfStringSectionFileReadThreshold.Should().Be(threshold);
+        }
+
+        [Fact]
         public void MultithreadedAnalyzeCommand_ValidAnalysisFileExtensions_ContainsExpectedExtensions()
         {
             MultithreadedAnalyzeCommand.ValidAnalysisFileExtensions.Should().Contain(".dll");

--- a/src/Test.UnitTests.BinaryParsers/Dwarf/DwarfFileStringReaderTests.cs
+++ b/src/Test.UnitTests.BinaryParsers/Dwarf/DwarfFileStringReaderTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
+{
+    public class DwarfFileStringReaderTests
+    {
+        [Fact]
+        public void ReadString_ReadsFromTheRequestedSectionPosition()
+        {
+            byte[] data = Encoding.UTF8.GetBytes("prefix\0first\0second\0");
+            using var stream = new MemoryStream(data);
+            using var reader = new DwarfFileStringReader(
+                stream,
+                sectionOffset: 7,
+                sectionSize: (ulong)data.Length - 7,
+                leaveOpen: true);
+
+            reader.ReadString(6).Should().Be("second");
+        }
+
+        [Fact]
+        public void ReadString_ReadsPastTheInt32BoundaryWithoutAllocatingTheWholeSection()
+        {
+            uint position = (uint)int.MaxValue + 34;
+            const string expected = "past-limit";
+            byte[] value = Encoding.UTF8.GetBytes(expected + "\0");
+            var contents = new Dictionary<long, byte>();
+            for (int index = 0; index < value.Length; index++)
+            {
+                contents[position + index] = value[index];
+            }
+
+            using var stream = new SparseReadStream((long)position + value.Length, contents);
+            using var reader = new DwarfFileStringReader(
+                stream,
+                sectionOffset: 0,
+                sectionSize: (ulong)stream.Length,
+                leaveOpen: true);
+
+            reader.ReadString(position).Should().Be(expected);
+        }
+
+        [Fact]
+        public void ReadString_ReturnsEmptyWhenPositionIsOutsideTheSection()
+        {
+            using var stream = new MemoryStream(new byte[] { 0 });
+            using var reader = new DwarfFileStringReader(
+                stream,
+                sectionOffset: 0,
+                sectionSize: 1,
+                leaveOpen: true);
+
+            reader.ReadString(1).Should().BeEmpty();
+        }
+
+        private sealed class SparseReadStream : Stream
+        {
+            internal SparseReadStream(long length, IReadOnlyDictionary<long, byte> contents)
+            {
+                this.Length = length;
+                this.contents = contents;
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => true;
+
+            public override bool CanWrite => false;
+
+            public override long Length { get; }
+
+            public override long Position { get; set; }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int bytesRead = 0;
+                while (bytesRead < count && this.Position < this.Length)
+                {
+                    buffer[offset + bytesRead] = this.contents.TryGetValue(this.Position, out byte value)
+                        ? value
+                        : (byte)0;
+                    this.Position++;
+                    bytesRead++;
+                }
+
+                return bytesRead;
+            }
+
+            public override int ReadByte()
+            {
+                if (this.Position >= this.Length)
+                {
+                    return -1;
+                }
+
+                int value = this.contents.TryGetValue(this.Position, out byte result)
+                    ? result
+                    : 0;
+                this.Position++;
+                return value;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                this.Position = origin switch
+                {
+                    SeekOrigin.Begin => offset,
+                    SeekOrigin.Current => checked(this.Position + offset),
+                    SeekOrigin.End => checked(this.Length + offset),
+                    _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+                };
+                return this.Position;
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            private readonly IReadOnlyDictionary<long, byte> contents;
+        }
+    }
+}

--- a/src/Test.UnitTests.BinaryParsers/Dwarf/DwarfFileStringReaderTests.cs
+++ b/src/Test.UnitTests.BinaryParsers/Dwarf/DwarfFileStringReaderTests.cs
@@ -63,6 +63,28 @@ namespace Microsoft.CodeAnalysis.BinaryParsers.Dwarf
             reader.ReadString(1).Should().BeEmpty();
         }
 
+        [Fact]
+        public void FileBackedReader_IsDisabledWhenThresholdIsNotSpecified()
+        {
+            ElfBinary.ShouldUseFileBackedDwarfStringReader(
+                sectionSize: (ulong)int.MaxValue + 1,
+                fileReadThreshold: null).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(1023, 1024, false)]
+        [InlineData(1024, 1024, true)]
+        [InlineData(1025, 1024, true)]
+        public void FileBackedReader_UsesConfiguredThreshold(
+            ulong sectionSize,
+            ulong fileReadThreshold,
+            bool expected)
+        {
+            ElfBinary.ShouldUseFileBackedDwarfStringReader(
+                sectionSize,
+                fileReadThreshold).Should().Be(expected);
+        }
+
         private sealed class SparseReadStream : Stream
         {
             internal SparseReadStream(long length, IReadOnlyDictionary<long, byte> contents)


### PR DESCRIPTION
## Summary

- Add a string-reader abstraction for DWARF string sections.
- Add the opt-in `--dwarf-string-read-threshold` CLI option.
- Use file-backed reads only when that option is supplied and the DWARF string section reaches the configured limit.
- Preserve the existing in-memory behavior by default and for sections below the configured limit.
- Add regression tests for reads beyond 2 GB and for the opt-in threshold behavior.

## Root cause

ELFSharp materializes section contents in a byte array. Sections larger than `int.MaxValue` overflow when their size is converted to a 32-bit integer, preventing BinSkim from analyzing otherwise valid ELF binaries.

## Validation

- All 154 `Test.UnitTests.BinaryParsers` tests passed.
- All 85 `Test.UnitTests.BinSkim.Driver` tests passed.
- The new CLI option is present in `BinSkim analyze --help`.
- The earlier custom-package validation successfully analyzed the affected Minecraft Switch artifact.
