### PR TITLE
Fix BA2022 verification for long paths

### DIFF
--- a/src/BinSkim.Driver/app.manifest
+++ b/src/BinSkim.Driver/app.manifest
@@ -9,6 +9,12 @@
     </security>
   </trustInfo>
 
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
   <file name="msdia140.dll">
     <comClass description="Debug Information Accessor" clsid="{E6756135-1E65-4D17-8576-610761398C3C}" threadingModel = "Both"/>
   </file>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="ELFSharp" Version="2.17.3" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Sarif.Driver" Version="4.6.0" />

--- a/src/Test.FunctionalTests.BinSkim.Rules/RuleTests.cs
+++ b/src/Test.FunctionalTests.BinSkim.Rules/RuleTests.cs
@@ -11,9 +11,11 @@ using System.Text;
 using Microsoft.CodeAnalysis.IL.Sdk;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Driver;
+using Microsoft.Win32;
 
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.CodeAnalysis.IL.Rules
 {
@@ -94,17 +96,23 @@ namespace Microsoft.CodeAnalysis.IL.Rules
             foreach (string target in targets)
             {
                 context = CreateContext(logger, policy, target);
-
-                if (!context.IsValidAnalysisTarget) { continue; }
-
-                context.Rule = skimmer;
-
-                if (skimmer.CanAnalyze(context, out string reasonForNotAnalyzing) != AnalysisApplicability.ApplicableToSpecifiedTarget)
+                try
                 {
-                    continue;
-                }
+                    if (!context.IsValidAnalysisTarget) { continue; }
 
-                skimmer.Analyze(context);
+                    context.Rule = skimmer;
+
+                    if (skimmer.CanAnalyze(context, out string reasonForNotAnalyzing) != AnalysisApplicability.ApplicableToSpecifiedTarget)
+                    {
+                        continue;
+                    }
+
+                    skimmer.Analyze(context);
+                }
+                finally
+                {
+                    context.Dispose();
+                }
             }
 
             var failTargets = new HashSet<string>(logger.ErrorTargets.Union(logger.WarningTargets));
@@ -1194,6 +1202,49 @@ namespace Microsoft.CodeAnalysis.IL.Rules
                 kernel32Path = Path.Combine(kernel32Path, "kernel32.dll");
 
                 this.VerifyPass(new SignSecurely(), additionalTestFiles: new[] { kernel32Path });
+            }
+        }
+
+        [Fact]
+        public void BA2022_SignSecurely_LongPath_Pass()
+        {
+            const int maxPath = 260;
+
+            if (!OperatingSystem.IsWindows()) { return; }
+
+            const string fileSystemKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem";
+            if (!Equals(Registry.GetValue(fileSystemKey, "LongPathsEnabled", defaultValue: 0), 1))
+            {
+                throw SkipException.ForSkip("Windows long-path support is not enabled.");
+            }
+
+            string kernel32Path = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            kernel32Path = Path.Combine(kernel32Path, "kernel32.dll");
+
+            string tempRoot = Path.Combine(Path.GetTempPath(), $"{nameof(BA2022_SignSecurely_LongPath_Pass)}-{Guid.NewGuid():N}");
+            string longDirectory = tempRoot;
+            string targetFile = "";
+
+            try
+            {
+                do
+                {
+                    longDirectory = Path.Combine(longDirectory, new string('a', 32));
+                    targetFile = Path.Combine(longDirectory, Path.GetFileName(kernel32Path));
+                } while (targetFile.Length <= maxPath);
+
+                Directory.CreateDirectory(longDirectory);
+                File.Copy(kernel32Path, targetFile);
+
+                Assert.True(targetFile.Length > maxPath);
+                this.VerifyPass(new SignSecurely(), additionalTestFiles: new[] { targetFile });
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
             }
         }
 


### PR DESCRIPTION
Promotes the long-path fix for BA2022 into `main`. The change was staged on `fix/ba2022-long-paths` via #1214 and is now being promoted.

## What this does
- **`BinSkim.Driver/app.manifest`** — opts the process into `longPathAware` so native Authenticode verification (`WinVerifyTrust`) can open targets whose path exceeds `MAX_PATH` (260).
- **`Test.FunctionalTests.BinSkim.Rules/RuleTests.cs`** — adds the `BA2022_SignSecurely_LongPath_Pass` regression test and disposes the analysis context per iteration in the shared test harness.
- **`Directory.Packages.props`** — bumps `Microsoft.NET.Test.Sdk` 17.12.0 → 17.14.1 (supports the dynamic test skip used by the new test).

## Scope / known limitations
- The manifest opt-in only takes effect where the OS also has `LongPathsEnabled=1` (Windows 10 1607+). It is **inert otherwise** — notably on Microsoft-hosted / default agents, which don't set it and can't change it at runtime.
- It does **not** change the diagnostic emitted when a target still can't be read: a file-access failure (`CRYPT_E_FILE_ERROR`) is still reported as a BA2022 "insecure signing" error rather than an analysis failure. That soundness gap is tracked separately.
- The new regression test self-skips unless `LongPathsEnabled=1`, so it provides no coverage on agents without that setting.

## Refs
- Builds on #1214.
- Related to #977 (partial). Intentionally does **not** auto-close it — the "unclear error message" / misclassification half is still open; the durable fix is managed Authenticode validation (#1058).
